### PR TITLE
chore: sync dev to main - docs fixes and content rewrites

### DIFF
--- a/src/content/docs/workflows/feature-development.md
+++ b/src/content/docs/workflows/feature-development.md
@@ -31,7 +31,7 @@ The feature development workflow combines planning, research, implementation, te
 
 ### 2. Implementation Phase
 ```bash
-/cook
+/code
 ```
 
 **What happens**:
@@ -118,7 +118,7 @@ Let's walk through adding authentication to a Next.js app:
 
 ### Step 2: Implement
 ```bash
-/cook
+/code
 ```
 
 **Implementation Details**:


### PR DESCRIPTION
## Summary

- Fix `/cook` → `/code` command in feature-development workflow (fixes #54)
- Rewrite 42 skills + 17 agents documentation with concise templates
- Fix YAGNI typo in archive files
- Add critical link guidelines to CLAUDE.md
- Convert relative links to absolute paths to prevent 404s
- Update bun.lock

## Changes

| Type | Description |
|------|-------------|
| docs | Fix workflow command: `/plan` then `/code` (not `/cook`) |
| docs | Rewrite skills/agents with consistent templates |
| fix | Convert relative links to absolute paths |
| chore | Add link guidelines to prevent future issues |

## Test Plan

- [x] Build passes (`bun run build`)
- [x] All 285 pages generated successfully
- [x] Pagefind search index updated
