### PR TITLE
Resolve issue #51: Add Getting Started documentation pages

### DIFF
--- a/src/content/docs/getting-started/brownfield-projects.md
+++ b/src/content/docs/getting-started/brownfield-projects.md
@@ -1,0 +1,264 @@
+---
+title: "Brownfield Projects"
+description: "Learn how to integrate ClaudeKit into existing projects with minimal disruption to your current workflow."
+category: "getting-started"
+order: 3
+published: true
+lastUpdated: 2025-11-06
+---
+
+# Brownfield Projects
+
+Integrate ClaudeKit into your existing projects without disrupting your current development workflow. Perfect for legacy codebases, team collaborations, and gradual adoption scenarios.
+
+## Quick Integration
+
+### 1. Installation
+
+```bash
+# Install ClaudeKit CLI
+npm install -g @claudekit/cli
+
+# Or use npx for temporary usage
+npx @claudekit/cli init
+```
+
+### 2. Initialize ClaudeKit
+
+Navigate to your existing project directory:
+
+```bash
+cd your-existing-project
+claudekit init
+```
+
+This will:
+- Analyze your project structure
+- Detect your tech stack automatically
+- Create `.claude/` directory with minimal configuration
+- Preserve all existing files and workflows
+
+### 3. Configure for Your Stack
+
+ClaudeKit automatically detects common frameworks and libraries:
+
+```bash
+# For React projects
+claudekit bootstrap --framework react
+
+# For Next.js projects
+claudekit bootstrap --framework nextjs
+
+# For Node.js/Express projects
+claudekit bootstrap --framework express
+
+# For generic projects
+claudekit bootstrap --framework generic
+```
+
+## Project Analysis
+
+### Understanding Your Codebase
+
+```bash
+# Analyze project structure
+claudekit scout
+
+# Generate project summary
+claudekit ask "What is the architecture of this project?"
+
+# Identify potential issues
+claudekit debug
+```
+
+### Workflow Integration
+
+Gradually integrate ClaudeKit into your existing workflow:
+
+```bash
+# Code review existing files
+claudekit /review src/components/Header.tsx
+
+# Enhance documentation
+claudekit /docs update
+
+# Optimize performance
+claudekit /fix performance
+```
+
+## Team Collaboration
+
+### Sharing ClaudeKit Configuration
+
+```bash
+# Export configuration
+claudekit config export > claudekit-config.json
+
+# Share with team
+git add claudekit-config.json .claude/
+git commit -m "Add ClaudeKit configuration"
+git push
+```
+
+### Team Setup Instructions
+
+1. Clone the repository with ClaudeKit config
+2. Install dependencies: `npm install`
+3. Initialize with shared config: `claudekit init --import claudekit-config.json`
+
+## Common Integration Patterns
+
+### Legacy Code Migration
+
+```bash
+# Analyze legacy module
+claudekit ask "Explain this legacy module and suggest improvements"
+
+# Refactor gradually
+claudekit /refactor src/legacy/module.js --strategy incremental
+
+# Add tests to legacy code
+claudekit /test src/legacy/module.js
+```
+
+### Build System Integration
+
+```bash
+# Analyze build configuration
+claudekit scout --config webpack.config.js
+
+# Optimize build process
+claudekit /fix build --target production
+
+# Add CI/CD integration
+claudekit /plan ci --platform github
+```
+
+### Database Integration
+
+```bash
+# Analyze database schema
+claudekit scout --database
+
+# Create migration scripts
+claudekit /migration create --description "Add user_preferences table"
+
+# Optimize queries
+claudekit /fix database --target performance
+```
+
+## Best Practices
+
+### 1. Gradual Adoption
+- Start with documentation tasks
+- Move to code analysis and reviews
+- Implement small refactoring tasks
+- Gradually increase AI-assisted development
+
+### 2. Configuration Management
+```bash
+# Create environment-specific configs
+claudekit config set env development
+claudekit config set env production
+```
+
+### 3. Code Quality Standards
+```bash
+# Enforce coding standards
+claudekit /review --strict
+
+# Run automated tests
+claudekit /test --coverage
+
+# Performance monitoring
+claudekit /debug --performance
+```
+
+### 4. Documentation Maintenance
+```bash
+# Keep docs in sync
+claudekit /docs update --auto
+
+# Generate API documentation
+claudekit /docs api --output docs/api/
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Issue**: ClaudeKit conflicts with existing tools
+```bash
+# Check for conflicts
+claudekit doctor --check-conflicts
+
+# Resolve automatically
+claudekit fix --resolve-conflicts
+```
+
+**Issue**: Large repository performance
+```bash
+# Optimize for large repos
+claudekit config set scanDepth 2
+claudekit config set exclude "node_modules,dist,build"
+```
+
+**Issue**: Team configuration sync
+```bash
+# Reset and re-import
+claudekit config reset
+claudekit init --import team-config.json
+```
+
+## Migration Examples
+
+### React Project Example
+
+```bash
+# 1. Analyze existing React app
+claudekit init --framework react
+
+# 2. Review component structure
+claudekit ask "Analyze the React component architecture"
+
+# 3. Enhance existing components
+claudekit /enhance src/components/UserProfile.tsx
+
+# 4. Add missing tests
+claudekit /test src/components/
+
+# 5. Optimize build
+claudekit /fix build --target production
+```
+
+### Node.js API Example
+
+```bash
+# 1. Initialize for API project
+claudekit init --framework express
+
+# 2. Analyze API endpoints
+claudekit scout --api
+
+# 3. Document API routes
+claudekit /docs api --format openapi
+
+# 4. Add error handling
+claudekit /fix api --target error-handling
+
+# 5. Performance optimization
+claudekit /fix performance --target api
+```
+
+## Next Steps
+
+After successful integration:
+
+1. **Explore Agents**: Use specialized agents for specific tasks
+2. **Custom Commands**: Create commands for your workflow
+3. **Team Training**: Share best practices with your team
+4. **Advanced Features**: Implement custom skills and workflows
+
+---
+
+**Need help?** Check our [Troubleshooting Guide](../troubleshooting/) or [Community Forums](https://github.com/mrgoonie/claudekit-cli/discussions)

--- a/src/content/docs/getting-started/cheatsheet.md
+++ b/src/content/docs/getting-started/cheatsheet.md
@@ -1,0 +1,534 @@
+---
+title: "ClaudeKit Cheatsheet"
+description: "Quick reference guide for ClaudeKit commands, features, and workflows. Essential commands and shortcuts for productive development."
+category: "getting-started"
+order: 5
+published: true
+lastUpdated: 2025-11-06
+---
+
+# ClaudeKit Cheatsheet
+
+Quick reference guide for ClaudeKit commands, features, and essential workflows.
+
+## Installation & Setup
+
+### Basic Installation
+
+```bash
+# Install globally
+npm install -g @claudekit/cli
+
+# Install locally
+npm install --save-dev @claudekit/cli
+
+# Use npx (no installation)
+npx @claudekit init
+```
+
+### Project Initialization
+
+```bash
+# New project
+claudekit new my-project
+
+# Existing project
+claudekit init
+
+# With template
+claudekit new my-app --template nextjs-fullstack
+
+# Specify framework
+claudekit bootstrap --framework react
+```
+
+## Core Commands
+
+### Project Management
+
+```bash
+# Project information
+claudekit --version
+claudekit doctor
+claudekit status
+
+# Configuration
+claudekit config list
+claudekit config set key value
+claudekit config get key
+claudekit config reset
+```
+
+### Development Workflow
+
+```bash
+# Analysis and planning
+claudekit scout                    # Analyze project structure
+claudekit ask "question"           # Get AI assistance
+claudekit plan "feature"           # Plan implementation
+claudekit debug                    # Debug issues
+
+# Code generation
+claudekit generate component Name
+claudekit generate api /endpoint
+claudekit generate model ModelName
+claudekit generate test Component
+
+# Code improvement
+claudekit review path/             # Code review
+claudekit fix path/                # Auto-fix issues
+claudekit optimize path/           # Performance optimization
+claudekit refactor path/           # Refactor code
+```
+
+## Slash Commands
+
+### Core Commands
+
+```bash
+/ask "What does this function do?"
+/plan "Implement user authentication"
+/debug "Fix this TypeError"
+/scout "Analyze the codebase structure"
+/cook "Generate a REST API endpoint"
+/journal "Summarize today's work"
+```
+
+### Content Commands
+
+```bash
+/enhance "Improve this documentation"
+/fast "Quick implementation"
+/good "Best practices implementation"
+/cro "Conversion rate optimization"
+```
+
+### Design Commands
+
+```bash
+/design "Create a modern dashboard"
+/screenshot "Analyze this design"
+/video "Review this UI interaction"
+/describe "Describe this component"
+/3d "Create 3D visualization"
+```
+
+### Fix Commands
+
+```bash
+/fix types "Fix TypeScript errors"
+/fix performance "Optimize performance"
+/fix ui "Fix UI issues"
+/fix logs "Analyze error logs"
+/fix hard "Handle complex issues"
+/fix fast "Quick fixes"
+/fix ci "Fix CI/CD pipeline"
+```
+
+### Git Commands
+
+```bash
+/commit "Create meaningful commit message"
+/commit-push "Commit and push changes"
+/pull-request "Create pull request"
+```
+
+### Documentation Commands
+
+```bash
+/docs init "Initialize documentation"
+/docs update "Update existing docs"
+/docs summarize "Summarize documentation"
+```
+
+### Integration Commands
+
+```bash
+/integrate polar "Integrate Polar API"
+/integrate sepay "Integrate SePay payment"
+```
+
+### Plan Commands
+
+```bash
+/plan ci "Plan CI/CD setup"
+/plan two "Two-step implementation plan"
+```
+
+### Skill Commands
+
+```bash
+/skill create "Create new skill"
+/skill fix-logs "Fix skill errors"
+```
+
+## Project Templates
+
+### Web Applications
+
+```bash
+# Next.js Full Stack
+claudekit new app --template nextjs-fullstack
+
+# React SPA
+claudekit new app --template react-spa
+
+# Vue.js App
+claudekit new app --template vue-app
+
+# Angular App
+claudekit new app --template angular-app
+```
+
+### API Projects
+
+```bash
+# Express.js API
+claudekit new api --template express-api
+
+# FastAPI Python
+claudekit new api --template fastapi
+
+# GraphQL Server
+claudekit new api --template graphql-server
+```
+
+### Component Libraries
+
+```bash
+# React Library
+claudekit new lib --template react-library
+
+# Vue Library
+claudekit new lib --template vue-library
+
+# TypeScript Library
+claudekit new lib --template typescript-lib
+```
+
+## Framework-Specific Commands
+
+### React
+
+```bash
+# Generate components
+claudekit generate component Button --props variant,size
+claudekit generate component Modal --props isOpen,onClose
+claudekit generate hook useAuth --dependencies auth
+
+# Next.js specific
+claudekit generate page /about
+claudekit generate api /api/users
+claudekit generate middleware auth
+```
+
+### Vue.js
+
+```bash
+# Generate components
+claudekit generate component UserProfile --props user
+claudekit generate component Navigation --items navItems
+
+# Vue Router
+claudekit generate route /profile --component Profile
+claudekit generate route /settings --component Settings
+```
+
+### Node.js
+
+```bash
+# Generate API endpoints
+claudekit generate endpoint GET /api/users
+claudekit generate endpoint POST /api/auth/login
+claudekit generate middleware auth
+claudekit generate service UserService
+```
+
+## Database Operations
+
+### PostgreSQL
+
+```bash
+# Create models
+claudekit model create User name:string email:string
+claudekit model create Post title:string content:text user:reference
+
+# Migrations
+claudekit migration create create_users_table
+claudekit migration run
+claudekit migration rollback
+```
+
+### MongoDB
+
+```bash
+# Create schemas
+claudekit schema User name email profile
+claudekit schema Post title content author
+
+# Seed data
+claudekit seed users --count 10
+claudekit seed posts --count 50
+```
+
+## Testing Commands
+
+### Unit Tests
+
+```bash
+# Generate tests
+claudekit test unit src/components/
+claudekit test unit src/utils/
+
+# Run tests
+claudekit test run --unit
+claudekit test run --coverage
+```
+
+### Integration Tests
+
+```bash
+# API tests
+claudekit test integration tests/api/
+claudekit test api --endpoint /api/users
+
+# Database tests
+claudekit test integration tests/database/
+```
+
+### E2E Tests
+
+```bash
+# Generate E2E tests
+claudekit test e2e tests/e2e/login.spec.js
+claudekit test e2e tests/e2e/checkout.spec.js
+
+# Run E2E tests
+claudekit test run --e2e
+claudekit test run --e2e --headless
+```
+
+## Deployment Commands
+
+### Vercel
+
+```bash
+# Deploy to Vercel
+claudekit deploy vercel
+
+# Setup environment
+claudekit deploy vercel --env production
+claudekit env set vercel API_KEY=${API_KEY}
+```
+
+### Netlify
+
+```bash
+# Deploy to Netlify
+claudekit deploy netlify
+
+# Configure redirects
+claudekit deploy netlify --config netlify.toml
+```
+
+### Docker
+
+```bash
+# Build Docker image
+claudekit docker build
+
+# Run container
+claudekit docker run --port 3000
+
+# Push to registry
+claudekit docker push --registry ghcr
+```
+
+### Kubernetes
+
+```bash
+# Generate K8s manifests
+claudekit k8s generate
+
+# Deploy to cluster
+claudekit k8s deploy
+
+# Scale deployment
+claudekit k8s scale --replicas 3
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Set environment variables
+claudekit env set development NODE_ENV=development
+claudekit env set production NODE_ENV=production
+
+# List environment variables
+claudekit env list
+
+# Load from .env file
+claudekit env load .env.production
+```
+
+### Project Settings
+
+```bash
+# Configure TypeScript
+claudekit config set typescript.strict true
+claudekit config set typescript.target ES2020
+
+# Configure testing
+claudekit config set testing.framework jest
+claudekit config set testing.coverage 80
+
+# Configure linting
+claudekit config set linting.eslint true
+claudekit config set linting.prettier true
+```
+
+## AI Assistant Features
+
+### Code Analysis
+
+```bash
+# Explain code
+claudekit ask "Explain this function and its purpose"
+
+# Find bugs
+claudekit debug "Look for potential issues in this code"
+
+# Suggest improvements
+claudekit ask "How can I improve this component's performance?"
+```
+
+### Documentation
+
+```bash
+# Generate docs
+claudekit docs generate --format markdown
+claudekit docs api --output docs/api/
+
+# Update README
+claudekit docs readme --update
+```
+
+### Refactoring
+
+```bash
+# Refactor suggestions
+claudekit refactor src/components/OldComponent.js
+
+# Modernize code
+claudekit modernize src/legacy/ --target es6+
+```
+
+## Troubleshooting
+
+### Common Issues
+
+```bash
+# Check system health
+claudekit doctor
+
+# Fix permissions
+claudekit fix permissions
+
+# Clear cache
+claudekit cache clear
+
+# Reset configuration
+claudekit config reset --hard
+```
+
+### Performance Issues
+
+```bash
+# Analyze performance
+claudekit analyze performance
+
+# Profile application
+claudekit profile --duration 30s
+
+# Memory usage
+claudekit analyze memory
+```
+
+## Keyboard Shortcuts
+
+### Interactive Mode
+
+```bash
+# Start interactive mode
+claudekit interactive
+
+# Navigation shortcuts (in interactive mode)
+Ctrl+C      # Exit
+Tab         # Auto-complete
+↑/↓         # Navigate history
+Ctrl+R      # Search history
+```
+
+## Quick Examples
+
+### Create a React Component
+
+```bash
+# Quick component creation
+claudekit generate component Button \
+  --props variant,size,onClick \
+  --styled true \
+  --typescript true
+
+# With styled-components
+claudekit generate component Card \
+  --props children,title \
+  --styled-components true
+```
+
+### Create API Endpoint
+
+```bash
+# Express.js endpoint
+claudekit generate endpoint POST /api/users \
+  --middleware auth,validation \
+  --response json
+
+# GraphQL resolver
+claudekit generate resolver Query.users \
+  --type [User] \
+  --resolver getUserList
+```
+
+### Database Migration
+
+```bash
+# Create migration
+claudekit migration create add_email_verified_to_users
+
+# Run migration
+claudekit migration run
+
+# Rollback
+claudekit migration rollback --step 1
+```
+
+## Resources
+
+### Documentation
+
+- [Official Docs](https://docs.claudekit.cc)
+- [API Reference](../api-reference/)
+- [Examples](https://github.com/mrgoonie/claudekit-cli/examples)
+
+### Community
+
+- [GitHub Issues](https://github.com/mrgoonie/claudekit-cli/issues)
+- [Discussions](https://github.com/mrgoonie/claudekit-cli/discussions)
+- [Discord Community](https://discord.gg/claudekit)
+
+---
+
+**Need more help?** Check our [Troubleshooting Guide](../troubleshooting/) or ask in the [Community Forums](https://github.com/mrgoonie/claudekit-cli/discussions).

--- a/src/content/docs/getting-started/greenfield-projects.md
+++ b/src/content/docs/getting-started/greenfield-projects.md
@@ -1,0 +1,395 @@
+---
+title: "Greenfield Projects"
+description: "Start new projects with ClaudeKit from scratch. Build modern applications faster with AI-powered development tools."
+category: "getting-started"
+order: 4
+published: true
+lastUpdated: 2025-11-06
+---
+
+# Greenfield Projects
+
+Start new projects with ClaudeKit's AI-powered development workflow. Perfect for new applications, prototypes, and modern development stacks.
+
+## Project Initialization
+
+### 1. Create New Project
+
+```bash
+# Create new project with ClaudeKit
+claudekit new my-awesome-app
+
+# Or create in current directory
+claudekit init --project-type new
+```
+
+### 2. Choose Your Stack
+
+ClaudeKit supports modern development stacks:
+
+```bash
+# React with TypeScript
+claudekit bootstrap --framework react --language typescript
+
+# Next.js full-stack
+claudekit bootstrap --framework nextjs --features api,auth,db
+
+# Node.js API
+claudekit bootstrap --framework express --template api-server
+
+# Vue.js application
+claudekit bootstrap --framework vue --features router,pinia
+
+# Python with FastAPI
+claudekit bootstrap --framework fastapi --language python
+```
+
+### 3. Configure Project Features
+
+```bash
+# Add authentication
+claudekit add feature auth --provider nextauth
+
+# Add database
+claudekit add feature database --provider postgres
+
+# Add API routes
+claudekit add feature api --pattern rest
+
+# Add testing setup
+claudekit add feature testing --framework jest
+```
+
+## Project Templates
+
+### Modern Web Application
+
+```bash
+# Full-stack Next.js application
+claudekit new my-web-app \
+  --template nextjs-fullstack \
+  --features auth,database,api,testing \
+  --ui-framework tailwind \
+  --deployment vercel
+```
+
+**Includes:**
+- Next.js 14 with App Router
+- TypeScript configuration
+- Tailwind CSS + shadcn/ui
+- Authentication setup
+- PostgreSQL database
+- API routes structure
+- Testing with Jest and Playwright
+- Deployment configuration
+
+### React Component Library
+
+```bash
+# Reusable component library
+claudekit new my-ui-library \
+  --template react-library \
+  --features storybook,testing \
+  --build-tool rollup \
+  --package-manager npm
+```
+
+**Includes:**
+- TypeScript + React setup
+- Storybook for component documentation
+- Rollup build configuration
+- Automated testing with Jest
+- NPM package publishing setup
+
+### Node.js Microservice
+
+```bash
+# API microservice
+claudekit new my-api-service \
+  --template node-microservice \
+  --features api,database,cache \
+  --database postgres \
+  --cache redis
+```
+
+**Includes:**
+- Express.js with TypeScript
+- PostgreSQL connection
+- Redis caching layer
+- API documentation with Swagger
+- Docker configuration
+- Kubernetes manifests
+
+### Mobile App Backend
+
+```bash
+# Backend for mobile apps
+claudekit new mobile-backend \
+  --template api-server \
+  --features auth,database,storage \
+  --auth jwt \
+  --storage s3
+```
+
+## Development Workflow
+
+### 1. Project Planning
+
+```bash
+# Plan project architecture
+claudekit /plan project "Build a task management app"
+
+# Create project structure
+claudekit scaffold --pattern mvc
+
+# Define data models
+claudekit /model create User name:string email:string
+claudekit /model create Task title:string completed:boolean
+```
+
+### 2. Core Development
+
+```bash
+# Generate components
+claudekit /generate component UserProfile --props user,avatar
+claudekit /generate component TaskList --props tasks,onDelete
+
+# Create API endpoints
+claudekit /generate api /api/users --methods GET,POST,PUT,DELETE
+claudekit /generate api /api/tasks --methods GET,POST,PUT,DELETE
+
+# Add database migrations
+claudekit /migration create create_users_table
+claudekit /migration create create_tasks_table
+```
+
+### 3. Feature Development
+
+```bash
+# Add authentication
+claudekit /feature auth --flow email-password
+
+# Add file uploads
+claudekit /feature upload --provider s3
+
+# Add real-time features
+claudekit /feature realtime --provider socket.io
+
+# Add search functionality
+claudekit /feature search --provider elasticsearch
+```
+
+## Best Practices
+
+### 1. Project Structure
+
+ClaudeKit follows best practices for project organization:
+
+```
+my-project/
+├── src/
+│   ├── components/     # React/Vue components
+│   ├── pages/         # Page components
+│   ├── lib/           # Utility functions
+│   ├── hooks/         # Custom hooks
+│   ├── types/         # TypeScript definitions
+│   └── styles/        # Global styles
+├── docs/              # Documentation
+├── tests/             # Test files
+├── scripts/           # Build scripts
+└── config/            # Configuration files
+```
+
+### 2. Code Quality
+
+```bash
+# Set up linting and formatting
+claudekit add feature linting --tools eslint,prettier
+
+# Configure pre-commit hooks
+claudekit add feature pre-commit --tools husky,lint-staged
+
+# Set up code coverage
+claudekit add feature coverage --threshold 80
+```
+
+### 3. Testing Strategy
+
+```bash
+# Unit tests
+claudekit /test unit src/components/
+
+# Integration tests
+claudekit /test integration tests/api/
+
+# End-to-end tests
+claudekit /test e2e tests/e2e/
+
+# Performance tests
+claudekit /test performance --threshold 1000ms
+```
+
+## AI-Powered Development
+
+### 1. Intelligent Code Generation
+
+```bash
+# Generate based on requirements
+claudekit /ask "Create a user authentication system with JWT"
+
+# Enhance existing code
+claudekit /enhance src/components/Header.tsx --add mobile-responsive
+
+# Optimize performance
+claudekit /optimize src/pages/Dashboard.tsx --target performance
+```
+
+### 2. Automated Documentation
+
+```bash
+# Generate API documentation
+claudekit /docs api --format openapi
+
+# Create component documentation
+claudekit /docs components --output docs/components/
+
+# Generate README
+claudekit /docs readme --template comprehensive
+```
+
+### 3. Code Review and Optimization
+
+```bash
+# Review code quality
+claudekit /review src/ --strict
+
+# Find and fix bugs
+claudekit /debug src/ --auto-fix
+
+# Refactor for better performance
+claudekit /refactor src/ --strategy performance
+```
+
+## Deployment Setup
+
+### 1. Choose Platform
+
+```bash
+# Vercel deployment
+claudekit deploy vercel --auto-setup
+
+# Netlify deployment
+claudekit deploy netlify --setup-functions
+
+# AWS deployment
+claudekit deploy aws --services ec2,rds,s3
+
+# Docker deployment
+claudekit deploy docker --registry ghcr
+```
+
+### 2. CI/CD Pipeline
+
+```bash
+# GitHub Actions
+claudekit /ci github --workflow test,build,deploy
+
+# GitLab CI
+claudekit /ci gitlab --stages test,build,deploy
+
+# CircleCI
+claudekit /ci circleci --workflow test,build,deploy
+```
+
+### 3. Environment Configuration
+
+```bash
+# Development environment
+claudekit env set development NODE_ENV=development
+claudekit env set development DATABASE_URL=postgresql://localhost/dev
+
+# Production environment
+claudekit env set production NODE_ENV=production
+claudekit env set production DATABASE_URL=${DATABASE_URL}
+```
+
+## Project Templates Gallery
+
+### E-commerce Platform
+
+```bash
+claudekit new ecommerce-store \
+  --template nextjs-ecommerce \
+  --features auth,payments,inventory,cms \
+  --payment stripe \
+  --cms contentful
+```
+
+### Social Media App
+
+```bash
+claudekit new social-app \
+  --template react-native-social \
+  --features auth,chat,feed,notifications \
+  --backend firebase
+```
+
+### Analytics Dashboard
+
+```bash
+claudekit new analytics-dashboard \
+  --template react-dashboard \
+  --features charts,real-time,exports \
+  --charts recharts
+```
+
+### Content Management System
+
+```bash
+claudekit new cms-platform \
+  --template nextjs-cms \
+  --features auth,content,media,workflow \
+  --database mongodb
+```
+
+## Migration and Scaling
+
+### 1. Scaling Up
+
+```bash
+# Add microservices
+claudekit /microservice create users-service
+claudekit /microservice create orders-service
+
+# Add message queue
+claudekit add feature queue --provider rabbitmq
+
+# Add caching layer
+claudekit add feature cache --provider redis
+```
+
+### 2. Team Collaboration
+
+```bash
+# Add team workspace
+claudekit team add developer@company.com --role developer
+claudekit team add designer@company.com --role designer
+
+# Configure workflows
+claudekit workflow set code-review --required 2
+claudekit workflow set deployment --staging first
+```
+
+## Next Steps
+
+After initializing your greenfield project:
+
+1. **Customize Configuration**: Tailor settings to your needs
+2. **Explore Agents**: Use specialized AI agents for specific tasks
+3. **Build Features**: Leverage AI-powered development tools
+4. **Deploy**: Set up production deployment
+5. **Monitor**: Add analytics and monitoring
+
+---
+
+**Ready to start?** Use our [Quick Start Guide](./quick-start.md) or explore [Project Templates](https://github.com/mrgoonie/claudekit-cli/templates) for more options.


### PR DESCRIPTION
## Summary
- Add brownfield projects documentation for existing project integration
- Add greenfield projects documentation for new project setup  
- Add comprehensive cheatsheet with commands and quick reference

## Changes Made
- Created `brownfield-projects.md` with integration guide for existing projects
- Created `greenfield-projects.md` with setup guide for new projects
- Created `cheatsheet.md` with comprehensive command reference
- All pages automatically integrated into navigation via content collections

## Test Plan
- [x] Documentation builds successfully
- [x] New pages appear in Getting Started navigation
- [x] All content follows project documentation standards

Closes #51