### PR TITLE
docs(cli): add --prefix flag documentation

### DIFF
--- a/src/content/docs-vi/docs/cli/installation.md
+++ b/src/content/docs-vi/docs/cli/installation.md
@@ -68,16 +68,19 @@ Usage:
 
 Commands:
   new       Create new project from latest ClaudeKit release
+  init      Initialize or update project from ClaudeKit release
   update    Update existing project to latest version
   versions  List available ClaudeKit releases
 
 Options:
   --version, -v   Show version number
   --help, -h      Show help
+  --prefix        Apply /ck: namespace to slash commands
 
 Examples:
   ck new --kit engineer
   ck init
+  ck init --prefix
   ck versions --kit engineer
 
 For more info: https://docs.claudekit.cc

--- a/src/content/docs-vi/getting-started/quick-start.md
+++ b/src/content/docs-vi/getting-started/quick-start.md
@@ -35,6 +35,11 @@ ck new my-app --kit engineer
 cd my-app
 ```
 
+**Tip:** Sử dụng `--prefix` để namespace các lệnh thành `/ck:plan`, `/ck:code`, v.v.:
+```bash
+ck new my-app --kit engineer --prefix
+```
+
 **Đã tạo**:
 - `.claude/` - 14 AI agents, 30+ lệnh, 45 skills
 - `docs/` - Docs dự án tự động tạo

--- a/src/content/docs/docs/cli/index.md
+++ b/src/content/docs/docs/cli/index.md
@@ -70,6 +70,7 @@ ck init -g --kit engineer
 - `--version <version>` - Specific version to download (default: latest)
 - `--exclude <pattern>` - Exclude files/directories using glob patterns (can be used multiple times)
 - `--global, -g` - Use platform-specific user configuration directory
+- `--prefix` - Apply `/ck:` namespace to slash commands (see [Command Namespacing](#command-namespacing))
 
 **Global vs Local Configuration:**
 
@@ -80,6 +81,44 @@ For platform-specific **user-scoped settings**, use the `--global` flag:
 - **Windows**: `%LOCALAPPDATA%\.claude`
 
 Global mode uses user-scoped directories (no sudo required), allowing separate configurations for different projects.
+
+## Command Namespacing
+
+Use `--prefix` to avoid conflicts with other Claude Code slash commands or custom commands.
+
+### What It Does
+
+When you run `ck init --prefix` or `ck new --prefix`, all ClaudeKit slash commands are moved to a `/ck:` namespace:
+
+| Without --prefix | With --prefix |
+|------------------|---------------|
+| `/plan` | `/ck:plan` |
+| `/code` | `/ck:code` |
+| `/cook` | `/ck:cook` |
+| `/debug` | `/ck:debug` |
+| `/test` | `/ck:test` |
+
+### When to Use
+
+- **Multiple command sources**: When using other CLI tools that define their own slash commands
+- **Custom commands**: When you have project-specific commands that might conflict
+- **Team conventions**: When your team prefers namespaced commands for clarity
+
+### Example
+
+```bash
+# Initialize with prefix namespace
+ck init --prefix
+
+# Commands are now namespaced
+/ck:plan add user authentication
+/ck:code plans/auth-plan.md
+/ck:cook fix the login bug
+```
+
+### Technical Details
+
+The `--prefix` flag moves command files to `.claude/commands/ck/` subdirectory. Claude Code automatically recognizes this structure and prefixes commands with `ck:`.
 
 ### ck update
 

--- a/src/content/docs/docs/cli/installation.md
+++ b/src/content/docs/docs/cli/installation.md
@@ -68,16 +68,19 @@ Usage:
 
 Commands:
   init      Initialize or update project from ClaudeKit release
+  new       Bootstrap new project from ClaudeKit release
   update    (deprecated) Use 'init' instead
   versions  List available ClaudeKit releases
 
 Options:
   --version, -v   Show version number
   --help, -h      Show help
+  --prefix        Apply /ck: namespace to slash commands
 
 Examples:
   ck init --kit engineer
   ck init --global
+  ck init --prefix
   ck versions --kit engineer
 
 For more info: https://docs.claudekit.cc

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -53,6 +53,11 @@ ck init my-app --kit engineer
 cd my-app
 ```
 
+**Tip:** Use `--prefix` to namespace commands as `/ck:plan`, `/ck:code`, etc.:
+```bash
+ck init my-app --kit engineer --prefix
+```
+
 **Created**:
 - `.claude/` - 14 AI agents, 30+ commands, 45 skills
 - `docs/` - Auto-generated project docs


### PR DESCRIPTION
## Summary
- Add Command Namespacing section to CLI overview explaining `/ck:` prefix feature
- Document `--prefix` flag in init/new command options
- Add prefix usage tips to quick-start guides (EN/VI)
- Update CLI help output examples with `--prefix`

## Files Changed
- `docs/docs/cli/index.md` - Full Command Namespacing section with table, use cases, examples
- `docs/docs/cli/installation.md` - Updated help output
- `docs-vi/docs/cli/installation.md` - Updated help output (Vietnamese)
- `docs/getting-started/quick-start.md` - Added tip
- `docs-vi/getting-started/quick-start.md` - Added tip (Vietnamese)

## Test Plan
- [x] Build passes (285 pages)
- [ ] Verify Command Namespacing section renders correctly
- [ ] Verify internal anchor link works