### PR TITLE
fix(i18n): add missing lang tags and CLAUDE.md guidelines

### DIFF
--- a/src/content/docs-vi/engineer/commands/core/code-parallel.md
+++ b/src/content/docs-vi/engineer/commands/core/code-parallel.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /code:parallel
 description: Thực thi các phase song song hoặc tuần tự từ kế hoạch hiện có dựa trên phân tích dependency graph
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/code.md
+++ b/src/content/docs-vi/engineer/commands/core/code.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /code
 description: Thực thi kế hoạch triển khai với quy trình 6 bước kiểm soát chất lượng bao gồm kiểm thử tự động và đánh giá code
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/cook-auto-parallel.md
+++ b/src/content/docs-vi/engineer/commands/core/cook-auto-parallel.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /cook:auto:parallel
 description: Triển khai tính năng với thực thi song song sử dụng plan:parallel và các agent fullstack-developer
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/cook.md
+++ b/src/content/docs-vi/engineer/commands/core/cook.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /cook
 description: Documentation for cook
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/debug.md
+++ b/src/content/docs-vi/engineer/commands/core/debug.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /debug
 description: Documentation for debug
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/journal.md
+++ b/src/content/docs-vi/engineer/commands/core/journal.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /journal
 description: Documentation for journal
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/review-codebase.md
+++ b/src/content/docs-vi/engineer/commands/core/review-codebase.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /review:codebase
 description: Phân tích codebase toàn diện với agent researcher, scout, và code-reviewer để đánh giá chất lượng
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/scout-ext.md
+++ b/src/content/docs-vi/engineer/commands/core/scout-ext.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /scout:ext
 description: Khám phá codebase sử dụng công cụ agentic bên ngoài như Gemini CLI cho khả năng tìm kiếm nâng cao và context lớn
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/scout.md
+++ b/src/content/docs-vi/engineer/commands/core/scout.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /scout
 description: Documentation for scout
 section: engineer

--- a/src/content/docs-vi/engineer/commands/core/watzup.md
+++ b/src/content/docs-vi/engineer/commands/core/watzup.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /watzup
 description: Documentation for watzup
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/3d.md
+++ b/src/content/docs-vi/engineer/commands/design/3d.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:3d
 description: Documentation for 3d
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/describe.md
+++ b/src/content/docs-vi/engineer/commands/design/describe.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:describe
 description: Documentation for describe
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/fast.md
+++ b/src/content/docs-vi/engineer/commands/design/fast.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:fast
 description: Documentation for fast
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/good.md
+++ b/src/content/docs-vi/engineer/commands/design/good.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:good
 description: Documentation for good
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/screenshot.md
+++ b/src/content/docs-vi/engineer/commands/design/screenshot.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:screenshot
 description: Documentation for screenshot
 section: engineer

--- a/src/content/docs-vi/engineer/commands/design/video.md
+++ b/src/content/docs-vi/engineer/commands/design/video.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /design:video
 description: Documentation for video
 section: engineer

--- a/src/content/docs-vi/engineer/commands/docs-cmd/init.md
+++ b/src/content/docs-vi/engineer/commands/docs-cmd/init.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /docs:init
 description: Documentation for init
 section: engineer

--- a/src/content/docs-vi/engineer/commands/plan/parallel.md
+++ b/src/content/docs-vi/engineer/commands/plan/parallel.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: /plan:parallel
 description: Tạo kế hoạch triển khai với các giai đoạn có thể thực thi song song sử dụng đồ thị phụ thuộc và ma trận sở hữu file
 section: engineer

--- a/src/content/docs-vi/marketing/agents/analytics-analyst.md
+++ b/src/content/docs-vi/marketing/agents/analytics-analyst.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Analytics Analyst Agent"
 description: "Tạo báo cáo hiệu suất, phân tích lưu lượng truy cập, theo dõi chuyển đổi và xác định xu hướng marketing."
 section: marketing

--- a/src/content/docs-vi/marketing/agents/attraction-specialist.md
+++ b/src/content/docs-vi/marketing/agents/attraction-specialist.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Attraction Specialist"
 description: "Chuyên gia TOFU tạo ra leads của bạn cho nghiên cứu từ khóa, phân tích đối thủ, trang đích và lead magnet"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/brainstormer.md
+++ b/src/content/docs-vi/marketing/agents/brainstormer.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Brainstormer"
 description: "Chuyển đổi ý tưởng mơ hồ thành chiến lược marketing được xác thực thông qua khám phá có hệ thống và cuộc tranh luận"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/campaign-debugger.md
+++ b/src/content/docs-vi/marketing/agents/campaign-debugger.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Campaign Debugger"
 description: "Điều tra các vấn đề marketing, chẩn đoán các vấn đề hiệu suất, và tối ưu hóa hiệu quả chiến dịch"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/campaign-manager.md
