### PR TITLE
fix(i18n): add missing Vietnamese index pages

### DIFF
--- a/src/content/docs-vi/cli/index.md
+++ b/src/content/docs-vi/cli/index.md
@@ -1,0 +1,184 @@
+---
+title: "ClaudeKit CLI"
+description: "CLI để tạo và quản lý các dự án ClaudeKit"
+lang: vi
+section: cli
+order: 1
+---
+
+# ClaudeKit CLI
+
+> Công cụ dòng lệnh nhanh, an toàn để khởi động và quản lý các dự án được cung cấp bởi ClaudeKit từ các bản phát hành GitHub riêng tư.
+
+ClaudeKit CLI (`ck`) giúp bạn tạo và quản lý các dự án được cung cấp bởi ClaudeKit. Được xây dựng bằng Bun và TypeScript, nó cung cấp một giao diện đẹp cho thiết lập dự án, cập nhật và bảo trì.
+
+## Key Features
+
+- Xác thực GitHub đa tầng với lưu trữ thông tin đăng nhập an toàn
+- Tải xuống trực tuyến với theo dõi tiến trình và tối ưu hóa nền tảng
+- Sáp nhập tệp thông minh với phát hiện xung đột
+- Quá trình di chuyển thư mục kỹ năng tự động với xử lý song song
+- Cài đặt phụ thuộc hệ thống tự động
+- Thông báo cập nhật thông minh với bộ đệm 7 ngày
+- Giao diện CLI đẹp với các lời nhắc tương tác
+
+## Quick Install
+
+Cài đặt CLI trên toàn cầu bằng trình quản lý gói ưa thích của bạn:
+
+```bash
+# npm (recommended)
+npm install -g claudekit-cli
+
+# bun
+bun add -g claudekit-cli
+
+# pnpm
+pnpm add -g claudekit-cli
+
+# yarn
+yarn global add claudekit-cli
+```
+
+Để biết hướng dẫn cài đặt chi tiết bao gồm các điều kiện tiên quyết và các bước xác minh, hãy xem [Installation](/vi/docs/cli/installation).
+
+## Verify Installation
+
+```bash
+ck --version
+```
+
+Bạn sẽ thấy đầu ra như:
+
+```
+CLI Version: 3.10.1
+Local Kit Version: 1.16.0 (ClaudeKit Engineer)
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| [`ck new`](/vi/docs/cli/new) | Tạo một dự án ClaudeKit mới |
+| [`ck init`](/vi/docs/cli/init) | Khởi tạo hoặc cập nhật ClaudeKit trong dự án hiện có |
+| [`ck doctor`](/vi/docs/cli/doctor) | Chạy kiểm tra sức khỏe và chẩn đoán |
+| [`ck versions`](/vi/docs/cli/versions) | Liệt kê các phiên bản kit có sẵn |
+| [`ck update`](/vi/docs/cli/update) | Cập nhật CLI lên phiên bản mới nhất |
+| [`ck uninstall`](/vi/docs/cli/uninstall) | Xóa cài đặt ClaudeKit |
+
+## Quick Start
+
+### Create a New Project
+
+```bash
+# Interactive mode (recommended)
+ck new
+
+# With options
+ck new --kit engineer --dir my-project
+
+# Include beta versions in selection
+ck new --beta
+
+# Auto-install skill dependencies
+ck new --install-skills
+```
+
+[Full documentation](/vi/docs/cli/new)
+
+### Initialize Existing Project
+
+```bash
+# Thêm ClaudeKit vào dự án hiện có của bạn
+cd my-existing-project
+ck init
+
+# Non-interactive mode with defaults
+ck init --yes
+
+# Global installation (user-level config)
+ck init --global
+```
+
+[Full documentation](/vi/docs/cli/init)
+
+### Health Check
+
+```bash
+# Chạy chẩn đoán
+ck doctor
+
+# Auto-fix issues
+ck doctor --fix
+
+# Generate shareable report
+ck doctor --report
+```
+
+[Full documentation](/vi/docs/cli/doctor)
+
+## Prerequisites
+
+Trước khi sử dụng ClaudeKit CLI, bạn cần:
+
+1. **Purchase a ClaudeKit Starter Kit** từ [ClaudeKit.cc](https://claudekit.cc)
+2. **Get Repository Access** - Bạn sẽ nhận được quyền truy cập vào kho lưu trữ GitHub riêng tư sau khi mua
+3. **Install GitHub CLI** và xác thực bằng `gh auth login`
+
+Nếu không có kit được mua và quyền truy cập kho lưu trữ, CLI không thể tải xuống các mẫu dự án.
+
+## Authentication
+
+ClaudeKit CLI sử dụng hệ thống xác thực đa tầng:
+
+1. GitHub CLI (`gh auth token`)
+2. Environment Variables (`GITHUB_TOKEN`)
+3. Config File (`~/.claudekit/config.json`)
+4. OS Keychain (secure storage)
+5. User Prompt (with save option)
+
+Để biết hướng dẫn thiết lập, hãy xem [Installation - Authentication](/vi/docs/cli/installation#authentication).
+
+## Kit Selection
+
+Khi tạo một dự án mới, hãy chọn từ các kit có sẵn:
+
+| Kit | Best For | Status |
+|-----|----------|--------|
+| **Engineer** | Phát triển phần mềm, tự động hóa, kiểm tra | Available |
+| **Marketing** | Tạo nội dung, chiến dịch, phân tích | Coming Soon |
+
+## Global vs Local Installation
+
+ClaudeKit hỗ trợ hai chế độ cài đặt:
+
+- **Local** (default): Cài đặt vào `.claude/` trong thư mục dự án của bạn
+- **Global**: Cài đặt vào `~/.claude/` để cấu hình cấp người dùng
+
+Sử dụng `ck init --global` để cài đặt toàn cầu, hoặc `ck init` để cài đặt cục bộ (dành riêng cho dự án).
+
+## Configuration
+
+Cấu hình được lưu trữ trong `~/.claudekit/config.json`:
+
+```json
+{
+  "github": {
+    "token": "stored_in_keychain"
+  },
+  "defaults": {
+    "kit": "engineer",
+    "dir": "."
+  }
+}
+```
+
+Để tham khảo cấu hình đầy đủ, hãy xem [Configuration](/vi/docs/cli/configuration).
+
+## Next Steps
+
+- [Installation](/vi/docs/cli/installation) - Hướng dẫn thiết lập chi tiết
+- [ck new](/vi/docs/cli/new) - Tạo dự án đầu tiên của bạn
+- [ck init](/vi/docs/cli/init) - Thêm vào dự án hiện có
+- [ck doctor](/vi/docs/cli/doctor) - Khắc phục sự cố
+- [Configuration](/vi/docs/cli/configuration) - Tùy chỉnh cài đặt của bạn

--- a/src/content/docs-vi/engineer/index.md
+++ b/src/content/docs-vi/engineer/index.md
@@ -1,0 +1,83 @@
+---
+title: Engineer Kit
+description: Bộ công cụ phát triển được cung cấp bởi AI để xây dựng, kiểm tra và triển khai phần mềm
+lang: vi
+section: engineer
+kit: engineer
+category: overview
+order: 1
+---
+
+# Engineer Kit
+
+Chào mừng đến với tài liệu Engineer Kit của ClaudeKit. Bộ công cụ này tăng cường quy trình phát triển của bạn với tự động hóa được cung cấp bởi AI.
+
+## What's Inside
+
+Engineer Kit bao gồm:
+
+- **17+ Specialized Agents** - Từ lập kế hoạch đến triển khai
+- **50+ Slash Commands** - Truy cập nhanh vào các tác vụ phát triển
+- **80+ Skills** - Khả năng kỹ thuật cho mọi nhu cầu
+- **Workflow Automation** - Quy trình phát triển được tối ưu hóa
+
+## Quick Start
+
+Bắt đầu với Engineer Kit chỉ với một vài lệnh:
+
+```bash
+# Cài đặt ClaudeKit CLI
+npm install -g claudekit-cli
+
+# Tạo một dự án engineer mới
+ck new --kit engineer
+
+# Bắt đầu xây dựng
+/plan "implement user authentication"
+/cook "add login form with validation"
+```
+
+## Core Features
+
+### Planning & Architecture
+
+Lập kế hoạch tính năng và thiết kế hệ thống với sự hỗ trợ AI:
+
+```bash
+/plan "implement payment integration"
+/plan:parallel "refactor authentication system"
+```
+
+### Code Generation
+
+Tạo code chất lượng cao với nhận thức ngữ cảnh:
+
+```bash
+/cook "add REST API endpoints for users"
+/code "implement caching layer"
+```
+
+### Testing & Quality
+
+Đảm bảo chất lượng code với kiểm tra tự động:
+
+```bash
+/test "run full test suite"
+/fix:types "resolve TypeScript errors"
+/review "code review recent changes"
+```
+
+### Database & Infrastructure
+
+Quản lý cơ sở dữ liệu và triển khai:
+
+```bash
+/db:query "show slow queries"
+/deploy "staging environment"
+```
+
+## Next Steps
+
+- [Engineer Agents](/vi/docs/engineer/agents) - Gặp gỡ đội ngũ phát triển AI của bạn
+- [Engineer Commands](/vi/docs/engineer/commands) - Tất cả các lệnh có sẵn
+- [Engineer Skills](/vi/docs/engineer/skills) - Các khả năng kỹ thuật

--- a/src/content/docs-vi/getting-started/index.md
+++ b/src/content/docs-vi/getting-started/index.md
@@ -1,0 +1,39 @@
+---
+title: "Bắt Đầu"
+description: "Tìm hiểu cách thiết lập và bắt đầu sử dụng ClaudeKit trong vòng dưới 15 phút"
+lang: vi
+section: getting-started
+order: 0
+published: true
+---
+
+# Bắt Đầu với ClaudeKit
+
+ClaudeKit tăng cường Claude Code với các agent, lệnh và kỹ năng cho phát triển cấp production. Bắt đầu trong 15 phút.
+
+## Quick Paths
+
+### Mới với ClaudeKit?
+1. [Giới Thiệu](/vi/docs/getting-started/introduction) - Hiểu ClaudeKit là gì
+2. [Khái Niệm](/vi/docs/getting-started/concepts) - Tìm hiểu cách hoạt động của agents, commands và skills
+3. [Cài Đặt](/vi/docs/getting-started/installation) - Cài đặt ClaudeKit CLI
+4. [Bắt Đầu Nhanh](/vi/docs/getting-started/quick-start) - Xây dựng tính năng đầu tiên trong 15 phút
+
+### Đã sử dụng Claude Code?
+[Hướng Dẫn Nâng Cấp](/vi/docs/getting-started/upgrade-guide) - Di chuyển sang ClaudeKit một cách liền mạch
+
+### Đang đánh giá ClaudeKit?
+[Tại Sao ClaudeKit](/vi/docs/getting-started/why-claudekit) - Xem so sánh, ROI và giá cả
+
+## Additional Resources
+
+- [Cheatsheet](/vi/docs/getting-started/cheatsheet) - Tham khảo nhanh cho các lệnh phổ biến
+- [FAQ](/vi/docs/support/faq) - Câu hỏi thường gặp
+- [Khắc Phục Sự Cố](/vi/docs/support/troubleshooting) - Các vấn đề phổ biến và giải pháp
+
+## Next Steps
+
+Sau khi cài đặt, khám phá:
+- **[Workflows](/vi/docs/workflows)** - Hướng dẫn theo nhiệm vụ cho các kịch bản phổ biến
+- **[Docs](/vi/docs)** - Tài liệu tham khảo chi tiết
+- **[Support](/vi/docs/support)** - Nhận trợ giúp khi cần

--- a/src/content/docs-vi/marketing/commands/index.md
+++ b/src/content/docs-vi/marketing/commands/index.md
@@ -1,0 +1,429 @@
+---
+title: "Marketing Commands"
+description: "Tài liệu đầy đủ về 21 lệnh marketing được hỗ trợ AI của ClaudeKit Marketing Kit - từ quản lý chiến dịch đến tạo nội dung"
+lang: vi
+section: marketing
+category: commands
+order: 1
+published: true
+---
+
+# Lệnh Marketing (Marketing Commands)
+
+19 lệnh chuyên biệt cho tự động hóa marketing, tạo nội dung và quản lý chiến dịch. Mỗi lệnh kích hoạt các agent AI chuyên môn sâu về marketing.
+
+## Ma Trận Tham Chiếu Nhanh
+
+### Lệnh Marketing Cốt Lõi (6 lệnh)
+
+| Lệnh | Mục Đích | Kết Quả | Agents Sử Dụng |
+|---------|---------|--------|-------------|
+| [/campaign](/vi/docs/marketing/commands/campaign) | Tạo và quản lý chiến dịch | Bản tóm tắt chiến dịch + báo cáo | campaign-manager, funnel-architect |
+| [/content](/vi/docs/marketing/commands/content) | Tạo nội dung marketing | Bài blog, trang landing | content-creator, seo-specialist |
+| [/seo](/vi/docs/marketing/commands/seo) | Kiểm tra và tối ưu SEO | Báo cáo SEO + đề xuất | seo-specialist |
+| [/email](/vi/docs/marketing/commands/email) | Tạo nội dung email | Chuỗi email | email-wizard, copywriter |
+| [/social](/vi/docs/marketing/commands/social) | Nội dung mạng xã hội | Bài đăng theo nền tảng | social-media-manager |
+| [/analyze](/vi/docs/marketing/commands/analyze) | Phân tích và hiệu suất | Thông tin dựa trên dữ liệu | analytics-analyst |
+
+### Lệnh Tạo Nội Dung (6 lệnh)
+
+| Lệnh | Mục Đích | Tốt Nhất Cho | Thời Gian Tiết Kiệm |
+|---------|---------|----------|------------|
+| [/write](/vi/docs/marketing/commands/write) | Bài blog, kiểm tra nội dung, xuất bản | Nội dung dài | 2-4 giờ |
+| [/video](/vi/docs/marketing/commands/video) | Script video, storyboard, sản xuất | Marketing video | 4-8 giờ |
+| [/slide](/vi/docs/marketing/commands/slide) | Bài thuyết trình, pitch deck | Bán hàng & đề xuất | 2-3 giờ |
+| [/brainstorm](/vi/docs/marketing/commands/brainstorm) | Tạo ý tưởng hợp tác | Phiên chiến lược | 1-2 giờ |
+| [/design](/vi/docs/marketing/commands/design) | Tạo hình ảnh AI | Tài sản hình ảnh | 30-60 phút |
+
+### Lệnh Tiện Ích (8 lệnh)
+
+| Lệnh | Mục Đích | Khi Nào Sử Dụng |
+|---------|---------|-------------|
+| [/scout](/vi/docs/marketing/commands/scout) | Tìm kiếm codebase nhanh | Tìm tệp liên quan |
+| [/review](/vi/docs/marketing/commands/review) | Phân tích chất lượng code | Trước khi commit |
+| [/ask](/vi/docs/marketing/commands/ask) | Tư vấn kiến trúc | Quyết định kỹ thuật |
+| [/bootstrap](/vi/docs/marketing/commands/bootstrap) | Khởi tạo dự án | Dự án mới |
+| [/git](/vi/docs/marketing/commands/git) | Thao tác Git | Tạo PR, commit |
+| [/dashboard](/vi/docs/marketing/commands/dashboard) | Giao diện dashboard marketing | Quản lý trực quan |
+| [/use-mcp](/vi/docs/marketing/commands/use-mcp) | Thao tác MCP server | Tích hợp bên ngoài |
+| [/persona](/vi/docs/marketing/commands/persona) | Quản lý persona khách hàng | Nghiên cứu đối tượng |
+
+## Danh Mục Lệnh
+
+### Lập Kế Hoạch & Chiến Lược
+
+Bắt đầu từ đây cho chiến dịch hoặc creative brief mới:
+
+```bash
+# Brainstorm giải pháp cùng nhau
+/brainstorm how to improve conversion rates
+
+# Nhận hướng dẫn kiến trúc
+/ask what's the best way to structure our marketing automation?
+
+# Tạo persona khách hàng
+/persona create "enterprise software buyers"
+```
+
+### Tạo Nội Dung
+
+Tạo tài sản marketing:
+
+```bash
+# Tạo nội dung blog với khớp giọng văn thương hiệu
+/write:blog "AI marketing automation guide"
+
+# Kiểm tra chất lượng nội dung hiện có
+/write:audit /assets/blog-posts/latest-post.md
+
+# Tạo video với script và storyboard
+/video:create "30-second product demo for social media"
+
+# Tạo pitch deck
+/slide:create "Series A investor pitch deck"
+
+# Tạo chuỗi email
+/email nurture "SaaS trial users"
+
+# Bài đăng mạng xã hội
+/social linkedin post "product launch announcement"
+
+# Tài sản hình ảnh
+/design hero banner for landing page
+```
+
+### Quản Lý Chiến Dịch
+
+Điều phối chiến dịch marketing:
+
+```bash
+# Tạo chiến dịch mới
+/campaign create "Q1 Product Launch"
+
+# Kiểm tra trạng thái chiến dịch
+/campaign status "Q1 Product Launch"
+
+# Phân tích hiệu suất
+/campaign analyze "Q1 Product Launch"
+```
+
+### SEO & Phân Tích
+
+Tối ưu hóa và đo lường:
+
+```bash
+# Kiểm tra SEO kỹ thuật
+/seo audit https://example.com
+
+# Nghiên cứu từ khóa
+/seo keywords "project management software"
+
+# Báo cáo phân tích
+/analyze traffic
+/analyze conversions
+```
+
+## Quy Trình Làm Việc Phổ Biến
+
+### 1. Khởi Chạy Chiến Dịch Marketing
+
+```bash
+# Bước 1: Xác định đối tượng
+/persona create
+
+# Bước 2: Lập kế hoạch chiến dịch
+/campaign create "Summer Sale 2025"
+
+# Bước 3: Tạo nội dung
+/email launch "Summer Sale"
+/social twitter thread "Summer Sale announcement"
+/design social graphic for Twitter
+
+# Bước 4: Theo dõi hiệu suất
+/analyze campaigns
+```
+
+**Thời gian**: 30 phút so với 2-3 ngày làm thủ công
+
+### 2. Tạo Bài Blog SEO
+
+```bash
+# Bước 1: Nghiên cứu từ khóa
+/seo keywords "best marketing automation tools"
+
+# Bước 2: Tạo nội dung
+/content blog "Marketing automation tools comparison 2025"
+
+# Bước 3: Tạo hình ảnh
+/design featured image for blog post
+
+# Bước 4: Tối ưu hóa
+/seo audit https://yourblog.com/marketing-automation
+
+# Bước 5: Commit
+/git:cm
+```
+
+**Thời gian**: 20 phút so với 4-6 giờ làm thủ công
+
+### 3. Tạo Video Marketing
+
+```bash
+# Bước 1: Tạo script
+/video:script "Product feature demo" --duration=60 --platform=youtube
+
+# Bước 2: Tạo storyboard
+/video:storyboard /assets/videos/latest-script.md
+
+# Bước 3: Tạo video hoàn chỉnh
+/video:create "Product demo video for homepage"
+```
+
+**Thời gian**: 30 phút so với 2-3 ngày làm thủ công
+
+### 4. Chuẩn Bị Pitch Deck
+
+```bash
+# Bước 1: Tạo bài thuyết trình
+/slide:create "Series A investor pitch deck"
+
+# Bước 2: Xem dashboard để quản lý tài sản
+/dashboard
+
+# Bước 3: Xuất và chia sẻ
+# File .pptx sẵn sàng chỉnh sửa tại /assets/slides/
+```
+
+**Thời gian**: 20 phút so với 1-2 ngày làm thủ công
+
+## Quy Ước Đầu Ra
+
+Tất cả lệnh tuân theo các mẫu đầu ra nhất quán:
+
+### Tài Sản Chiến Dịch
+```
+assets/campaigns/{date}-{slug}/
+├── briefs/
+├── creatives/
+└── reports/
+```
+
+### Tài Sản Nội Dung
+```
+assets/
+├── copy/emails/{date}-{type}-{slug}.md
+├── posts/{platform}/{date}-{slug}.md
+├── articles/{date}-{slug}/{date}-{slug}.md
+└── banners/
+```
+
+### Báo Cáo
+```
+reports/analytics/{date}-{type}.md
+assets/diagnostics/campaign-audits/{date}-{name}.md
+assets/seo/audits/{date}-{domain}-audit.md
+```
+
+### Kế Hoạch
+```
+plans/{date}-{slug}/
+├── plan.md
+├── phase-01-{name}.md
+├── phase-02-{name}.md
+└── reports/
+```
+
+## Hệ Sinh Thái Agent
+
+Các lệnh kích hoạt các agent AI chuyên biệt:
+
+### Content Agents
+- **content-creator**: Bài blog, trang landing
+- **copywriter**: Bản sao bán hàng, CTAs
+- **email-wizard**: Chuỗi email
+- **social-media-manager**: Nội dung xã hội
+
+### Strategy Agents
+- **campaign-manager**: Điều phối chiến dịch
+- **funnel-architect**: Phễu chuyển đổi
+- **seo-specialist**: Tối ưu SEO
+- **analytics-analyst**: Phân tích hiệu suất
+
+### Development Agents
+- **planner**: Lập kế hoạch triển khai
+- **tester**: Đảm bảo chất lượng
+- **code-reviewer**: Chất lượng code
+- **debugger**: Phân tích nguyên nhân gốc
+
+### Support Agents
+- **researcher**: Nghiên cứu thị trường
+- **lead-qualifier**: Phân tích đối tượng
+- **project-manager**: Theo dõi tiến độ
+- **docs-manager**: Tài liệu
+
+Xem [Marketing Agents](/vi/docs/marketing/agents) để biết chi tiết đầy đủ.
+
+## Kích Hoạt Skill
+
+Các lệnh tự động kích hoạt các skill liên quan:
+
+- **campaign-management**: Mẫu và quy trình chiến dịch
+- **email-marketing**: Best practices email
+- **seo-optimization**: Frameworks SEO
+- **social-media**: Chiến lược nền tảng
+- **creativity**: Thiết kế và copywriting
+- **analytics**: Theo dõi hiệu suất
+- **ai-multimodal**: Tạo và phân tích hình ảnh
+- **brand-guidelines**: Tính nhất quán thương hiệu
+
+Xem [Marketing Skills](/vi/docs/marketing/skills) để biết danh mục đầy đủ.
+
+## Tích Hợp MCP
+
+Các lệnh hỗ trợ Model Context Protocol servers:
+
+- **Google Analytics 4**: Dữ liệu lưu lượng và hành vi
+- **Search Console**: Hiệu suất tìm kiếm
+- **Discord**: Quản lý cộng đồng
+- **Slack**: Cộng tác nhóm
+
+Sử dụng `/use-mcp` để tương tác với các MCP servers đã kết nối.
+
+## Best Practices
+
+### 1. Bắt Đầu Cụ Thể
+```bash
+# Tốt: Cụ thể, tập trung
+/write:blog "10 SaaS pricing strategies for 2025"
+
+# Tránh: Mơ hồ, quá rộng
+/write:blog "marketing tips"
+```
+
+### 2. Sử Dụng Đúng Lệnh Cho Công Việc
+```bash
+# Blog post → /write
+/write:blog "Complete guide to email marketing"
+
+# Video content → /video
+/video:create "30-second product demo"
+
+# Presentations → /slide
+/slide:create "Q1 campaign proposal"
+```
+
+### 3. Để AI Làm Rõ
+Các lệnh sẽ đặt câu hỏi khi cần:
+```bash
+/email newsletter
+
+# AI hỏi:
+# - Đối tượng mục tiêu?
+# - Thông điệp chính?
+# - Hành động mong muốn?
+```
+
+### 4. Xem Xét Trước Khi Xuất Bản
+```bash
+# Luôn kiểm tra nội dung
+/write:audit /assets/blog-posts/latest.md
+
+# Xem xét điểm chất lượng
+# Sau đó xuất bản
+/write:publish /assets/blog-posts/latest.md
+```
+
+### 5. Sử Dụng Dashboard Để Quản Lý
+```bash
+# Xem tất cả tài sản marketing
+/dashboard
+
+# Quản lý:
+# - Copy & Writing Styles
+# - Video Storyboards
+# - Presentations
+# - Branding Guidelines
+# - Social Posts
+```
+
+## Nhận Trợ Giúp
+
+### Trợ Giúp Lệnh Cụ Thể
+```bash
+# Nhận hướng dẫn sử dụng lệnh chi tiết
+/ck-help campaign
+/ck-help plan
+/ck-help fix
+```
+
+### Tìm Kiếm Tài Liệu
+```bash
+# Tìm lệnh liên quan
+/ck-help search email marketing
+/ck-help search SEO
+```
+
+### Đề Xuất Nhiệm Vụ
+```bash
+# Nhận gợi ý lệnh
+/ck-help How do I create a blog post?
+/ck-help What command analyzes campaigns?
+```
+
+## Mẹo Hiệu Suất
+
+### Sử Dụng Dashboard Để Quản Lý Trực Quan
+```bash
+# Khởi chạy giao diện trực quan
+/dashboard
+
+# Quản lý chiến dịch, nội dung, tài sản một cách trực quan
+# Truy cập tại http://localhost:5173
+```
+
+### Tận Dụng Asset Management
+```bash
+# Tổ chức tài sản theo danh mục
+# - Copy & Writing Styles
+# - Video Storyboards
+# - Presentations
+# - Infographics
+# - Branding Guidelines
+# - Social Posts
+```
+
+### Kiểm Tra Nội Dung Trước Xuất Bản
+```bash
+# Kiểm tra chất lượng trước khi xuất bản
+/write:audit /assets/blog-posts/article.md
+
+# Đảm bảo điểm ≥75/100 cho SEO, khả năng đọc, giọng văn thương hiệu
+```
+
+## Bước Tiếp Theo
+
+**Mới với ClaudeKit Marketing?**
+1. [Hướng Dẫn Bắt Đầu Nhanh](/vi/docs/marketing/quick-start)
+2. [Cài Đặt](/vi/docs/getting-started/installation)
+3. [Khái Niệm Marketing](/vi/docs/marketing/core-concepts)
+
+**Sẵn Sàng Tạo?**
+- [Quản Lý Chiến Dịch](/vi/docs/marketing/commands/campaign)
+- [Tạo Nội Dung](/vi/docs/marketing/commands/content)
+- [Tối Ưu SEO](/vi/docs/marketing/commands/seo)
+
+**Chủ Đề Nâng Cao**:
+- [Marketing Agents Tùy Chỉnh](/vi/docs/marketing/agents/custom)
+- [Marketing Workflows](/vi/docs/marketing/workflows)
+- [Tính Năng Dashboard](/vi/docs/marketing/commands/dashboard)
+
+## Tài Nguyên Liên Quan
+
+- [Marketing Agents](/vi/docs/marketing/agents) - Gặp gỡ đội ngũ marketing AI của bạn
+- [Marketing Skills](/vi/docs/marketing/skills) - Các module chuyên môn
+- [Marketing Workflows](/vi/docs/marketing/workflows) - Quy trình làm việc phổ biến
+- [Marketing Dashboard](/vi/docs/marketing/dashboard) - Giao diện quản lý trực quan
+
+---
+
+**19 lệnh. Khả năng marketing vô hạn.** Đội ngũ marketing AI của bạn đã sẵn sàng.

--- a/src/content/docs-vi/marketing/index.md
+++ b/src/content/docs-vi/marketing/index.md
@@ -1,0 +1,162 @@
+---
+title: "Marketing Kit"
+description: "Bộ công cụ tự động hóa tiếp thị được cung cấp bởi AI"
+lang: vi
+section: marketing
+category: overview
+order: 1
+---
+
+# Marketing Kit
+
+Chào mừng đến với tài liệu Marketing Kit của ClaudeKit. Bộ công cụ này cung cấp tự động hóa tiếp thị được cung cấp bởi AI cho toàn bộ quy trình tiếp thị của bạn.
+
+## What's Inside
+
+Marketing Kit bao gồm:
+
+- **27 Specialized Agents** - Từ quản lý chiến dịch đến tạo nội dung
+- **73+ Slash Commands** - Truy cập nhanh vào các tác vụ tự động hóa tiếp thị
+- **60+ Skills** - Khả năng chuyên biệt cho mọi nhu cầu tiếp thị
+- **10 Workflows** - Hướng dẫn từng bước cho các tác vụ tiếp thị phổ biến
+- **Real-time Dashboard** - Giám sát chiến dịch và phân tích
+
+## Quick Start
+
+Bắt đầu với Marketing Kit chỉ với một vài lệnh:
+
+```bash
+# Cài đặt ClaudeKit CLI
+npm install -g claudekit-cli
+
+# Tạo một dự án tiếp thị mới
+ck new --kit marketing
+
+# Bắt đầu chiến dịch đầu tiên của bạn
+/campaign create "Q1 Product Launch"
+```
+
+## Lợi Thế Vượt Trội
+
+Không giống như các công cụ marketing truyền thống, ClaudeKit Marketing có **quyền truy cập đầy đủ vào codebase của bạn**:
+
+- **Ảnh Chụp Màn Hình Sản Phẩm** - Tự động trích xuất từ code UI thực tế
+- **Mô Tả Tính Năng** - Được tạo từ triển khai thực, không phải tưởng tượng
+- **Độ Chính Xác Kỹ Thuật** - Tuyên bố marketing được xác minh dựa trên code thực
+- **Đồng Bộ Phiên Bản** - Nội dung tự động cập nhật khi tính năng thay đổi
+
+Điều này có nghĩa là tài liệu marketing của bạn luôn chính xác, chính xác về kỹ thuật và không thể bị đối thủ sao chép nếu không có codebase của bạn.
+
+## Core Features
+
+### Quản Lý Tài Sản (Content Hub)
+
+Trung tâm tập trung cho tất cả tài sản marketing với tổ chức thông minh:
+
+```bash
+# Mở dashboard trực quan
+/dashboard
+
+# Quản lý 6 danh mục tài sản:
+# - Copy & Phong Cách Viết
+# - Storyboard (câu chuyện video)
+# - Bài Thuyết Trình (pitch deck, đề xuất)
+# - Infographic (trực quan hóa dữ liệu)
+# - Hướng Dẫn Thương Hiệu (logo, màu sắc, giọng văn)
+# - Bài Đăng Mạng Xã Hội (nội dung theo nền tảng)
+```
+
+**Ảnh chụp màn hình**:
+
+![Trung tâm Quản lý Tài sản](/docs/screenshots/assets-management.png)
+![Hướng dẫn Thương hiệu](/docs/screenshots/assets-branding-guideline.png)
+![Xem trước Storyboard](/docs/screenshots/assets-storyboard-preview.png)
+
+Xem [Quản Lý Tài Sản](/vi/docs/marketing/features/asset-management) để biết chi tiết đầy đủ.
+
+### Tạo Nội Dung
+
+Tạo nội dung marketing chất lượng cao với trích xuất giọng văn tác giả:
+
+```bash
+# Bài blog với khớp phong cách
+/write:blog "10 Chiến Lược Giá SaaS" --style casual-founder
+
+# Kiểm tra chất lượng nội dung
+/write:audit /assets/copy/blog-posts/pricing-guide.md
+
+# Quy trình xuất bản
+/write:publish /assets/copy/blog-posts/pricing-guide.md
+```
+
+Xem [Lệnh Write](/vi/docs/marketing/commands/write) để biết chi tiết.
+
+### Sản Xuất Video
+
+Quy trình video chuyên nghiệp với Gemini Veo 3.1 + Imagen 4:
+
+```bash
+# Tạo video hoàn chỉnh
+/video:create "Demo sản phẩm cho trang chủ"
+
+# Tạo script video
+/video:script "Giải thích API rate limiting" --duration=60 --platform=youtube
+
+# Tạo storyboard trực quan
+/video:storyboard /assets/videos/2024-12-30-api-demo/script.md
+```
+
+Xem [Lệnh Video](/vi/docs/marketing/commands/video) để biết chi tiết.
+
+### Bài Thuyết Trình
+
+Tạo pitch deck, đề xuất chiến dịch và bài thuyết trình đẹp:
+
+```bash
+# Pitch deck cho nhà đầu tư
+/slide:create "Series A pitch deck - AI marketing automation"
+
+# Đề xuất chiến dịch
+/slide:create "Q1 product launch campaign với phân tích ngân sách"
+
+# Demo sản phẩm
+/slide:create "Technical demo API features cho doanh nghiệp"
+```
+
+Xem [Lệnh Slide](/vi/docs/marketing/commands/slide) để biết chi tiết.
+
+### Quản Lý Chiến Dịch
+
+Tạo, quản lý và tối ưu hóa chiến dịch tiếp thị với hỗ trợ AI:
+
+```bash
+/campaign create "Summer Sale 2025"
+/campaign status
+/campaign analyze
+```
+
+### SEO Optimization
+
+Tăng xếp hạng tìm kiếm của bạn bằng các công cụ SEO được cung cấp bởi AI:
+
+```bash
+/seo keywords "competitor analysis"
+/seo optimize "landing page"
+/seo audit
+```
+
+### Analytics & Insights
+
+Theo dõi hiệu suất và nhận được những hiểu biết có thể hành động:
+
+```bash
+/analyze traffic
+/analyze campaigns
+/analyze conversions
+```
+
+## Next Steps
+
+- [Marketing Agents](/vi/docs/marketing/agents) - Gặp gỡ đội tiếp thị AI của bạn
+- [Marketing Commands](/vi/docs/marketing/commands) - Tất cả các lệnh có sẵn
+- [Marketing Workflows](/vi/docs/marketing/workflows) - Hướng dẫn từng bước

--- a/src/content/docs-vi/support/index.md
+++ b/src/content/docs-vi/support/index.md
@@ -1,0 +1,241 @@
+---
+title: "Hỗ Trợ"
+description: "Nhận trợ giúp với ClaudeKit thông qua cộng đồng, tài liệu và các kênh hỗ trợ trực tiếp"
+lang: vi
+section: support
+order: 0
+published: true
+---
+
+# Hỗ Trợ
+
+Nhận trợ giúp với ClaudeKit thông qua tài nguyên cộng đồng, tài liệu và các kênh hỗ trợ trực tiếp.
+
+## Quick Help
+
+### Gặp vấn đề cụ thể?
+- [FAQ](/vi/docs/support/faq) - Câu trả lời cho các câu hỏi phổ biến
+- [Khắc Phục Sự Cố](/vi/docs/support/troubleshooting) - Giải pháp cho các vấn đề phổ biến
+- [Discord Community](https://claudekit.cc/discord) - Trợ giúp thời gian thực từ cộng đồng
+
+### Đang tìm hướng dẫn?
+- [Bắt Đầu](/vi/docs/getting-started) - Học các kiến thức cơ bản
+- [Workflows](/vi/docs/workflows) - Hướng dẫn từng bước
+- [Commands Reference](/vi/docs/commands) - Tất cả các lệnh có sẵn
+
+## Community Support
+
+### Discord Community
+[**Tham gia ClaudeKit Discord**](https://claudekit.cc/discord)
+
+**Bạn sẽ tìm thấy**:
+- Chat thời gian thực với người dùng và nhà phát triển ClaudeKit
+- Trợ giúp với các lệnh và workflows cụ thể
+- Chia sẻ dự án và nhận phản hồi
+- Thảo luận về yêu cầu tính năng
+- Skills và templates do cộng đồng tạo
+
+**Channels**:
+- `#help` - Nhận hỗ trợ với các vấn đề
+- `#show-and-tell` - Chia sẻ những gì bạn đang xây dựng
+- `#feature-requests` - Đề xuất tính năng mới
+- `#skills` - Chia sẻ custom skills
+- `#workflows` - Thảo luận về workflow patterns
+
+### GitHub Discussions
+[**GitHub Discussions**](https://github.com/claudekit/claudekit/discussions)
+
+**Tốt nhất cho**:
+- Yêu cầu và ý tưởng tính năng
+- Câu hỏi chung về ClaudeKit
+- Chia sẻ workflows và kỹ thuật
+- Phản hồi cộng đồng và khảo sát
+- Thảo luận dài
+
+### Stack Overflow
+[**ClaudeKit trên Stack Overflow**](https://stackoverflow.com/questions/tagged/claudekit)
+
+**Sử dụng khi**:
+- Bạn có câu hỏi kỹ thuật cụ thể
+- Bạn muốn có knowledge base có thể tìm kiếm
+- Bạn cần câu trả lời chuyên gia cho các vấn đề coding
+- Câu hỏi của bạn có thể giúp người khác có vấn đề tương tự
+
+**Gắn thẻ câu hỏi**: `claudekit` và các thẻ công nghệ liên quan
+
+## Self-Service Resources
+
+### Documentation
+- [Bắt Đầu](/vi/docs/getting-started) - Hướng dẫn người dùng mới
+- [Commands Reference](/vi/docs/commands) - Tài liệu lệnh đầy đủ
+- [Agents Overview](/vi/docs/agents) - Gặp đội ngũ AI của bạn
+- [Skills Library](/vi/docs/skills) - Các module kiến thức tích hợp
+- [Khắc Phục Sự Cố](/vi/docs/support/troubleshooting) - Các vấn đề và giải pháp phổ biến
+
+### Tutorials and Examples
+- [Workflow Examples](/vi/docs/workflows) - Workflows thực tế
+- [Use Cases](/vi/docs/workflows) - Ứng dụng thực tế
+- [Quick Start Guide](/vi/docs/getting-started/quick-start) - Dự án đầu tiên trong 15 phút
+- [Migration Guide](/vi/docs/getting-started/upgrade-guide) - Từ Claude Code sang ClaudeKit
+
+### Code Examples
+- [GitHub Repository](https://github.com/claudekit/examples) - Dự án mẫu
+- [Templates](https://github.com/claudekit/templates) - Starter templates
+- [Community Skills](https://github.com/claudekit/community-skills) - Skills do người dùng đóng góp
+
+## Direct Support
+
+### Email Support
+**support@claudekit.cc**
+
+**Thời gian phản hồi**: Trong vòng 24 giờ làm việc
+
+**Cho**:
+- Yêu cầu licensing doanh nghiệp
+- Hỗ trợ kỹ thuật cho gói trả phí
+- Cơ hội hợp tác
+- Yêu cầu báo chí và truyền thông
+- Báo cáo lỗ hổng bảo mật
+
+### Business Support
+**Business@claudekit.cc**
+
+**Cho**:
+- Triển khai doanh nghiệp
+- Đào tạo và onboarding nhóm
+- Phát triển custom skills
+- Tư vấn tích hợp
+- SLA và thỏa thuận hỗ trợ
+
+### Security Issues
+**security@claudekit.cc**
+
+**Cho**:
+- Báo cáo lỗ hổng bảo mật
+- Câu hỏi và lo ngại về bảo mật
+- Yêu cầu tuân thủ
+- Các vấn đề liên quan đến quyền riêng tư
+
+**Vui lòng không tiết lộ lỗ hổng công khai**
+
+## Getting Better Help
+
+### Trước Khi Yêu Cầu Trợ Giúp
+
+1. **Tìm kiếm trước**: Kiểm tra [FAQ](/vi/docs/support/faq) và [Khắc Phục Sự Cố](/vi/docs/support/troubleshooting)
+2. **Kiểm tra tài liệu**: Tìm trong các phần tài liệu liên quan
+3. **Tìm GitHub Issues**: Xem vấn đề của bạn đã được báo cáo chưa
+4. **Thử debug**: Sử dụng lệnh `/debug` để điều tra vấn đề
+
+### Khi Yêu Cầu Trợ Giúp
+
+**Bao gồm trong yêu cầu của bạn**:
+- Phiên bản ClaudeKit (`claudekit --version`)
+- Hệ điều hành và phiên bản
+- Phiên bản Node.js (`node --version`)
+- Lệnh hoặc workflow cụ thể bạn đang sử dụng
+- Thông báo lỗi (full stack traces)
+- Hành vi mong đợi so với thực tế
+- Các bước để tái tạo vấn đề
+
+**Ví dụ tốt**:
+```
+Xin chào! Tôi gặp vấn đề với lệnh /cook trên dự án Next.js.
+
+Phiên bản ClaudeKit: 1.0.0
+OS: macOS 14.0
+Node.js: v18.17.0
+
+Lệnh: /cook "add user authentication with Better Auth"
+
+Lỗi: "Better Auth skill not found"
+Mong đợi: Nên phát hiện dự án Next.js và kích hoạt Better Auth skill
+
+Cấu trúc dự án:
+- next.config.js tồn tại
+- package.json bao gồm better-auth
+- .claude/CLAUDE.md đã cấu hình
+
+Tôi đã thử chạy /skill:refresh và khởi động lại ClaudeKit.
+```
+
+### Nơi Để Hỏi
+
+**Câu hỏi nhanh** (< 5 phút phản hồi):
+- Discord `#help` channel
+
+**Vấn đề kỹ thuật**:
+- GitHub Issues (báo cáo lỗi)
+- Stack Overflow (câu hỏi kỹ thuật)
+
+**Yêu cầu tính năng**:
+- GitHub Discussions
+- Discord `#feature-requests`
+
+**Yêu cầu kinh doanh**:
+- Email support@claudekit.cc
+- Tin nhắn trực tiếp trên Discord
+
+## Contributing
+
+### Giúp Cải Thiện Tài Liệu
+- [Contributing Guide](/vi/docs/development/contributing)
+- Báo cáo vấn đề tài liệu trên GitHub
+- Đề xuất cải tiến qua Discord
+
+### Chia Sẻ Kinh Nghiệm
+- Viết blog posts về workflows ClaudeKit của bạn
+- Chia sẻ custom skills với cộng đồng
+- Tạo video tutorials
+- Đóng góp vào GitHub discussions
+
+### Báo Cáo Bugs
+- [GitHub Issues](https://github.com/claudekit/claudekit/issues)
+- Bao gồm các bước tái tạo chi tiết
+- Cung cấp thông tin hệ thống
+- Chia sẻ error logs và output
+
+## Community Guidelines
+
+### Code of Conduct
+- Tôn trọng và hòa nhập
+- Giúp đỡ người khác học và phát triển
+- Chia sẻ kiến thức hào phóng
+- Tuân theo hướng dẫn cộng đồng Discord
+
+### Support Etiquette
+- Tìm kiếm trước khi hỏi
+- Cung cấp ngữ cảnh và chi tiết
+- Kiên nhẫn chờ phản hồi
+- Cảm ơn những người giúp bạn
+- Trả lại bằng cách giúp đỡ người khác
+
+## Additional Resources
+
+### Learning Resources
+- [Blog](https://claudekit.cc/blog) - Mẹo, thủ thuật và thông báo
+- [YouTube Channel](https://youtube.com/@claudekit) - Video tutorials và demos
+- [Newsletter](https://claudekit.cc/newsletter) - Mẹo hàng tuần và cập nhật
+
+### Professional Services
+- [ClaudeKit Pro Services](https://claudekit.cc/pro) - Tư vấn doanh nghiệp
+- [Training Programs](https://claudekit.cc/training) - Workshops nhóm và onboarding
+- [Certification](https://claudekit.cc/certification) - Trở thành chuyên gia ClaudeKit
+
+### Developer Resources
+- [API Documentation](/vi/docs/api) - Để mở rộng ClaudeKit
+- [Plugin Development](/vi/docs/development/plugins) - Tạo extensions
+- [Skill Development](/vi/docs/development/creating-skills) - Xây dựng custom skills
+
+## Feedback
+
+Chúng tôi đánh giá cao phản hồi của bạn! Giúp chúng tôi cải thiện ClaudeKit:
+
+- [Feature Requests](https://github.com/claudekit/claudekit/discussions/categories/feature-requests)
+- [Bug Reports](https://github.com/claudekit/claudekit/issues)
+- [Documentation Feedback](https://github.com/claudekit/claudekit/discussions/categories/documentation)
+- [Community Survey](https://claudekit.cc/survey) - Chia sẻ kinh nghiệm của bạn
+
+---
+
+**Cần trợ giúp ngay?** Tham gia [Discord community](https://claudekit.cc/discord) của chúng tôi để được hỗ trợ thời gian thực từ người dùng khác và đội ngũ ClaudeKit.

--- a/src/content/docs-vi/support/troubleshooting/index.md
+++ b/src/content/docs-vi/support/troubleshooting/index.md
@@ -1,0 +1,197 @@
+---
+title: Khắc Phục Sự Cố
+description: "Hướng dẫn khắc phục sự cố cho ClaudeKit"
+lang: vi
+section: support
+category: support/troubleshooting
+order: 1
+published: true
+---
+
+# Khắc Phục Sự Cố
+
+Sửa nhanh các vấn đề phổ biến. Hầu hết các vấn đề giải quyết trong vòng dưới 5 phút.
+
+## Quick Diagnosis
+
+**Loại vấn đề?**
+- [Cài đặt thất bại](#installation) → [Vấn Đề Cài Đặt](/vi/docs/troubleshooting/installation-issues)
+- [Lệnh không tìm thấy hoặc lỗi](#commands) → [Lỗi Lệnh](/vi/docs/troubleshooting/command-errors)
+- [Agent không hoạt động](#agents) → [Vấn Đề Agent](/vi/docs/troubleshooting/agent-issues)
+- [Lỗi API key](#api-keys) → [Thiết Lập API Key](/vi/docs/troubleshooting/api-key-setup)
+- [Chậm hoặc treo](#performance) → [Vấn Đề Hiệu Suất](/vi/docs/troubleshooting/performance-issues)
+
+## Installation
+
+**Vấn đề**: `ck: command not found`
+
+**Sửa**:
+```bash
+# Xác minh cài đặt
+npm list -g claudekit-cli
+
+# Cài đặt lại nếu cần
+npm install -g claudekit-cli
+
+# Xác minh
+ck --version
+```
+
+[Xem thêm cách sửa cài đặt →](/vi/docs/troubleshooting/installation-issues)
+
+## Commands
+
+**Vấn đề**: `/command` không hoạt động
+
+**Sửa**:
+1. Kiểm tra `.claude/commands/` tồn tại
+2. Xác minh file lệnh tồn tại
+3. Kiểm tra frontmatter hợp lệ
+
+```bash
+# Liệt kê các lệnh có sẵn
+ls .claude/commands/**/*.md
+
+# Kiểm tra lệnh cụ thể
+cat .claude/commands/core/cook.md
+```
+
+[Xem thêm cách sửa lệnh →](/vi/docs/troubleshooting/command-errors)
+
+## Agents
+
+**Vấn đề**: Agent không kích hoạt
+
+**Sửa**:
+1. Xác minh `.claude/agents/` tồn tại
+2. Kiểm tra định dạng file agent
+3. Xác nhận Claude Code đang chạy
+
+```bash
+# Liệt kê agents
+ls .claude/agents/*.md
+
+# Xác minh file agent
+cat .claude/agents/planner.md
+```
+
+[Xem thêm cách sửa agent →](/vi/docs/troubleshooting/agent-issues)
+
+## API Keys
+
+**Vấn đề**: "API key not found"
+
+**Sửa**:
+```bash
+# Thêm vào .env
+echo 'GEMINI_API_KEY=your-key' >> .env
+echo 'SEARCH_API_KEY=your-key' >> .env
+
+# Hoặc export cho session
+export GEMINI_API_KEY=your-key
+```
+
+[Hướng dẫn API key đầy đủ →](/vi/docs/troubleshooting/api-key-setup)
+
+## Performance
+
+**Vấn đề**: Lệnh mất quá lâu
+
+**Sửa**:
+1. Kiểm tra kết nối internet
+2. Xác minh API keys đã được thiết lập
+3. Sử dụng `--verbose` để xem gì chậm
+
+```bash
+# Chạy với verbose logging
+/cook add feature --verbose
+```
+
+[Xem thêm cách sửa hiệu suất →](/vi/docs/troubleshooting/performance-issues)
+
+## Common Quick Fixes
+
+### Reset ClaudeKit
+
+```bash
+# Backup trước
+cp -r .claude .claude.backup
+
+# Cập nhật lên phiên bản mới nhất
+ck init --kit engineer
+
+# Khôi phục files tùy chỉnh
+cp .claude.backup/commands/my-custom.md .claude/commands/
+```
+
+### Clear Cache
+
+```bash
+# Xóa Node modules
+rm -rf node_modules
+npm install
+
+# Xóa ClaudeKit cache
+rm -rf ~/.claudekit/cache
+```
+
+### Verify Setup
+
+```bash
+# Kiểm tra CLI
+ck --version
+
+# Kiểm tra Claude Code
+claude --version
+
+# Kiểm tra cấu trúc thư mục
+tree .claude -L 2
+```
+
+## Still Stuck?
+
+### Get Help
+
+1. **Chạy diagnostics**:
+   ```bash
+   ck diagnose --verbose
+   ```
+
+2. **Kiểm tra logs**:
+   ```bash
+   # Bật verbose mode
+   export CLAUDEKIT_VERBOSE=1
+
+   # Chạy lệnh
+   /cook add feature
+
+   # Kiểm tra output
+   cat claudekit-debug.log
+   ```
+
+3. **Báo cáo vấn đề**:
+   - GitHub: https://github.com/claudekit/claudekit-engineer/issues
+   - Bao gồm: OS, CLI version, error message, steps to reproduce
+
+### Community
+
+- **Discord**: [Tham gia ClaudeKit Discord](https://claudekit.cc/discord)
+- **GitHub Discussions**: Chia sẻ giải pháp, đặt câu hỏi
+
+## Prevention Tips
+
+✅ **Nên**:
+- Giữ ClaudeKit cập nhật (`ck init`)
+- Sử dụng `--verbose` khi debug
+- Backup trước khi thay đổi lớn
+- Đọc kỹ thông báo lỗi
+
+❌ **Không nên**:
+- Sửa đổi trực tiếp các files core `.claude/`
+- Bỏ qua API rate limits
+- Bỏ qua cập nhật phiên bản
+- Xóa thư mục `.claude/`
+
+---
+
+**95% các vấn đề giải quyết trong vòng dưới 5 phút** với các hướng dẫn này. Đi sâu vào các phần cụ thể để biết cách sửa chi tiết.


### PR DESCRIPTION
## Summary
- Add 7 missing `index.md` files in `docs-vi/` that caused directory listings instead of rendered pages
- All content properly translated to Vietnamese with `/vi/` link prefixes
- Fixes URLs: `/vi/docs/cli/`, `/vi/docs/engineer/`, `/vi/docs/getting-started/`, `/vi/docs/marketing/`, `/vi/docs/marketing/commands/`, `/vi/docs/support/`, `/vi/docs/support/troubleshooting/`

## Files Added
| File | Lines |
|------|-------|
| `docs-vi/cli/index.md` | 184 |
| `docs-vi/engineer/index.md` | 83 |
| `docs-vi/getting-started/index.md` | 39 |
| `docs-vi/marketing/index.md` | 162 |
| `docs-vi/marketing/commands/index.md` | 429 |
| `docs-vi/support/index.md` | 241 |
| `docs-vi/support/troubleshooting/index.md` | 197 |

## Test Plan
- [x] `bun run build` passes
- [x] All 7 `index.html` files generated in `dist/vi/docs/`
- [x] Vietnamese translations match English structure (sections, links, code blocks)