### PR TITLE
docs(cli): update ck init/update command documentation

### DIFF
--- a/public/docs/cli/index.md
+++ b/public/docs/cli/index.md
@@ -27,35 +27,14 @@ Command-line tool for bootstrapping and updating ClaudeKit projects from private
 
 ## Core Commands
 
-### ck new
-
-Create new project from latest ClaudeKit release:
-
-```bash
-# Interactive mode
-ck new
-
-# With options
-ck new --dir my-project --kit engineer
-
-# Specific version
-ck new --kit engineer --version v1.0.0
-```
-
-**Options:**
-- `--dir <dir>` - Target directory (default: current directory)
-- `--kit <kit>` - Kit to use (`engineer` or `marketing`)
-- `--version <version>` - Specific version to download (default: latest)
-- `--exclude <pattern>` - Exclude files/directories using glob patterns (can be used multiple times)
-
-[Learn more about `ck new`](/docs/cli/new)
-
 ### ck init
 
-Update existing project to latest or specific version:
+Initialize or update ClaudeKit Engineer in your project:
+
+**Note:** This command should be run from the root directory of your project.
 
 ```bash
-# Interactive mode
+# Interactive mode (recommended)
 ck init
 
 # With options
@@ -63,6 +42,9 @@ ck init --kit engineer
 
 # Specific version
 ck init --kit engineer --version v1.0.0
+
+# With exclude patterns
+ck init --exclude "local-config/**" --exclude "*.local"
 
 # Global mode - use platform-specific user configuration
 ck init --global
@@ -81,6 +63,30 @@ ck init -g --kit engineer
 - `--kit <kit>` - Kit to use (`engineer` or `marketing`)
 - `--version <version>` - Specific version to download (default: latest)
 - `--exclude <pattern>` - Exclude files/directories using glob patterns (can be used multiple times)
+- `--global, -g` - Use platform-specific user configuration directory
+
+**Global vs Local Configuration:**
+
+By default, ClaudeKit uses local configuration (`~/.claudekit`).
+
+For platform-specific **user-scoped settings**, use the `--global` flag:
+- **macOS/Linux**: `~/.claude`
+- **Windows**: `%LOCALAPPDATA%\.claude`
+
+Global mode uses user-scoped directories (no sudo required), allowing separate configurations for different projects.
+
+### ck update
+
+Update the ClaudeKit CLI itself to the latest version:
+
+```bash
+# Update CLI to latest
+ck update
+```
+
+**What it does:**
+- Updates the `ck` command-line tool to the latest version
+- Does NOT update ClaudeKit Engineer files (use `ck init` for that)
 
 ### ck versions
 
@@ -115,7 +121,7 @@ All commands support these global options:
 Enable verbose logging for debugging:
 
 ```bash
-ck new --verbose
+ck init --verbose
 ck init -v  # Short form
 ```
 
@@ -131,7 +137,7 @@ ck init -v  # Short form
 Write logs to file for sharing:
 
 ```bash
-ck new --verbose --log-file debug.log
+ck init --verbose --log-file debug.log
 ```
 
 **Note:** All sensitive data (tokens, credentials) is automatically sanitized in logs.
@@ -224,8 +230,8 @@ gh auth login
 # OR
 export GITHUB_TOKEN=ghp_your_token
 
-# Create new project
-ck new --kit engineer
+# Initialize project
+ck init --kit engineer
 
 # Navigate to project
 cd my-project
@@ -236,26 +242,22 @@ claude  # Start Claude Code
 
 ## Common Workflows
 
-### Create New Project
+### Initialize or Update ClaudeKit Engineer
 
 ```bash
 # Interactive mode (recommended)
-ck new
+ck init
 
 # Direct with options
-ck new --dir my-app --kit engineer
+ck init --dir my-app --kit engineer
 
 # Specific version
-ck new --dir my-app --kit engineer --version v1.0.0
+ck init --dir my-app --kit engineer --version v1.0.0
 
 # With exclusions
-ck new --kit engineer --exclude "*.log" --exclude "temp/**"
-```
+ck init --exclude "*.log" --exclude "temp/**"
 
-### Update Existing Project
-
-```bash
-# Update to latest
+# Update ClaudeKit Engineer to latest
 ck init
 
 # Update to specific version
@@ -266,10 +268,13 @@ ck init --exclude "local-config/**" --exclude "*.local"
 
 # Update with verbose output
 ck init --verbose
