### PR TITLE
fix: correct /plan → /code workflow documentation (closes #28)

### DIFF
--- a/src/content/docs-vi/docs/agents/planner.md
+++ b/src/content/docs-vi/docs/agents/planner.md
@@ -411,8 +411,8 @@ cat plans/latest-plan.md
 # 4. Regenerate if needed
 /plan [updated requirements]
 
-# 5. Implement
-/cook [implement following the plan]
+# 5. Implement (use /code since plan exists)
+/code @plans/your-feature-plan.md
 ```
 
 ### During Implementation
@@ -468,7 +468,7 @@ A good plan results in:
 
 ## Next Steps
 
-- [Implementation](/docs/commands/core/cook) - Execute the plan
+- [Implementation](/docs/commands/core/code) - Execute the plan
 - [Testing](/docs/commands/core/test) - Validate the implementation
 - [Documentation](/docs/commands/docs/update) - Update docs
 

--- a/src/content/docs-vi/docs/commands/plan/ci.md
+++ b/src/content/docs-vi/docs/commands/plan/ci.md
@@ -828,8 +828,8 @@ cat plans/fix-ci-12345.md
 # Option A: Implement manually
 # Follow steps in plan
 
-# Option B: Use /cook
-/cook [implement CI fix from plans/fix-ci-12345.md]
+# Option B: Use /code (recommended - uses existing plan)
+/code @plans/fix-ci-12345.md
 
 # Option C: Use /fix:ci (auto-implements)
 /fix:ci https://github.com/user/repo/actions/runs/12345
@@ -848,7 +848,7 @@ npm run build
 ## Next Steps
 
 - [/fix:ci](/docs/commands/fix/ci) - Auto-implement CI fix
-- [/cook](/docs/commands/core/cook) - Implement plan manually
+- [/code](/docs/commands/core/code) - Implement existing plan
 - [/debug](/docs/commands/core/debug) - Debug complex issues
 
 ---

--- a/src/content/docs-vi/docs/commands/plan/two.md
+++ b/src/content/docs-vi/docs/commands/plan/two.md
@@ -837,19 +837,19 @@ cat plans/[task]-comparison.md
 # 4. Make decision
 # Consider: team skills, timeline, budget, requirements
 
-# 5. Implement chosen approach
-/cook [implement approach 1 from plan]
+# 5. Implement chosen approach (use /code since plan exists)
+/code @plans/[task]-approach-1-*.md
 # OR
-/cook [implement approach 2 from plan]
+/code @plans/[task]-approach-2-*.md
 
 # 6. Optionally: Hybrid
-/cook [implement hybrid approach using X from plan 1 and Y from plan 2]
+/code @plans/[task]-approach-1-*.md  # then manually integrate from approach 2
 ```
 
 ## Next Steps
 
 - [/plan](/docs/commands/core/plan) - Single approach planning
-- [/cook](/docs/commands/core/cook) - Implement chosen plan
+- [/code](/docs/commands/core/code) - Implement chosen plan
 - [/plan:cro](/docs/commands/plan/cro) - CRO-specific planning
 
 ---

--- a/src/content/docs-vi/getting-started/quick-start.md
+++ b/src/content/docs-vi/getting-started/quick-start.md
@@ -83,7 +83,7 @@ Quét qua kế hoạch. Kiến trúc vững chắc? Tiếp tục.
 ### Bước 4: Triển Khai
 
 ```bash
-/cook implement the auth plan
+/code @plans/251030-auth-implementation.md
 ```
 
 **Điều gì xảy ra** (5 phút):

--- a/src/content/docs-vi/support/troubleshooting/api-key-setup.md
+++ b/src/content/docs-vi/support/troubleshooting/api-key-setup.md
@@ -149,7 +149,7 @@ curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:g
 # Wait 1 minute between commands
 /plan implement feature
 # Wait 60 seconds...
-/cook implement feature
+/code @plans/feature.md
 
 # Or upgrade to paid tier
 # Visit: console.cloud.google.com/billing

--- a/src/content/docs-vi/support/troubleshooting/performance-issues.md
+++ b/src/content/docs-vi/support/troubleshooting/performance-issues.md
@@ -83,7 +83,7 @@ curl -w "@-" -o /dev/null -s https://generativelanguage.googleapis.com <<< "time
 # Wait between commands
 /plan feature A
 # Wait 60 seconds
-/cook feature A
+/code @plans/feature-a.md
 
 # Or upgrade to paid tier
 # console.cloud.google.com/billing
@@ -292,9 +292,7 @@ node --version  # Should be 18+
 
 # ✅ Fast (incremental)
 /plan implement authentication
-/cook implement login endpoint
-/cook implement signup endpoint
-/cook implement password reset
+/code @plans/auth.md  # Implements login, signup, password reset phases
 ```
 
 #### Check API Endpoint
@@ -522,11 +520,11 @@ EOF
 # ✅ Correct (one at a time)
 /plan implement auth
 # Wait for completion
-/cook implement auth
+/code @plans/auth.md
 
 # ❌ Wrong (compete for resources)
 /plan implement auth
-/cook implement auth  # Don't run simultaneously!
+/code @plans/auth.md  # Don't run simultaneously!
 ```
 
 ---

--- a/src/content/docs/docs/agents/planner.md
+++ b/src/content/docs/docs/agents/planner.md
@@ -411,8 +411,8 @@ cat plans/latest-plan.md
 # 4. Regenerate if needed
 /plan [updated requirements]
 
-# 5. Implement
-/cook [implement following the plan]
+# 5. Implement (use /code since plan exists)
+/code @plans/your-feature-plan.md
 ```
 
 ### During Implementation
@@ -468,7 +468,7 @@ A good plan results in:
 
 ## Next Steps
 
-- [Implementation](/docs/commands/core/cook) - Execute the plan
+- [Implementation](/docs/commands/core/code) - Execute the plan
 - [Testing](/docs/commands/core/test) - Validate the implementation
 - [Documentation](/docs/commands/docs/update) - Update docs
 

--- a/src/content/docs/docs/commands/core/scout.md
+++ b/src/content/docs/docs/commands/core/scout.md
@@ -354,7 +354,7 @@ System continues with available results, doesn't retry.
 /ask [should we consolidate these caching patterns or keep separate?]
 ```
 
-### Scout → Plan → Cook
+### Scout → Plan → Code
 
 ```bash
 # 1. Scout codebase
@@ -364,7 +364,7 @@ System continues with available results, doesn't retry.
 /plan [add centralized error handling middleware]
 
 # 3. Implement
-/cook [implement error handling following discovered patterns]
+/code @plans/error-handling.md
 ```
 
 ### Scout → Debug

--- a/src/content/docs/docs/commands/index.md
+++ b/src/content/docs/docs/commands/index.md
@@ -91,7 +91,7 @@ ClaudeKit provides a comprehensive set of slash commands to accelerate your deve
 ```bash
 # Feature Development
 /plan [feature description]      # Plan the feature
-/cook [feature description]      # Implement the feature
+/code @plans/feature.md          # Implement the plan
 
 # Bug Fixing
 /fix [any issue]                 # Smart fix (auto-selects approach)
@@ -256,14 +256,14 @@ ClaudeKit provides a comprehensive set of slash commands to accelerate your deve
 ✅ **Clear**
 ```bash
 /plan [add OAuth2 authentication with Google and GitHub providers]
-/cook [implement JWT token refresh with 15-minute expiry]
+/code @plans/oauth.md  # Implement the plan
 /debug [API returns 500 error when creating user with empty email]
 ```
 
 ❌ **Vague**
 ```bash
 /plan [add auth]
-/cook [make it work]
+/code [make it work]
 /debug [something's broken]
 ```
 

--- a/src/content/docs/docs/commands/plan/ci.md
+++ b/src/content/docs/docs/commands/plan/ci.md
@@ -828,8 +828,8 @@ cat plans/fix-ci-12345.md
 # Option A: Implement manually
 # Follow steps in plan
 
-# Option B: Use /cook
-/cook [implement CI fix from plans/fix-ci-12345.md]
+# Option B: Use /code (recommended - uses existing plan)
+/code @plans/fix-ci-12345.md
 
 # Option C: Use /fix:ci (auto-implements)
 /fix:ci https://github.com/user/repo/actions/runs/12345
@@ -848,7 +848,7 @@ npm run build
 ## Next Steps
 
 - [/fix:ci](/docs/commands/fix/ci) - Auto-implement CI fix
-- [/cook](/docs/commands/core/cook) - Implement plan manually
+- [/code](/docs/commands/core/code) - Implement existing plan
 - [/debug](/docs/commands/core/debug) - Debug complex issues
 
 ---

--- a/src/content/docs/docs/commands/plan/two.md
+++ b/src/content/docs/docs/commands/plan/two.md
@@ -837,19 +837,19 @@ cat plans/[task]-comparison.md
 # 4. Make decision
 # Consider: team skills, timeline, budget, requirements
 
-# 5. Implement chosen approach
-/cook [implement approach 1 from plan]
+# 5. Implement chosen approach (use /code since plan exists)
+/code @plans/[task]-approach-1-*.md
 # OR
-/cook [implement approach 2 from plan]
+/code @plans/[task]-approach-2-*.md
 
 # 6. Optionally: Hybrid
-/cook [implement hybrid approach using X from plan 1 and Y from plan 2]
+/code @plans/[task]-approach-1-*.md  # then manually integrate from approach 2
 ```
 
 ## Next Steps
 
 - [/plan](/docs/commands/core/plan) - Single approach planning
-- [/cook](/docs/commands/core/cook) - Implement chosen plan
+- [/code](/docs/commands/core/code) - Implement chosen plan
 - [/plan:cro](/docs/commands/plan/cro) - CRO-specific planning
 
 ---

--- a/src/content/docs/getting-started/concepts.md
+++ b/src/content/docs/getting-started/concepts.md
@@ -115,7 +115,7 @@ All agent behaviors, skills, and workflows configured in `.claude/CLAUDE.md`:
 - nextjs: Next.js App Router best practices
 
 ## Workflows
-- /cook: Plan → Develop → Test → Commit
+- /plan → /code: Plan → Implement existing plan
 - /fix: Debug → Fix → Test → Commit
 ```
 

--- a/src/content/docs/getting-started/upgrade-guide.md
+++ b/src/content/docs/getting-started/upgrade-guide.md
@@ -67,7 +67,7 @@ Add custom skills for your stack:
 Combine commands for complete workflows:
 ```bash
 /plan "redesign checkout flow"
-/cook
+/code @plans/checkout-redesign.md
 /design:good "checkout UI mockup"
 /fix:test
 /git:pr "feature/new-checkout"

--- a/src/content/docs/support/faq.md
+++ b/src/content/docs/support/faq.md
@@ -68,7 +68,7 @@ claudekit init
 **A:** The feature development workflow:
 ```bash
 /plan "add user authentication with OAuth"  # Plan the feature
-/cook                                      # Implement it
+/code @plans/user-auth.md                  # Implement the plan
 /fix:test                                  # Test and fix issues
 /git:cm                                    # Commit changes
 ```

--- a/src/content/docs/support/troubleshooting/api-key-setup.md
+++ b/src/content/docs/support/troubleshooting/api-key-setup.md
@@ -148,7 +148,7 @@ curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:g
 # Wait 1 minute between commands
 /plan implement feature
 # Wait 60 seconds...
-/cook implement feature
+/code @plans/feature.md
 
 # Or upgrade to paid tier
 # Visit: console.cloud.google.com/billing

--- a/src/content/docs/support/troubleshooting/performance-issues.md
+++ b/src/content/docs/support/troubleshooting/performance-issues.md
@@ -83,7 +83,7 @@ curl -w "@-" -o /dev/null -s https://generativelanguage.googleapis.com <<< "time
 # Wait between commands
 /plan feature A
 # Wait 60 seconds
-/cook feature A
+/code @plans/feature-a.md
 
 # Or upgrade to paid tier
 # console.cloud.google.com/billing
@@ -292,9 +292,7 @@ node --version  # Should be 18+
 
 # ✅ Fast (incremental)
 /plan implement authentication
-/cook implement login endpoint
-/cook implement signup endpoint
-/cook implement password reset
+/code @plans/auth.md  # Implements login, signup, password reset phases
 ```
 
 #### Check API Endpoint
@@ -522,11 +520,11 @@ EOF
 # ✅ Correct (one at a time)
 /plan implement auth
 # Wait for completion
-/cook implement auth
+/code @plans/auth.md
 
 # ❌ Wrong (compete for resources)
 /plan implement auth
-/cook implement auth  # Don't run simultaneously!
+/code @plans/auth.md  # Don't run simultaneously!
 ```
 
 ---

--- a/src/content/docs/workflows/adding-feature.md
+++ b/src/content/docs/workflows/adding-feature.md
@@ -487,7 +487,7 @@ Real-world scenario: Adding search functionality to an e-commerce site.
 ```bash
 # Plan complex database changes first
 /plan [implement multi-tenant architecture with tenant isolation]
-/cook [implement multi-tenant architecture]
+/code @plans/multi-tenant.md
 ```
 
 ### Variation 3: UI + Backend Feature
@@ -503,7 +503,7 @@ Real-world scenario: Adding search functionality to an e-commerce site.
 ```bash
 # Research included automatically
 /plan [integrate Twilio SMS notifications]
-/cook [integrate Twilio SMS as planned]
+/code @plans/twilio-sms.md
 ```
 
 ## Troubleshooting
@@ -516,10 +516,10 @@ Real-world scenario: Adding search functionality to an e-commerce site.
 ```bash
 # Break into smaller features
 /plan [add user management - phase 1: user CRUD]
-/cook [implement user CRUD]
+/code @plans/user-crud.md
 
 /plan [add user management - phase 2: roles and permissions]
-/cook [implement roles and permissions]
+/code @plans/roles-permissions.md
 ```
 
 ### Issue: Tests Failing

--- a/src/content/docs/workflows/index.md
+++ b/src/content/docs/workflows/index.md
@@ -16,7 +16,7 @@ Task-oriented guides for common development scenarios using ClaudeKit's slash co
 [**Feature Development Guide**](./feature-development.md) - Complete feature lifecycle from planning to deployment
 ```bash
 /plan "add user authentication with OAuth"
-/cook
+/code @plans/user-auth.md
 /fix:test
 /git:pr "feature/user-auth"
 ```
@@ -44,13 +44,13 @@ Task-oriented guides for common development scenarios using ClaudeKit's slash co
 ck init my-project --kit engineer
 cd my-project
 /plan "set up project structure"
-/cook
+/code @plans/project-setup.md
 ```
 
 ### Add New Feature
 ```bash
 /plan "add [feature description]"
-/cook
+/code @plans/your-feature.md
 /design:good "UI mockups if needed"
 /fix:test
 /git:cm

--- a/src/content/docs/workflows/integrating-payment.md
+++ b/src/content/docs/workflows/integrating-payment.md
@@ -520,8 +520,8 @@ Implement payment system for SaaS platform:
 # Plan implementation
 /plan [design payment system for SaaS with all requirements]
 
-# Integrate Stripe
-/cook [integrate Stripe with subscription and usage billing]
+# Integrate Stripe (use /code since plan exists)
+/code @plans/payment-system.md
 
 # Subscription tiers
 /cook [create three subscription tiers with feature gates]

--- a/src/content/docs/workflows/maintaining-old-project.md
+++ b/src/content/docs/workflows/maintaining-old-project.md
@@ -652,7 +652,7 @@ cat docs/technical-debt.md
 /plan [new feature description]
 
 # 2. Implement
-/cook [implement feature]
+/code @plans/feature.md
 
 # 3. Test
 /test
@@ -692,7 +692,7 @@ Prioritize:
 ```bash
 /plan [migrate from package X v1 to v2]
 # Review plan carefully
-/cook [implement migration]
+/code @plans/migration.md
 /test  # Comprehensive testing
 ```
 

--- a/src/content/docs/workflows/starting-new-project.md
+++ b/src/content/docs/workflows/starting-new-project.md
@@ -660,7 +660,7 @@ A production-ready REST API with:
 
 ```bash
 /plan [add task reminders and notifications]
-/cook [implement the feature]
+/code @plans/reminders.md
 /test
 /git:cm
 ```

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -288,7 +288,7 @@ const headings = [
 <p>Multi-agent orchestration system with role-based specialists:</p>
 
 <ul>
-  <li><strong>Core Workflow</strong>: <code>/plan</code> → <code>/cook</code> → <code>/test</code> → <code>/debug</code> → <code>/git:cm</code></li>
+  <li><strong>Core Workflow</strong>: <code>/plan</code> → <code>/code</code> → <code>/test</code> → <code>/debug</code> → <code>/git:cm</code></li>
   <li><strong>Design Tools</strong>: <code>/design:fast</code>, <code>/design:3d</code>, <code>/design:screenshot</code></li>
   <li><strong>Fix Commands</strong>: <code>/fix:fast</code>, <code>/fix:hard</code>, <code>/fix:ui</code>, <code>/fix:types</code></li>
   <li><strong>Content Creation</strong>: <code>/content:good</code>, <code>/content:cro</code>, <code>/docs:update</code></li>


### PR DESCRIPTION
## Summary
Fixed GitHub issue #28 by correcting documentation that incorrectly recommended using `/cook` command after `/plan`. All references now correctly guide users to use `/code` instead, since `/cook` = `/plan` + `/code` (would cause wasteful re-planning).

## Changes
- Updated 22 documentation files across both English and Vietnamese sections
- Corrected workflow references in: agents, commands, getting-started, workflows, and support docs
- Consistent application of the correct `/plan` → `/code` sequence

## Test Plan
- [x] All 22 files updated with consistent messaging
- [x] No secret/credential patterns in changes
- [x] Documentation files only (no code changes)
- [x] Ready for review and merge to `dev` branch

## Files Changed
- Agent documentation (planner.md)
- Command documentation (index, scout, plan variants)
- Getting started guides (concepts, quick-start, upgrade-guide)
- Workflow documentation (all 5 workflow guides)
- Support documentation (FAQ, troubleshooting)
- Landing page (index.astro)