+++ b/src/content/docs-vi/marketing/agents/campaign-manager.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Campaign Manager"
 description: "Điều phối chiến dịch marketing đa kênh với lập kế hoạch thống nhất, theo dõi và tối ưu hóa"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/code-reviewer.md
+++ b/src/content/docs-vi/marketing/agents/code-reviewer.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Code Reviewer"
 description: "Đánh giá chất lượng code toàn diện cho tự động hóa marketing, theo dõi, và công cụ chiến dịch"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/community-manager.md
+++ b/src/content/docs-vi/marketing/agents/community-manager.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Community Manager"
 description: "Quản lý cộng đồng Discord và Slack, phân tích cảm xúc, tối ưu hóa engagement, và hỗ trợ thành viên"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/content-creator.md
+++ b/src/content/docs-vi/marketing/agents/content-creator.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Content Creator"
 description: "Chuyên gia nội dung đa định dạng của bạn cho blog, media xã hội, video, quảng cáo, và trang đích"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/content-reviewer.md
+++ b/src/content/docs-vi/marketing/agents/content-reviewer.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Content Reviewer"
 description: "Đánh giá chất lượng nội dung toàn diện và thực thi best practice marketing trước khi khởi động"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/copywriter.md
+++ b/src/content/docs-vi/marketing/agents/copywriter.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Copywriter"
 description: "Tạo copy chuyển đổi cao, xứng đáng lan truyền dừng cuộn và thúc đẩy hành động trên tất cả các kênh"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/project-manager.md
+++ b/src/content/docs-vi/marketing/agents/project-manager.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Project Manager Agent"
 description: "Track progress, consolidate reports, and keep marketing projects on schedule with comprehensive oversight."
 section: marketing

--- a/src/content/docs-vi/marketing/agents/researcher.md
+++ b/src/content/docs-vi/marketing/agents/researcher.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Researcher"
 description: "Chuyên gia thông tin thị trường của bạn cho phân tích cạnh tranh, xu hướng và thông tin chiến lược"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/sale-enabler.md
+++ b/src/content/docs-vi/marketing/agents/sale-enabler.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Sales Enabler"
 description: "Your sales collateral expert for pitches, proposals, objection handling, and deal acceleration"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/scout-external.md
+++ b/src/content/docs-vi/marketing/agents/scout-external.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Scout External Agent"
 description: "Advanced codebase exploration using external AI tools for complex multi-directory searches."
 section: marketing

--- a/src/content/docs-vi/marketing/agents/seo-specialist.md
+++ b/src/content/docs-vi/marketing/agents/seo-specialist.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "SEO Specialist"
 description: "Chuyên gia SEO kỹ thuật của bạn cho kiểm tra, tối ưu hóa, schema markup và xếp hạng tìm kiếm"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/social-media-manager.md
+++ b/src/content/docs-vi/marketing/agents/social-media-manager.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Social Media Manager"
 description: "Multi-platform content strategy, scheduling, engagement analysis, and social presence optimization"
 section: marketing

--- a/src/content/docs-vi/marketing/agents/tester.md
+++ b/src/content/docs-vi/marketing/agents/tester.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Tester Agent"
 description: "Validate code quality through comprehensive testing, coverage analysis, and quality assurance."
 section: marketing

--- a/src/content/docs-vi/marketing/agents/ui-ux-designer.md
+++ b/src/content/docs-vi/marketing/agents/ui-ux-designer.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "UI/UX Designer Agent"
 description: "Create exceptional user interfaces with award-winning design, accessibility, and conversion optimization."
 section: marketing

--- a/src/content/docs-vi/marketing/agents/upsell-maximizer.md
+++ b/src/content/docs-vi/marketing/agents/upsell-maximizer.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "Upsell Maximizer"
 description: "Your revenue expansion expert for upsells, cross-sells, product recommendations, and pricing optimization"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/analyze.md
+++ b/src/content/docs-vi/marketing/commands/analyze.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/analyze"
 description: "Tạo báo cáo phân tích và hiệu suất với thông tin chi tiết do AI cung cấp"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/ask.md
+++ b/src/content/docs-vi/marketing/commands/ask.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/ask"
 description: "Tư vấn kiến trúc chuyên gia với 4 cố vấn chuyên biệt để đưa ra quyết định kỹ thuật, thiết kế hệ thống và lập kế hoạch khả năng mở rộng"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/bootstrap.md
+++ b/src/content/docs-vi/marketing/commands/bootstrap.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/bootstrap"
 description: "Khởi tạo dự án hoàn chỉnh với nghiên cứu, lựa chọn công nghệ, lập kế hoạch, thiết kế, thực hiện, kiểm tra và tài liệu trong một lệnh"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/brainstorm.md
+++ b/src/content/docs-vi/marketing/commands/brainstorm.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/brainstorm"
 description: "Các buổi họp não được hỗ trợ bởi AI hợp tác cho chiến lược, giải pháp và ra quyết định với quy trình có cấu trúc 5 pha"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/campaign.md