+```
 
-# Global mode - use platform-specific user configuration
-ck init --global
-ck init -g --kit engineer
+### Update the CLI Itself
+
+```bash
+# Update ck CLI to latest version
+ck update
 ```
 
 ### Check Available Versions
@@ -320,7 +325,7 @@ npm list -g claudekit-cli
 1. Check internet connection
 2. Verify GitHub token is valid: `gh auth status`
 3. Confirm you have repository access (purchased kit)
-4. Try with verbose flag: `ck new --verbose`
+4. Try with verbose flag: `ck init --verbose`
 
 ## Version Information
 
@@ -340,9 +345,8 @@ ck -h
 ## Next Steps
 
 - [Installation Guide](/docs/cli/installation) - Install ClaudeKit CLI
-- [ck new Command](/docs/cli/new) - Create new projects
 - [Getting Started](/docs/getting-started/installation) - Start using ClaudeKit
 
 ---
 
-**Ready to start?** Purchase a kit at [ClaudeKit.cc](https://claudekit.cc), then run `ck new` to create your first project.
+**Ready to start?** Purchase a kit at [ClaudeKit.cc](https://claudekit.cc), then run `ck init` to initialize your first project.

--- a/public/docs/getting-started/installation.md
+++ b/public/docs/getting-started/installation.md
@@ -95,23 +95,12 @@ bun add -g claudekit-cli
 ck --version
 ```
 
-### Create a New Project
+### Initialize or Update ClaudeKit Engineer
+
+**Note:** This command should be run from the root directory of your project.
 
 ```bash
-# Interactive mode
-ck new
-
-# With options
-ck new --dir my-project --kit engineer
-
-# Specific version
-ck new --kit engineer --version v1.0.0
-```
-
-### Update Existing Project
-
-```bash
-# Interactive mode
+# Interactive mode (recommended)
 ck init
 
 # With options
@@ -119,7 +108,24 @@ ck init --kit engineer
 
 # Specific version
 ck init --kit engineer --version v1.0.0
+
+# With exclude patterns
+ck init --exclude "local-config/**" --exclude "*.local"
+
+# Global mode - use platform-specific user configuration
+ck init --global
+ck init -g --kit engineer
 ```
+
+### Update the CLI Itself
+
+To update the `ck` command-line tool to the latest version:
+
+```bash
+ck update
+```
+
+**Note:** This updates the CLI tool only, not ClaudeKit Engineer files. Use `ck init` to update ClaudeKit Engineer.
 
 ### Authentication
 
@@ -158,13 +164,14 @@ ls -la .claude/
 
 ## Update ClaudeKit
 
-Keep ClaudeKit up to date:
+Keep ClaudeKit Engineer up to date:
 
 ```bash
-# Using CLI
+# Update ClaudeKit Engineer to latest version
 ck init
 
-# Or manually pull latest changes from claudekit-engineer repo
+# Update to specific version
+ck init --version v1.2.0
 ```
 
 **Exclude specific files during update:**
@@ -172,6 +179,13 @@ ck init
 ```bash
 # Don't overwrite CLAUDE.md
 ck init --exclude CLAUDE.md
+```
+
+**Update the CLI itself:**
+
+```bash
+# Update ck command-line tool
+ck update
 ```
 
 ## Troubleshooting

--- a/src/content/docs-vi/docs/cli/index.md
+++ b/src/content/docs-vi/docs/cli/index.md
@@ -33,56 +33,66 @@ Command-line tool for bootstrapping and updating ClaudeKit projects from private
 
 ## Core Commands
 
-### ck new
-
-Create new project from latest ClaudeKit release:
-
-```bash
-# Interactive mode
-ck new
-
-# With options
-ck new --dir my-project --kit engineer
-
-# Specific version
-ck new --kit engineer --version v1.0.0
-```
-
-**Options:**
-- `--dir <dir>` - Target directory (default: current directory)
-- `--kit <kit>` - Kit to use (`engineer` or `marketing`)
-- `--version <version>` - Specific version to download (default: latest)
-- `--exclude <pattern>` - Exclude files/directories using glob patterns (can be used multiple times)
-
-[Learn more about `ck new`](/docs/cli/new)
-
 ### ck init
 
-Update existing project to latest or specific version:
+Khởi tạo hoặc cập nhật ClaudeKit Engineer trong dự án:
+
+**Lưu ý:** Lệnh này nên được chạy từ thư mục gốc của dự án.
 
 ```bash
-# Interactive mode
+# Chế độ tương tác (khuyến nghị)
 ck init
 
-# With options
+# Với tùy chọn
 ck init --kit engineer
 
-# Specific version
+# Phiên bản cụ thể
 ck init --kit engineer --version v1.0.0
+
+# Với mẫu loại trừ
+ck init --exclude "local-config/**" --exclude "*.local"
+
+# Chế độ global - sử dụng thư mục cấu hình người dùng theo platform
+ck init --global
+ck init -g --kit engineer
 ```
 
