### PR TITLE
docs: improve local vs global installation UX

### DIFF
--- a/src/content/docs-vi/getting-started/installation.md
+++ b/src/content/docs-vi/getting-started/installation.md
@@ -101,27 +101,67 @@ bun add -g claudekit-cli
 ck --version
 ```
 
-### Khởi Tạo hoặc Cập Nhật ClaudeKit Engineer
+### Nên Chọn Chế Độ Cài Đặt Nào?
 
-**Lưu ý:** Lệnh này nên được chạy từ thư mục gốc của dự án.
+| Trường hợp | Chế độ | Lệnh |
+|------------|--------|------|
+| **Cài đặt lần đầu** | Global ⭐ | `ck init -g --kit engineer` |
+| **Muốn dùng ClaudeKit cho TẤT CẢ dự án** | Global ⭐ | `ck init -g --kit engineer` |
+| **Chỉ cho một dự án cụ thể** | Local | `ck init --kit engineer` |
+| **Môi trường CI/CD** | Local | `ck init --kit engineer` |
+
+---
+
+### Tùy Chọn A: Cài Đặt Global ⭐ Khuyến Nghị Cho Đa Số Người Dùng
+
+> **Sử dụng khi:** Bạn muốn ClaudeKit có sẵn cho TẤT CẢ dự án mà không cần copy file vào từng dự án.
+>
+> **Chạy từ:** Bất kỳ thư mục nào (ví dụ: home folder, desktop, bất cứ đâu)
 
 ```bash
-# Chế độ tương tác (khuyến nghị)
-ck init
+# Chế độ tương tác
+ck init -g
 
-# Với tùy chọn
-ck init --kit engineer
+# Với lựa chọn kit
+ck init -g --kit engineer
 
 # Phiên bản cụ thể
-ck init --kit engineer --version v1.0.0
+ck init -g --kit engineer --version v1.0.0
+```
+
+**File được cài đặt ở đâu:**
+- **macOS/Linux**: `~/.claude/`
+- **Windows**: `%LOCALAPPDATA%\.claude\`
+
+> ✅ **Mẹo:** Chế độ global lý tưởng cho phát triển cá nhân. Cài một lần, dùng mọi nơi.
+
+---
+
+### Tùy Chọn B: Cài Đặt Local (Dành Riêng Cho Dự Án)
+
+> **Sử dụng khi:** Bạn muốn file ClaudeKit CHỈ trong một dự án cụ thể.
+>
+> **Chạy từ:** Thư mục gốc của dự án (ví dụ: `/projects/my-app/`)
+
+```bash
+# Di chuyển đến dự án trước!
+cd /path/to/your/project
+
+# Chế độ tương tác
+ck init
+
+# Với lựa chọn kit
+ck init --kit engineer
 
 # Với mẫu loại trừ
 ck init --exclude "local-config/**" --exclude "*.local"
-
-# Chế độ global - sử dụng thư mục cấu hình theo platform
-ck init --global
-ck init -g --kit engineer
 ```
+
+**File được cài đặt ở đâu:** Trong thư mục dự án hiện tại (`./.claude/`)
+
+> ⚠️ **Cảnh báo:** Chạy `ck init` (không có `-g`) từ **thư mục home** hoặc **thư mục user** sẽ cài ClaudeKit tại đó, có thể gây lỗi đường dẫn hook. Nếu muốn ClaudeKit có sẵn ở mọi nơi, hãy dùng `ck init -g`.
+
+---
 
 ### Cập Nhật CLI
 
@@ -131,7 +171,7 @@ ck init -g --kit engineer
 ck update
 ```
 
-**Lưu ý:** Lệnh này chỉ cập nhật CLI, không cập nhật file ClaudeKit Engineer. Dùng `ck init` để cập nhật ClaudeKit Engineer.
+**Lưu ý:** Lệnh này chỉ cập nhật CLI, không cập nhật file ClaudeKit Engineer. Dùng `ck init` (local) hoặc `ck init -g` (global) để cập nhật file ClaudeKit Engineer.
 
 ### Xác Thực
 

