### PR TITLE
feat(docs): add YouTube walkthrough video to key pages

### DIFF
--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -16,6 +16,24 @@ published: true
 
 This guide will help you install ClaudeKit and set up your development environment. You can choose between manual setup or using the ClaudeKit CLI.
 
+## Video Guide
+
+Prefer video? Watch the complete installation walkthrough:
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 0.75rem; border: 1px solid var(--color-border); margin-bottom: 1rem;">
+  <iframe
+    src="https://www.youtube.com/embed/F_E0GIi_kVY"
+    title="ClaudeKit Installation Walkthrough"
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+</div>
+
+*More tutorials: [@goonnguyen](https://www.youtube.com/@goonnguyen)*
+
 ## Prerequisites
 
 Before installing ClaudeKit, ensure you have:

--- a/src/content/docs/getting-started/introduction.md
+++ b/src/content/docs/getting-started/introduction.md
@@ -10,6 +10,24 @@ published: true
 
 **ClaudeKit** extends Claude Code with specialized agents, slash commands, and reusable skills.
 
+## Video Walkthrough
+
+New to ClaudeKit? Watch this step-by-step walkthrough covering CLI installation, setup with `ck` commands, and a demo building UI from a screenshot.
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 0.75rem; border: 1px solid var(--color-border); margin-bottom: 1rem;">
+  <iframe
+    src="https://www.youtube.com/embed/F_E0GIi_kVY"
+    title="ClaudeKit Complete Walkthrough"
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+</div>
+
+*More tutorials: [@goonnguyen](https://www.youtube.com/@goonnguyen)*
+
 ## What is ClaudeKit?
 
 ClaudeKit transforms Claude Code from a general AI assistant into a focused engineering toolkit. Instead of writing prompts from scratch, you invoke battle-tested workflows optimized for speed and quality.

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -16,6 +16,24 @@ published: true
 
 Ship production feature in 15 minutes. No boilerplate, no setup hell.
 
+## Video Demo
+
+See ClaudeKit in action - from installation to building UI from a screenshot:
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; border-radius: 0.75rem; border: 1px solid var(--color-border); margin-bottom: 1rem;">
+  <iframe
+    src="https://www.youtube.com/embed/F_E0GIi_kVY"
+    title="ClaudeKit Quick Start Demo"
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen>
+  </iframe>
+</div>
+
+*More tutorials: [@goonnguyen](https://www.youtube.com/@goonnguyen)*
+
 ## Prerequisites
 
 - ClaudeKit CLI installed (`ck --version` works)

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -129,13 +129,32 @@ const headings = [
         Write less code, ship faster, maintain quality.
       </p>
 
-      <div class="flex flex-col sm:flex-row gap-4 justify-center items-center mb-16">
+      <div class="flex flex-col sm:flex-row gap-4 justify-center items-center mb-10">
         <a href="/docs/getting-started/installation" class="inline-flex items-center justify-center px-8 py-3.5 text-base font-medium text-white bg-[var(--color-accent-blue)] rounded-[var(--radius-md)] hover:bg-[var(--color-accent-cyan)] transition-all duration-200 shadow-blue hover:shadow-lg transform hover:-translate-y-0.5">
           Get Started in 5 Minutes
         </a>
         <a href="/docs/getting-started/introduction" class="inline-flex items-center justify-center px-8 py-3.5 text-base font-medium text-[var(--color-text-primary)] bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-[var(--radius-md)] hover:bg-[var(--color-bg-secondary)] hover:border-[var(--color-border-hover)] transition-all duration-200">
           View Documentation
         </a>
+      </div>
+
+      <!-- Video Walkthrough -->
+      <div class="mb-16">
+        <p class="text-sm text-[var(--color-text-muted)] mb-4">Watch the complete walkthrough</p>
+        <div class="relative mx-auto max-w-3xl aspect-video rounded-xl overflow-hidden border border-[var(--color-border)] shadow-2xl">
+          <iframe
+            src="https://www.youtube.com/embed/F_E0GIi_kVY"
+            title="ClaudeKit Complete Walkthrough - From Installation to Building UI"
+            frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+            class="absolute inset-0 w-full h-full"
+          ></iframe>
+        </div>
+        <p class="text-xs text-[var(--color-text-muted)] mt-3">
+          More tutorials on <a href="https://www.youtube.com/@goonnguyen" target="_blank" rel="noopener noreferrer" class="text-[var(--color-accent-blue)] hover:underline">@goonnguyen</a>
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- Add YouTube walkthrough video (https://www.youtube.com/watch?v=F_E0GIi_kVY) to homepage, introduction, installation, and quick-start pages
- Video covers: CLI installation, ClaudeKit setup with `ck` commands, and demo building UI from screenshot
- Include link to @goonnguyen YouTube channel for more tutorials

## Test plan
- [ ] Verify video embeds render correctly on all 4 pages
- [ ] Test responsive behavior on mobile/tablet
- [ ] Confirm video plays when clicked
- [ ] Check YouTube channel link works