### PR TITLE
fix(nav): correct docs link in header navbar

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -58,7 +58,7 @@ const navIcons = {
           <span>{t('nav.getting-started')}</span>
         </a>
         <a
-          href={getLocalizedPath('/docs/docs/agents/planner', currentLocale)}
+          href={getLocalizedPath('/docs/agents', currentLocale)}
           class:list={['nav-link', { active: currentSection === 'docs' }]}
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={navIcons['docs']} />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,19 +5,19 @@ const exactRedirects: Record<string, string> = {
   // Getting Started moves
   '/docs/getting-started/greenfield-projects': '/docs/workflows/new-project',
   '/docs/getting-started/brownfield-projects': '/docs/workflows/existing-project',
-  '/docs/getting-started/mcp-setup': '/docs/docs/configuration/mcp-setup',
-  '/docs/getting-started/gemini': '/docs/docs/skills/ai/gemini-vision',
+  '/docs/getting-started/mcp-setup': '/docs/configuration/mcp-setup',
+  '/docs/getting-started/gemini': '/docs/skills/ai/gemini-vision',
 
   // Core Concepts → Configuration/Docs
-  '/docs/core-concepts/claude-md': '/docs/docs/configuration/claude-md',
-  '/docs/core-concepts/workflows': '/docs/docs/configuration/workflows',
-  '/docs/core-concepts/architecture': '/docs/docs/agents',
-  '/docs/core-concepts/code-standards': '/docs/docs/configuration/claude-md',
-  '/docs/core-concepts/system-architecture': '/docs/docs/agents',
+  '/docs/core-concepts/claude-md': '/docs/configuration/claude-md',
+  '/docs/core-concepts/workflows': '/docs/configuration/workflows',
+  '/docs/core-concepts/architecture': '/docs/agents',
+  '/docs/core-concepts/code-standards': '/docs/configuration/claude-md',
+  '/docs/core-concepts/system-architecture': '/docs/agents',
 
-  // CLI → Docs
-  '/docs/cli': '/docs/docs/cli',
-  '/docs/cli/installation': '/docs/docs/cli/installation',
+  // CLI → Docs (no /docs/docs prefix needed - pages now at /docs/cli)
+  // '/docs/cli': '/docs/cli', // Same path, no redirect needed
+  // '/docs/cli/installation': '/docs/cli/installation', // Same path, no redirect needed
 
   // Use Cases → Workflows
   '/docs/use-cases': '/docs/workflows',


### PR DESCRIPTION
## Summary

- Fixed header navbar "Docs" link pointing to incorrect path `/docs/docs/agents/planner` 
- Updated redirect targets in middleware to remove duplicate `/docs/docs/` prefix

## Changes

- `src/components/Header.astro`: Changed Docs nav link from `/docs/docs/agents/planner` to `/docs/agents`
- `src/middleware.ts`: Corrected redirect targets to use `/docs/` prefix instead of `/docs/docs/`

## Related

Follow-up fix from PR #30 (duplicate /docs path issue)

## Test Plan

- [x] Build passes locally
- [x] Verify navbar "Docs" link navigates to `/docs/agents`
- [x] Verify old URLs redirect correctly