+++ b/src/content/docs-vi/marketing/commands/campaign.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/campaign"
 description: "Tạo, quản lý và phân tích các chiến dịch tiếp thị với quản lý chiến dịch do AI cung cấp, kiến trúc phễu và theo dõi hiệu suất"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/code.md
+++ b/src/content/docs-vi/marketing/commands/code.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/code"
 description: "Thực hiện kế hoạch thực hiện với quy trình 6 bước: phân tích, thực hiện, kiểm tra, đánh giá mã, phê duyệt người dùng và hoàn tất"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/content.md
+++ b/src/content/docs-vi/marketing/commands/content.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/content"
 description: "Tạo bài đăng blog được tối ưu hóa cho SEO, trang đích và nội dung tiếp thị với nghiên cứu do AI cung cấp, viết và tối ưu hóa"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/cook.md
+++ b/src/content/docs-vi/marketing/commands/cook.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/cook"
 description: "Thực hiện tính năng toàn bộ với lập kế hoạch, nghiên cứu, mã hóa, kiểm tra và tài liệu trong một lệnh duy nhất"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/design.md
+++ b/src/content/docs-vi/marketing/commands/design.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/design"
 description: "Tạo nội dung hình ảnh trên brand với AI, tăng cường prompt, và xác minh tự động cho tài sản marketing"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/email.md
+++ b/src/content/docs-vi/marketing/commands/email.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/email"
 description: "Tạo nội dung email chuyển đổi cao với viết quảng cáo được tạo bằng AI cho newsletter, cold outreach, launch sequences, và nurture campaigns"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/fix.md
+++ b/src/content/docs-vi/marketing/commands/fix.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/fix"
 description: "Định tuyến vấn đề thông minh tới các lệnh fix chuyên dụng dựa trên loại vấn đề - types, UI, CI/CD, tests, logs, và complex issues"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/git.md
+++ b/src/content/docs-vi/marketing/commands/git.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/git"
 description: "Tạo pull requests với so sánh branch tự động, conventional commit messages, và GitHub CLI integration"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/persona.md
+++ b/src/content/docs-vi/marketing/commands/persona.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/persona"
 description: "Tạo và quản lý customer personas với AI-powered audience research, market validation, và ICP profiling"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/plan.md
+++ b/src/content/docs-vi/marketing/commands/plan.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/plan"
 description: "Tạo detailed implementation plans với AI-powered research, complexity assessment, và progressive disclosure structure"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/review.md
+++ b/src/content/docs-vi/marketing/commands/review.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/review"
 description: "Code quality analysis and review với security, performance, và architecture checks trước commits"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/scout.md
+++ b/src/content/docs-vi/marketing/commands/scout.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/scout"
 description: "Fast, token-efficient codebase search với parallel agent spawning tìm relevant files cho implementation tasks"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/seo.md
+++ b/src/content/docs-vi/marketing/commands/seo.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/seo"
 description: "Technical SEO audits, keyword research, content optimization, và schema markup generation powered by AI analysis"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/social.md
+++ b/src/content/docs-vi/marketing/commands/social.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/social"
 description: "Tạo nội dung mạng xã hội được tối ưu hóa cho từng nền tảng với AI copywriting"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/test.md
+++ b/src/content/docs-vi/marketing/commands/test.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/test"
 description: "Chạy bộ test và phân tích kết quả - chỉ kiểm tra, không triển khai"
 section: marketing

--- a/src/content/docs-vi/marketing/commands/use-mcp.md
+++ b/src/content/docs-vi/marketing/commands/use-mcp.md
@@ -1,4 +1,5 @@
 ---
+lang: vi
 title: "/use-mcp"
 description: "Thực thi MCP thông qua Gemini CLI để giữ lại ngân sách ngữ cảnh"
 section: marketing


### PR DESCRIPTION
## Summary
- Add `lang: vi` frontmatter to 57 Vietnamese docs missing the tag
- Add **CRITICAL: Static Assets** section to CLAUDE.md with verification commands
- Add **CRITICAL: i18n Rules** section to CLAUDE.md with compliance checks

## Changes
- 58 files changed
- CLAUDE.md: +62 lines (guidelines for assets & i18n)
- 57 VI docs: +1 line each (`lang: vi` tag)

## Prevention Guidelines Added

### Static Assets
- All assets MUST go in `public/` folder
- Verification command to check missing images before commit

### i18n Compliance
- EN docs: no `lang:` tag, English content, `/docs/` links
- VI docs: `lang: vi` required, Vietnamese content, `/vi/docs/` links
- 4 verification commands to catch violations

## Test Plan
- [x] `bun run build` passes (440 pages)
- [x] No VI files missing `lang: vi`
- [x] No EN files with wrong lang tag