--- a/src/content/docs-vi/support/troubleshooting/installation-issues.md
+++ b/src/content/docs-vi/support/troubleshooting/installation-issues.md
@@ -16,9 +16,40 @@ published: true
 
 ClaudeKit installation problems? Get unblocked in minutes with platform-specific fixes.
 
-## Quick Fix: Command Not Found
+## Sửa Nhanh: Lỗi Đường Dẫn Hook / User Prompt Submit Error
 
-**Symptom**: `ck: command not found` or `claudekit-cli: command not found`
+**Triệu chứng**: "User prompt submit error", hooks lỗi với lỗi đường dẫn, hoặc `%CLAUDE_PROJECT_DIR%` không tìm thấy
+
+**Nguyên nhân**: Bạn đã chạy `ck init` (chế độ local) từ thư mục sai—có thể là thư mục home hoặc thư mục user thay vì thư mục dự án.
+
+**Giải pháp**:
+
+```bash
+# Bước 1: Xóa cài đặt bị lỗi
+# Di chuyển đến nơi bạn đã vô tình cài đặt
+cd ~  # hoặc bất cứ nơi nào bạn chạy ck init
+rm -rf .claude/  # Xóa cài đặt local bị lỗi
+
+# Bước 2: Cài đặt lại đúng cách
+# Cho GLOBAL (khuyến nghị cho đa số người dùng):
+ck init -g --kit engineer
+
+# Cho LOCAL (chỉ cho dự án cụ thể):
+cd /path/to/your/actual/project
+ck init --kit engineer
+```
+
+**Phòng ngừa**:
+- Dùng `ck init -g` (global) nếu bạn muốn ClaudeKit có sẵn ở mọi nơi
+- Chỉ dùng `ck init` (local) khi đang ở trong thư mục dự án thực sự
+
+Xem [Hướng Dẫn Cài Đặt - Nên Chọn Chế Độ Nào?](/vi/docs/getting-started/installation#nên-chọn-chế-độ-cài-đặt-nào) để biết thêm chi tiết.
+
+---
+
+## Sửa Nhanh: Không Tìm Thấy Lệnh
+
+**Triệu chứng**: `ck: command not found` hoặc `claudekit-cli: command not found`
 
 **Solution**:
 

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -119,27 +119,67 @@ bun add -g claudekit-cli
 ck --version
 ```
 
-### Initialize or Update ClaudeKit Engineer
+### Which Installation Mode Should I Use?
 
-**Note:** This command should be run from the root directory of your project.
+| Scenario | Mode | Command |
+|----------|------|---------|
+| **First-time setup** | Global ⭐ | `ck init -g --kit engineer` |
+| **Want ClaudeKit in ALL projects** | Global ⭐ | `ck init -g --kit engineer` |
+| **Single project only** | Local | `ck init --kit engineer` |
+| **CI/CD environment** | Local | `ck init --kit engineer` |
+
+---
+
+### Option A: Global Installation ⭐ Recommended for Most Users
+
+> **Use this when:** You want ClaudeKit available for ALL your projects without copying files to each one.
+>
+> **Run from:** Any directory (e.g., your home folder, desktop, anywhere)
 
 ```bash
-# Interactive mode (recommended)
-ck init
+# Interactive mode
+ck init -g
 
-# With options
-ck init --kit engineer
+# With kit selection
+ck init -g --kit engineer
 
 # Specific version
-ck init --kit engineer --version v1.0.0
+ck init -g --kit engineer --version v1.0.0
+```
+
+**Where files are installed:**
+- **macOS/Linux**: `~/.claude/`
+- **Windows**: `%LOCALAPPDATA%\.claude\`
+
+> ✅ **Tip:** Global mode is ideal for personal development. Install once, use everywhere.
+
+---
+
+### Option B: Local Installation (Project-Specific)
+
+> **Use this when:** You want ClaudeKit files ONLY in a specific project.
+>
+> **Run from:** Your project's root directory (e.g., `/projects/my-app/`)
+
+```bash
+# Navigate to your project first!
+cd /path/to/your/project
+
+# Interactive mode
+ck init
+
+# With kit selection
+ck init --kit engineer
 
 # With exclude patterns
 ck init --exclude "local-config/**" --exclude "*.local"
-
-# Global mode - use platform-specific user configuration
-ck init --global
-ck init -g --kit engineer
 ```
+
+**Where files are installed:** Inside your current project directory (`./.claude/`)
+
+> ⚠️ **Warning:** Running `ck init` (without `-g`) from your **home directory** or **user folder** will install ClaudeKit locally there, which may cause hook path errors. If you want ClaudeKit available everywhere, use `ck init -g` instead.
+
+---
 
 ### Update the CLI Itself
 
@@ -149,17 +189,7 @@ To update the `ck` command-line tool to the latest version:
 ck update
 ```
 
-**Note:** This updates the CLI tool only, not ClaudeKit Engineer files. Use `ck init` to update ClaudeKit Engineer.
-
-**Global vs Local Configuration:**
-
-By default, ClaudeKit uses local configuration (`~/.claudekit`).
-
-For platform-specific **user-scoped settings**, use the `--global` flag:
-- **macOS/Linux**: `~/.claude`
-- **Windows**: `%LOCALAPPDATA%\.claude`
-
-Global mode uses user-scoped directories (no sudo required), allowing separate configurations for different projects.
+**Note:** This updates the CLI tool only, not ClaudeKit Engineer files. Use `ck init` (local) or `ck init -g` (global) to update ClaudeKit Engineer files.
 
 ### Authentication
 

--- a/src/content/docs/support/troubleshooting/installation-issues.md
+++ b/src/content/docs/support/troubleshooting/installation-issues.md
@@ -16,6 +16,37 @@ published: true
 
 ClaudeKit installation problems? Get unblocked in minutes with platform-specific fixes.
 
+## Quick Fix: Hook Path Errors / User Prompt Submit Error
+
+**Symptom**: "User prompt submit error", hooks fail with path errors, or `%CLAUDE_PROJECT_DIR%` not found
+
+**Cause**: You ran `ck init` (local mode) from the wrong directory—likely your home folder or user directory instead of a project folder.
+
+**Solution**:
+
+```bash
+# Step 1: Remove broken installation
+# Navigate to where you accidentally installed
+cd ~  # or wherever you ran ck init
+rm -rf .claude/  # Remove the broken local installation
+
+# Step 2: Reinstall correctly
+# For GLOBAL (recommended for most users):
+ck init -g --kit engineer
+
+# For LOCAL (project-specific):
+cd /path/to/your/actual/project
+ck init --kit engineer
+```
+
+**Prevention**:
+- Use `ck init -g` (global) if you want ClaudeKit available everywhere
+- Only use `ck init` (local) when inside an actual project directory
+
+See [Installation Guide - Which Mode Should I Use?](/docs/getting-started/installation#which-installation-mode-should-i-use) for detailed guidance.
+
+---
+
 ## Quick Fix: Command Not Found
 
 **Symptom**: `ck: command not found` or `claudekit-cli: command not found`


### PR DESCRIPTION
## Summary

Improves documentation UX to prevent user confusion between local (`ck init`) and global (`ck init -g`) installation modes.

**Changes:**
- Split "Initialize or Update" into clear **Option A: Global ⭐** and **Option B: Local** sections
- Add decision helper table showing which mode to use for each scenario
- Add warning callouts about running from wrong directory
- Add troubleshooting section for "User prompt submit error" / hook path errors
- Update Vietnamese translations with same improvements

## Files Changed

| File | Changes |
|------|---------|
| `docs/getting-started/installation.md` | +74/-7 lines |
| `docs/support/troubleshooting/installation-issues.md` | +31 lines |
| `docs-vi/getting-started/installation.md` | +64/-4 lines |
| `docs-vi/support/troubleshooting/installation-issues.md` | +35/-1 lines |

## Test Plan

- [x] Build passes (`bun run build`)
- [x] Review EN installation page
- [x] Review EN troubleshooting page
- [x] Review VI translations

Closes #58