-**What it does:**
-- Downloads specified ClaudeKit release
-- Intelligently merges files
-- Preserves your custom changes
-- Protects sensitive files
-- Maintains custom `.claude/` files
+**Chức năng:**
+- Tải xuống bản phát hành ClaudeKit được chỉ định
+- Merge file thông minh
+- Bảo toàn các thay đổi tùy chỉnh của bạn
+- Bảo vệ file nhạy cảm
+- Duy trì file tùy chỉnh trong `.claude/`
 
-**Options:**
-- `--dir <dir>` - Target directory (default: current directory)
-- `--kit <kit>` - Kit to use (`engineer` or `marketing`)
-- `--version <version>` - Specific version to download (default: latest)
-- `--exclude <pattern>` - Exclude files/directories using glob patterns (can be used multiple times)
+**Tùy chọn:**
+- `--dir <dir>` - Thư mục đích (mặc định: thư mục hiện tại)
+- `--kit <kit>` - Kit sử dụng (`engineer` hoặc `marketing`)
+- `--version <version>` - Phiên bản cụ thể để tải (mặc định: mới nhất)
+- `--exclude <pattern>` - Loại trừ file/thư mục sử dụng glob patterns (có thể dùng nhiều lần)
+- `--global, -g` - Sử dụng thư mục cấu hình người dùng theo platform
+
+**Cấu hình Global vs Local:**
+
+Mặc định, ClaudeKit sử dụng cấu hình local (`~/.claudekit`).
+
+Để cài đặt **user-scoped theo platform**, sử dụng flag `--global`:
+- **macOS/Linux**: `~/.claude`
+- **Windows**: `%LOCALAPPDATA%\.claude`
+
+Chế độ global sử dụng thư mục user-scoped (không cần sudo), cho phép cấu hình riêng biệt cho các dự án khác nhau.
+
+### ck update
+
+Cập nhật ClaudeKit CLI lên phiên bản mới nhất:
+
+```bash
+# Cập nhật CLI lên phiên bản mới nhất
+ck update
+```
+
+**Chức năng:**
+- Cập nhật công cụ dòng lệnh `ck` lên phiên bản mới nhất
+- KHÔNG cập nhật file ClaudeKit Engineer (dùng `ck init` cho việc đó)
 
 ### ck versions
 
@@ -215,59 +225,62 @@ After update:
 ## Quick Start
 
 ```bash
-# Install CLI
+# Cài đặt CLI
 npm install -g claudekit-cli
 
-# Verify installation
+# Kiểm tra cài đặt
 ck --version
 
-# Authenticate with GitHub
+# Xác thực với GitHub
 gh auth login
-# OR
+# HOẶC
 export GITHUB_TOKEN=ghp_your_token
 
-# Create new project
-ck new --kit engineer
+# Khởi tạo dự án
+ck init --kit engineer
 
-# Navigate to project
+# Điều hướng tới dự án
 cd my-project
 
-# Start using ClaudeKit
-claude  # Start Claude Code
+# Bắt đầu sử dụng ClaudeKit
+claude  # Khởi động Claude Code
 ```
 
 ## Common Workflows
 
-### Create New Project
+### Khởi tạo hoặc Cập nhật ClaudeKit Engineer
 
 ```bash
-# Interactive mode (recommended)
-ck new
-
-# Direct with options
-ck new --dir my-app --kit engineer
-
-# Specific version
-ck new --dir my-app --kit engineer --version v1.0.0
-
-# With exclusions
-ck new --kit engineer --exclude "*.log" --exclude "temp/**"
-```
-
-### Update Existing Project
-
-```bash
-# Update to latest
+# Chế độ tương tác (khuyến nghị)
 ck init
 
-# Update to specific version
+# Trực tiếp với tùy chọn
+ck init --dir my-app --kit engineer
+
+# Phiên bản cụ thể
+ck init --dir my-app --kit engineer --version v1.0.0
+
+# Với loại trừ
+ck init --exclude "*.log" --exclude "temp/**"
+
+# Cập nhật ClaudeKit Engineer lên mới nhất
+ck init
+
+# Cập nhật lên phiên bản cụ thể
 ck init --version v1.2.0
 
-# Update with exclusions
+# Cập nhật với loại trừ
 ck init --exclude "local-config/**" --exclude "*.local"
 
-# Update with verbose output
+# Cập nhật với verbose output
 ck init --verbose
+```
+
+### Cập nhật CLI
+
+```bash
+# Cập nhật ck CLI lên phiên bản mới nhất
+ck update
 ```
 
 ### Check Available Versions
