### PR TITLE
feat(chat): connect AIChat to live RAG API

### DIFF
--- a/src/components/AIChat.tsx
+++ b/src/components/AIChat.tsx
@@ -1,8 +1,20 @@
 import { useState, useRef, useEffect } from 'react';
 
+const API_URL = import.meta.env.PROD
+  ? 'https://ck-api.kaitran.ca/api/public/ask'
+  : 'http://localhost:7319/api/public/ask';
+
 interface Message {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  sources?: Array<{ title: string; url: string; snippet: string }>;
+}
+
+interface ApiResponse {
+  answer: string;
+  sources: Array<{ title: string; url: string; snippet: string }>;
+  cached: boolean;
+  error?: string;
 }
 
 export function AIChat() {
@@ -14,6 +26,7 @@ export function AIChat() {
   ]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const scrollToBottom = () => {
@@ -35,26 +48,37 @@ export function AIChat() {
     setMessages((prev) => [...prev, userMessage]);
     setInput('');
     setIsLoading(true);
+    setError(null);
 
     try {
-      // TODO: Replace with actual API call when backend is available
-      // For now, show placeholder response
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      const response = await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: message }),
+      });
+
+      const data: ApiResponse = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || `Error: ${response.status}`);
+      }
 
       const aiResponse: Message = {
         role: 'assistant',
-        content:
-          'AI responses will be available once the OpenRouter integration is complete with a backend API. This is a placeholder response showing the UI functionality.',
+        content: data.answer,
+        sources: data.sources,
       };
 
       setMessages((prev) => [...prev, aiResponse]);
-    } catch (error) {
-      console.error('Error sending message:', error);
+    } catch (err) {
+      console.error('Error sending message:', err);
+      const errorMessage = err instanceof Error ? err.message : 'Failed to get response';
+      setError(errorMessage);
       setMessages((prev) => [
         ...prev,
         {
           role: 'assistant',
-          content: 'Sorry, I encountered an error. Please try again.',
+          content: `Sorry, I encountered an error: ${errorMessage}`,
         },
       ]);
     } finally {
@@ -69,6 +93,20 @@ export function AIChat() {
           <div key={index} className={`ai-message ${message.role}`}>
             <div className="message-content">
               <p>{message.content}</p>
+              {message.sources && message.sources.length > 0 && (
+                <div className="message-sources">
+                  <span className="sources-label">Sources:</span>
+                  <ul>
+                    {message.sources.slice(0, 3).map((source, i) => (
+                      <li key={i}>
+                        <a href={`/docs${source.url.replace('.md', '')}`} target="_blank" rel="noopener noreferrer">
+                          {source.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
             </div>
           </div>
         ))}
@@ -85,6 +123,7 @@ export function AIChat() {
       </div>
 
       <div className="ai-input-container">
+        {error && <div className="ai-error">{error}</div>}
         <form className="ai-input-form" onSubmit={handleSubmit}>
           <input
             type="text"
@@ -93,6 +132,7 @@ export function AIChat() {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             disabled={isLoading}
+            maxLength={500}
           />
           <button
             type="submit"


### PR DESCRIPTION
## Summary
- Connect AIChat component to live ClaudeKit Assistant API
- Endpoint: `https://ck-api.kaitran.ca/api/public/ask`
- Add source citations display
- Add error handling and rate limit feedback

## Test plan
- [ ] Verify AI chat works on docs site
- [ ] Test rate limiting (5 req/min)
- [ ] Check source links resolve correctly