### PR TITLE
fix: remove Twitter links and update Discord URLs

### DIFF
--- a/src/content/docs-vi/changelog/index.md
+++ b/src/content/docs-vi/changelog/index.md
@@ -212,7 +212,7 @@ Giải quyết bug:
 ## Hỗ trợ và tài nguyên
 
 ### Nhận trợ giúp
-- [Discord Community](https://discord.gg/claudekit) - Chat real-time với cộng đồng
+- [Discord Community](https://claudekit.cc/discord) - Chat real-time với cộng đồng
 - [GitHub Issues](https://github.com/claudekit/claudekit/issues) - Báo cáo bug và yêu cầu tính năng
 - [Documentation](../) - Tài liệu tham khảo đầy đủ
 - [Email Support](mailto:support@claudekit.cc) - Hỗ trợ doanh nghiệp
@@ -225,6 +225,6 @@ Giải quyết bug:
 
 ---
 
-**Cập nhật**: Theo dõi [@ClaudeKitDev](https://twitter.com/ClaudeKitDev) trên Twitter để nhận thông báo và cập nhật.
+**Cập nhật**: Tham gia [Discord](https://claudekit.cc/discord) để nhận thông báo và cập nhật.
 
 **Chu kỳ phát hành**: Phát hành định kỳ vào ngày 1 mỗi tháng. Bản vá bảo mật phát hành khi cần.

--- a/src/content/docs-vi/docs/agents/index.md
+++ b/src/content/docs-vi/docs/agents/index.md
@@ -54,7 +54,7 @@ These 14 agents are carefully optimized for daily development workflows based on
 - **Comprehensive Coverage**: Cover all aspects of development
 - **Maintainable**: Small enough to maintain, large enough to be effective
 
-> **Note**: If you need a new specialized agent, you can request it at the [ClaudeKit Discord](https://discord.gg/x7SwTSf3wc)
+> **Note**: If you need a new specialized agent, you can request it at the [ClaudeKit Discord](https://claudekit.cc/discord)
 
 ## How Agents Work Together
 

--- a/src/content/docs-vi/docs/skills/index.md
+++ b/src/content/docs-vi/docs/skills/index.md
@@ -744,7 +744,7 @@ then use gemini-document-processing to summarize key requirements"
 ```
 
 **Need help?**
-- Join [Discord](https://discord.gg/x7SwTSf3wc)
+- Join [Discord](https://claudekit.cc/discord)
 - Check [Commands](/docs/commands/) for workflows
 - Read [Agents](/docs/agents/) for orchestration
 

--- a/src/content/docs-vi/support/troubleshooting/agent-issues.md
+++ b/src/content/docs-vi/support/troubleshooting/agent-issues.md
@@ -637,7 +637,7 @@ done
 ### Get Help
 
 1. **GitHub Issues**: [Report agent problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Agent troubleshooting channel](https://discord.gg/claudekit)
+2. **Discord**: [Agent troubleshooting channel](https://claudekit.cc/discord)
 3. **Include**: Agent debug report, specific agent name, command used, expected vs actual behavior
 
 ---

--- a/src/content/docs-vi/support/troubleshooting/api-key-setup.md
+++ b/src/content/docs-vi/support/troubleshooting/api-key-setup.md
@@ -542,7 +542,7 @@ nano .env
 ### Get Help
 
 1. **GitHub Issues**: [Report API key problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [API configuration help](https://discord.gg/claudekit)
+2. **Discord**: [API configuration help](https://claudekit.cc/discord)
 3. **Include**: API debug report (keys masked), error messages, provider (Gemini/SearchAPI/OpenRouter)
 
 ---

--- a/src/content/docs-vi/support/troubleshooting/command-errors.md
+++ b/src/content/docs-vi/support/troubleshooting/command-errors.md
@@ -546,7 +546,7 @@ claude --dangerously-skip-permissions
 ### Get Help
 
 1. **GitHub Issues**: [Report command problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Ask community](https://discord.gg/claudekit)
+2. **Discord**: [Ask community](https://claudekit.cc/discord)
 3. **Include**: Debug report, error message, steps to reproduce
 
 ---

--- a/src/content/docs-vi/support/troubleshooting/index.md
+++ b/src/content/docs-vi/support/troubleshooting/index.md
@@ -179,9 +179,8 @@ tree .claude -L 2
 
 ### Community
 
-- **Discord**: [Join ClaudeKit Discord](https://discord.gg/claudekit)
+- **Discord**: [Join ClaudeKit Discord](https://claudekit.cc/discord)
 - **GitHub Discussions**: Share solutions, ask questions
-- **Twitter**: [@claudekit](https://twitter.com/claudekit) for updates
 
 ## Prevention Tips
 

--- a/src/content/docs-vi/support/troubleshooting/installation-issues.md
+++ b/src/content/docs-vi/support/troubleshooting/installation-issues.md
@@ -443,7 +443,7 @@ which ck
 
 1. **Check logs**: Look for errors during `npm install -g claudekit-cli`
 2. **GitHub Issues**: [Report installation problems](https://github.com/claudekit/claudekit-engineer/issues)
-3. **Discord**: [Join ClaudeKit community](https://discord.gg/claudekit)
+3. **Discord**: [Join ClaudeKit community](https://claudekit.cc/discord)
 
 Include in your report:
 - Operating system and version

--- a/src/content/docs-vi/support/troubleshooting/performance-issues.md
+++ b/src/content/docs-vi/support/troubleshooting/performance-issues.md
@@ -612,7 +612,7 @@ EOF
 ### Get Help
 
 1. **GitHub Issues**: [Report performance problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Performance optimization channel](https://discord.gg/claudekit)
+2. **Discord**: [Performance optimization channel](https://claudekit.cc/discord)
 3. **Include**: Performance report, project size, specific slow command, expected vs actual time
 
 ---

--- a/src/content/docs-vi/workflows/index.md
+++ b/src/content/docs-vi/workflows/index.md
@@ -187,14 +187,14 @@ Want to contribute use case examples? We're looking for:
 - Best practices learned
 
 **Contact us:**
-- [Discord Community](https://discord.gg/x7SwTSf3wc)
+- [Discord Community](https://claudekit.cc/discord)
 - [GitHub Discussions](https://github.com/claudekit/discussions)
 
 ## Request Use Cases
 
 Need a specific use case documented?
 
-1. Join our [Discord](https://discord.gg/x7SwTSf3wc)
+1. Join our [Discord](https://claudekit.cc/discord)
 2. Share your scenario
 3. We'll prioritize based on community interest
 

--- a/src/content/docs/changelog/index.md
+++ b/src/content/docs/changelog/index.md
@@ -212,7 +212,7 @@ Bug Resolution:
 ## Support and Resources
 
 ### Getting Help
-- [Discord Community](https://discord.gg/claudekit) - Real-time chat with community
+- [Discord Community](https://claudekit.cc/discord) - Real-time chat with community
 - [GitHub Issues](https://github.com/claudekit/claudekit/issues) - Bug reports and feature requests
 - [Documentation](../) - Complete reference documentation
 - [Email Support](mailto:support@claudekit.cc) - Enterprise support inquiries
@@ -225,6 +225,6 @@ Bug Resolution:
 
 ---
 
-**Stay Updated**: Follow [@ClaudeKitDev](https://twitter.com/ClaudeKitDev) on Twitter for announcements and updates.
+**Stay Updated**: Join our [Discord](https://claudekit.cc/discord) for announcements and updates.
 
 **Release Cadence**: Regular releases on the 1st of each month. Security patches released as needed.

--- a/src/content/docs/docs/agents/index.md
+++ b/src/content/docs/docs/agents/index.md
@@ -54,7 +54,7 @@ These 14 agents are carefully optimized for daily development workflows based on
 - **Comprehensive Coverage**: Cover all aspects of development
 - **Maintainable**: Small enough to maintain, large enough to be effective
 
-> **Note**: If you need a new specialized agent, you can request it at the [ClaudeKit Discord](https://discord.gg/x7SwTSf3wc)
+> **Note**: If you need a new specialized agent, you can request it at the [ClaudeKit Discord](https://claudekit.cc/discord)
 
 ## How Agents Work Together
 

--- a/src/content/docs/docs/skills/index.md
+++ b/src/content/docs/docs/skills/index.md
@@ -744,7 +744,7 @@ then use gemini-document-processing to summarize key requirements"
 ```
 
 **Need help?**
-- Join [Discord](https://discord.gg/x7SwTSf3wc)
+- Join [Discord](https://claudekit.cc/discord)
 - Check [Commands](/docs/commands/) for workflows
 - Read [Agents](/docs/agents/) for orchestration
 

--- a/src/content/docs/support/faq.md
+++ b/src/content/docs/support/faq.md
@@ -259,7 +259,7 @@ echo "node_modules/\ndist/\nbuild/\ncoverage/" > .claudeignore
 
 ### Q: How do I get help?
 **A:** Multiple support channels:
-- [Discord Community](https://discord.gg/claudekit) - Real-time help
+- [Discord Community](https://claudekit.cc/discord) - Real-time help
 - [GitHub Issues](https://github.com/claudekit/claudekit/issues) - Bug reports
 - [Documentation](../) - Complete reference
 - [Email Support](mailto:support@claudekit.cc) - Direct assistance
@@ -286,7 +286,7 @@ echo "node_modules/\ndist/\nbuild/\ncoverage/" > .claudeignore
 - [Complete Documentation](../)
 - [Getting Started Guide](../getting-started/)
 - [Workflow Examples](../workflows/)
-- [Discord Community](https://discord.gg/claudekit)
+- [Discord Community](https://claudekit.cc/discord)
 - [Blog](https://claudekit.cc/blog)
 
 ### Q: Can I talk to a human?
@@ -298,4 +298,4 @@ echo "node_modules/\ndist/\nbuild/\ncoverage/" > .claudeignore
 
 ---
 
-**Don't see your question here?** Ask in our [Discord community](https://discord.gg/claudekit) or [open an issue](https://github.com/claudekit/claudekit/issues). We're here to help!
+**Don't see your question here?** Ask in our [Discord community](https://claudekit.cc/discord) or [open an issue](https://github.com/claudekit/claudekit/issues). We're here to help!

--- a/src/content/docs/support/index.md
+++ b/src/content/docs/support/index.md
@@ -15,7 +15,7 @@ Get help with ClaudeKit through our community resources, documentation, and dire
 ### Stuck on something specific?
 - [FAQ](./faq.md) - Answers to common questions
 - [Troubleshooting](./troubleshooting.md) - Solutions to common issues
-- [Discord Community](https://discord.gg/claudekit) - Real-time help from community
+- [Discord Community](https://claudekit.cc/discord) - Real-time help from community
 
 ### Looking for how-to guides?
 - [Getting Started](../getting-started/) - Learn the basics
@@ -25,7 +25,7 @@ Get help with ClaudeKit through our community resources, documentation, and dire
 ## Community Support
 
 ### Discord Community
-[**Join ClaudeKit Discord**](https://discord.gg/claudekit)
+[**Join ClaudeKit Discord**](https://claudekit.cc/discord)
 
 **What you'll find**:
 - Real-time chat with ClaudeKit users and developers
@@ -162,7 +162,6 @@ I've tried running /skill:refresh and restarting ClaudeKit.
 
 **Quick questions** (< 5 min response):
 - Discord `#help` channel
-- Twitter [@ClaudeKitDev](https://twitter.com/ClaudeKitDev)
 
 **Technical issues**:
 - GitHub Issues (bug reports)
@@ -238,4 +237,4 @@ We value your feedback! Help us improve ClaudeKit:
 
 ---
 
-**Need immediate help?** Join our [Discord community](https://discord.gg/claudekit) for real-time assistance from fellow users and the ClaudeKit team.
+**Need immediate help?** Join our [Discord community](https://claudekit.cc/discord) for real-time assistance from fellow users and the ClaudeKit team.

--- a/src/content/docs/support/troubleshooting/agent-issues.md
+++ b/src/content/docs/support/troubleshooting/agent-issues.md
@@ -637,7 +637,7 @@ done
 ### Get Help
 
 1. **GitHub Issues**: [Report agent problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Agent troubleshooting channel](https://discord.gg/claudekit)
+2. **Discord**: [Agent troubleshooting channel](https://claudekit.cc/discord)
 3. **Include**: Agent debug report, specific agent name, command used, expected vs actual behavior
 
 ---

--- a/src/content/docs/support/troubleshooting/api-key-setup.md
+++ b/src/content/docs/support/troubleshooting/api-key-setup.md
@@ -541,7 +541,7 @@ nano .env
 ### Get Help
 
 1. **GitHub Issues**: [Report API key problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [API configuration help](https://discord.gg/claudekit)
+2. **Discord**: [API configuration help](https://claudekit.cc/discord)
 3. **Include**: API debug report (keys masked), error messages, provider (Gemini/SearchAPI/OpenRouter)
 
 ---

--- a/src/content/docs/support/troubleshooting/command-errors.md
+++ b/src/content/docs/support/troubleshooting/command-errors.md
@@ -543,7 +543,7 @@ claude --dangerously-skip-permissions
 ### Get Help
 
 1. **GitHub Issues**: [Report command problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Ask community](https://discord.gg/claudekit)
+2. **Discord**: [Ask community](https://claudekit.cc/discord)
 3. **Include**: Debug report, error message, steps to reproduce
 
 ---

--- a/src/content/docs/support/troubleshooting/index.md
+++ b/src/content/docs/support/troubleshooting/index.md
@@ -179,9 +179,8 @@ tree .claude -L 2
 
 ### Community
 
-- **Discord**: [Join ClaudeKit Discord](https://discord.gg/claudekit)
+- **Discord**: [Join ClaudeKit Discord](https://claudekit.cc/discord)
 - **GitHub Discussions**: Share solutions, ask questions
-- **Twitter**: [@claudekit](https://twitter.com/claudekit) for updates
 
 ## Prevention Tips
 

--- a/src/content/docs/support/troubleshooting/installation-issues.md
+++ b/src/content/docs/support/troubleshooting/installation-issues.md
@@ -443,7 +443,7 @@ which ck
 
 1. **Check logs**: Look for errors during `npm install -g claudekit-cli`
 2. **GitHub Issues**: [Report installation problems](https://github.com/claudekit/claudekit-engineer/issues)
-3. **Discord**: [Join ClaudeKit community](https://discord.gg/claudekit)
+3. **Discord**: [Join ClaudeKit community](https://claudekit.cc/discord)
 
 Include in your report:
 - Operating system and version

--- a/src/content/docs/support/troubleshooting/performance-issues.md
+++ b/src/content/docs/support/troubleshooting/performance-issues.md
@@ -612,7 +612,7 @@ EOF
 ### Get Help
 
 1. **GitHub Issues**: [Report performance problems](https://github.com/claudekit/claudekit-engineer/issues)
-2. **Discord**: [Performance optimization channel](https://discord.gg/claudekit)
+2. **Discord**: [Performance optimization channel](https://claudekit.cc/discord)
 3. **Include**: Performance report, project size, specific slow command, expected vs actual time
 
 ---

--- a/src/content/docs/workflows/bug-fixing.md
+++ b/src/content/docs/workflows/bug-fixing.md
@@ -241,7 +241,7 @@ const sessionConfig = {
 
 - [Troubleshooting Guide](../troubleshooting.md)
 - [Common Issues](../troubleshooting.md#common-issues)
-- [Discord Community](https://discord.gg/claudekit)
+- [Discord Community](https://claudekit.cc/discord)
 
 ## Related Workflows
 

--- a/src/content/docs/workflows/feature-development.md
+++ b/src/content/docs/workflows/feature-development.md
@@ -177,7 +177,7 @@ Let's walk through adding authentication to a Next.js app:
 ### Getting Help
 - [Troubleshooting Guide](../troubleshooting.md)
 - [FAQ](../support/faq/)
-- [Discord Community](https://discord.gg/claudekit)
+- [Discord Community](https://claudekit.cc/discord)
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

- Remove non-existent Twitter links (@claudekit, @ClaudeKitDev)
- Update all Discord links from `discord.gg/*` to `claudekit.cc/discord`
- Changes applied to both EN and VI documentation

## Changes

**Twitter links removed from:**
- `support/troubleshooting/index.md` (EN + VI)
- `support/index.md`
- `changelog/index.md` (EN + VI) - replaced with Discord link

**Discord links updated (23 files):**
- `discord.gg/claudekit` → `claudekit.cc/discord`
- `discord.gg/x7SwTSf3wc` → `claudekit.cc/discord`

## Test plan

- [x] Build passes (`bun run build`)

Closes #25
Closes #38