@@ -343,4 +356,4 @@ ck -h
 
 ---
 
-**Ready to start?** Purchase a kit at [ClaudeKit.cc](https://claudekit.cc), then run `ck new` to create your first project.
+**Ready to start?** Purchase a kit at [ClaudeKit.cc](https://claudekit.cc), then run `ck init` to initialize your first project.

--- a/src/content/docs-vi/getting-started/installation.md
+++ b/src/content/docs-vi/getting-started/installation.md
@@ -101,23 +101,12 @@ bun add -g claudekit-cli
 ck --version
 ```
 
-### Tạo Dự Án Mới
+### Khởi Tạo hoặc Cập Nhật ClaudeKit Engineer
+
+**Lưu ý:** Lệnh này nên được chạy từ thư mục gốc của dự án.
 
 ```bash
-# Chế độ tương tác
-ck new
-
-# Với tùy chọn
-ck new --dir my-project --kit engineer
-
-# Phiên bản cụ thể
-ck new --kit engineer --version v1.0.0
-```
-
-### Cập Nhật Dự Án Hiện Có
-
-```bash
-# Chế độ tương tác
+# Chế độ tương tác (khuyến nghị)
 ck init
 
 # Với tùy chọn
@@ -126,10 +115,23 @@ ck init --kit engineer
 # Phiên bản cụ thể
 ck init --kit engineer --version v1.0.0
 
-# Global mode - use platform-specific user configuration
+# Với mẫu loại trừ
+ck init --exclude "local-config/**" --exclude "*.local"
+
+# Chế độ global - sử dụng thư mục cấu hình theo platform
 ck init --global
 ck init -g --kit engineer
 ```
+
+### Cập Nhật CLI
+
+Để cập nhật công cụ dòng lệnh `ck` lên phiên bản mới nhất:
+
+```bash
+ck update
+```
+
+**Lưu ý:** Lệnh này chỉ cập nhật CLI, không cập nhật file ClaudeKit Engineer. Dùng `ck init` để cập nhật ClaudeKit Engineer.
 
 ### Xác Thực
 
@@ -168,13 +170,14 @@ ls -la .claude/
 
 ## Cập Nhật ClaudeKit
 
-Giữ ClaudeKit luôn cập nhật:
+Giữ ClaudeKit Engineer luôn cập nhật:
 
 ```bash
-# Sử dụng CLI
+# Cập nhật ClaudeKit Engineer lên phiên bản mới nhất
 ck init
 
-# Hoặc thủ công pull các thay đổi mới nhất từ repo claudekit-engineer
+# Cập nhật lên phiên bản cụ thể
+ck init --version v1.2.0
 ```
 
 **Loại trừ các file cụ thể khi cập nhật:**
@@ -182,6 +185,13 @@ ck init
 ```bash
 # Không ghi đè CLAUDE.md
 ck init --exclude CLAUDE.md
+```
+
+**Cập nhật CLI:**
+
+```bash
+# Cập nhật công cụ dòng lệnh ck
+ck update
 ```
 
 ## Khắc Phục Sự Cố

--- a/src/content/docs/docs/cli/index.md
+++ b/src/content/docs/docs/cli/index.md
@@ -35,11 +35,9 @@ Command-line tool for bootstrapping and updating ClaudeKit projects from private
 
 ### ck init
 
-Initialize or update project from ClaudeKit release:
+Initialize or update ClaudeKit Engineer in your project:
 
-**Note:** this command should be run from the root directory of your project.
-
-⚠️ **Deprecation Notice:** The `update` command has been renamed to `init`. The `update` command still works but will show a deprecation warning. Please use `init` instead.
+**Note:** This command should be run from the root directory of your project.
 
 ```bash
 # Interactive mode (recommended)
@@ -57,9 +55,6 @@ ck init --exclude "local-config/**" --exclude "*.local"
 # Global mode - use platform-specific user configuration
 ck init --global
 ck init -g --kit engineer
-
-# Legacy (deprecated - use 'init' instead)
-ck init  # Shows deprecation warning
 ```
 
 **What it does:**
@@ -78,13 +73,26 @@ ck init  # Shows deprecation warning
 
 **Global vs Local Configuration:**
 
-By default, ClaudeKit uses local configuration (`~/.claudekit`). 
+By default, ClaudeKit uses local configuration (`~/.claudekit`).
 
 For platform-specific **user-scoped settings**, use the `--global` flag:
 - **macOS/Linux**: `~/.claude`
 - **Windows**: `%LOCALAPPDATA%\.claude`
 
 Global mode uses user-scoped directories (no sudo required), allowing separate configurations for different projects.
+
+### ck update
+
+Update the ClaudeKit CLI itself to the latest version:
+
+```bash
+# Update CLI to latest
+ck update
+```
+
+**What it does:**
+- Updates the `ck` command-line tool to the latest version
+- Does NOT update ClaudeKit Engineer files (use `ck init` for that)
 
 ### ck versions
 
@@ -240,7 +248,7 @@ claude  # Start Claude Code
 
 ## Common Workflows
 
-### Initialize or Update Project
+### Initialize or Update ClaudeKit Engineer
 
 ```bash
 # Interactive mode (recommended)
@@ -255,7 +263,7 @@ ck init --dir my-app --kit engineer --version v1.0.0
 # With exclusions
 ck init --exclude "*.log" --exclude "temp/**"
 
-# Update to latest
+# Update ClaudeKit Engineer to latest
 ck init
 
 # Update to specific version
@@ -266,6 +274,13 @@ ck init --exclude "local-config/**" --exclude "*.local"
 
 # Update with verbose output
 ck init --verbose
+```
+
+### Update the CLI Itself
+
+```bash
+# Update ck CLI to latest version
+ck update
 ```
 
 ### Check Available Versions

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -101,11 +101,9 @@ bun add -g claudekit-cli
 ck --version
 ```
 
-### Initialize or Update Project
+### Initialize or Update ClaudeKit Engineer
 
-**Note:** this command should be run from the root directory of your project.
-
-⚠️ **Deprecation Notice:** The `update` command has been renamed to `init`. The `update` command still works but will show a deprecation warning. Please use `init` instead.
+**Note:** This command should be run from the root directory of your project.
 
 ```bash
 # Interactive mode (recommended)
@@ -123,10 +121,17 @@ ck init --exclude "local-config/**" --exclude "*.local"
 # Global mode - use platform-specific user configuration
 ck init --global
 ck init -g --kit engineer
-
-# Legacy (deprecated - use 'init' instead)
-ck init  # Shows deprecation warning
 ```
+
+### Update the CLI Itself
+
+To update the `ck` command-line tool to the latest version:
+
+```bash
+ck update
+```
+
+**Note:** This updates the CLI tool only, not ClaudeKit Engineer files. Use `ck init` to update ClaudeKit Engineer.
 
 **Global vs Local Configuration:**
 
@@ -175,13 +180,14 @@ ls -la .claude/
 
 ## Update ClaudeKit
 
-Keep ClaudeKit up to date:
+Keep ClaudeKit Engineer up to date:
 
 ```bash
-# Using CLI
+# Update ClaudeKit Engineer to latest version
 ck init
 
-# Or manually pull latest changes from claudekit-engineer repo
+# Update to specific version
+ck init --version v1.2.0
 ```
 
 **Exclude specific files during update:**
@@ -189,6 +195,13 @@ ck init
 ```bash
 # Don't overwrite CLAUDE.md
 ck init --exclude CLAUDE.md
+```
+
+**Update the CLI itself:**
+
+```bash
+# Update ck command-line tool
+ck update
 ```
 
 ## Troubleshooting

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,13 +28,13 @@ claude
 
 # Review, approve, deploy`;
 
-const cliCode = `# Create new project with ClaudeKit configuration
-ck new --dir my-app
+const cliCode = `# Initialize ClaudeKit Engineer in your project
+ck init --kit engineer
 
-# Update existing project to latest ClaudeKit version
+# Update ClaudeKit Engineer to latest version
 ck init
 
-# Check and switch between ClaudeKit versions
+# Check available ClaudeKit versions
 ck versions`;
 
 const planningCode = `# Planner agent reads your codebase


### PR DESCRIPTION
## Summary
- Update `ck init` documentation: install/update ClaudeKit Engineer into projects
- Add `ck update` documentation: update the CLI itself (new command)
- Remove deprecated `ck new` references
- Update EN and VI docs consistently

## Test plan
- [x] Build passes (`bun run build`)
- [x] Verify CLI commands section renders correctly
- [x] Verify installation guide renders correctly