### PR TITLE
fix: readable h1 titles for skill doc pages

### DIFF
--- a/src/content/docs-vi/engineer/skills/agent-browser.md
+++ b/src/content/docs-vi/engineer/skills/agent-browser.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:agent-browser`
+# Agent Browser
 
 Tự động hóa trình duyệt được thiết kế đặc biệt cho các AI agent. Sử dụng mô hình "snapshot + refs" để giảm 93% context so với các công cụ truyền thống.
 

--- a/src/content/docs-vi/engineer/skills/ai-multimodal.md
+++ b/src/content/docs-vi/engineer/skills/ai-multimodal.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:ai-multimodal`
+# AI Multimodal
 
 Bạn biết cảm giác cần phân tích một podcast dài 2 tiếng, trích xuất text từ PDF phức tạp, hay tạo images thực sự khớp với tầm nhìn của mình? Đó chính là lúc AI Multimodal phát huy tác dụng.
 

--- a/src/content/docs-vi/engineer/skills/ask.md
+++ b/src/content/docs-vi/engineer/skills/ask.md
@@ -8,7 +8,7 @@ order: 10
 lang: vi
 ---
 
-# `ck:ask`
+# Ask
 
 Trả lời các câu hỏi kỹ thuật và kiến trúc về codebase của bạn. Skill này cung cấp câu trả lời có nghiên cứu, chuyên sâu thay vì những phản hồi hời hợt.
 

--- a/src/content/docs-vi/engineer/skills/bootstrap.md
+++ b/src/content/docs-vi/engineer/skills/bootstrap.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:bootstrap`
+# Bootstrap
 
 Orchestrator scaffolding dự án end-to-end. Đưa một yêu cầu từ con số không đến code đã chạy, đã test, đã review bằng cách điều phối qua research, planning và implementation theo trình tự.
 

--- a/src/content/docs-vi/engineer/skills/brainstorm.md
+++ b/src/content/docs-vi/engineer/skills/brainstorm.md
@@ -8,7 +8,7 @@ order: 2
 lang: vi
 ---
 
-# `ck:brainstorm`
+# Brainstorm
 
 Cố vấn kỹ thuật hàng đầu của bạn cho các quyết định kiến trúc, thiết kế hệ thống và lập kế hoạch chiến lược. Skill này mang đến sự thẳng thắn và chuyên môn sâu để giúp bạn đưa ra những lựa chọn kỹ thuật đúng đắn.
 

--- a/src/content/docs-vi/engineer/skills/chrome-devtools.md
+++ b/src/content/docs-vi/engineer/skills/chrome-devtools.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:chrome-devtools`
+# Chrome DevTools
 
 Cần tự động hóa các tương tác trình duyệt, chụp screenshots của trang web, hay debug các vấn đề JavaScript? Đó chính xác là những gì Chrome DevTools skill làm bằng Puppeteer.
 

--- a/src/content/docs-vi/engineer/skills/ck-help.md
+++ b/src/content/docs-vi/engineer/skills/ck-help.md
@@ -8,7 +8,7 @@ order: 1
 lang: vi
 ---
 
-# `ck:help`
+# Help
 
 Hướng dẫn sử dụng ClaudeKit và khám phá skills. Giúp bạn tìm đúng skill cho mọi tác vụ và hiểu cách sử dụng ClaudeKit hiệu quả.
 

--- a/src/content/docs-vi/engineer/skills/coding-level.md
+++ b/src/content/docs-vi/engineer/skills/coding-level.md
@@ -8,7 +8,7 @@ order: 52
 lang: vi
 ---
 
-# `ck:coding-level`
+# Coding Level
 
 Đặt mức độ kinh nghiệm lập trình của bạn để ClaudeKit điều chỉnh giải thích, code comments và độ phức tạp output phù hợp với chuyên môn của bạn.
 

--- a/src/content/docs-vi/engineer/skills/context-engineering.md
+++ b/src/content/docs-vi/engineer/skills/context-engineering.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:context-engineering`
+# Context Engineering
 
 Nghệ thuật và khoa học của việc tuyển chọn tập token nhỏ nhất có tín hiệu cao để đạt chất lượng reasoning LLM tối đa trong khi giảm thiểu token usage.
 

--- a/src/content/docs-vi/engineer/skills/cook.md
+++ b/src/content/docs-vi/engineer/skills/cook.md
@@ -8,7 +8,7 @@ order: 4
 lang: vi
 ---
 
-# `ck:cook`
+# Cook
 
 Engine implementation tính năng hoàn chỉnh của bạn. Thay thế lệnh `/code` cũ bằng smart workflow detection, research phases và quality gates.
 

--- a/src/content/docs-vi/engineer/skills/copywriting.md
+++ b/src/content/docs-vi/engineer/skills/copywriting.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:copywriting`
+# Copywriting
 
 Các công thức copy chuyển đổi cao, templates và trích xuất phong cách viết cho marketing, landing pages, emails và mô tả sản phẩm.
 

--- a/src/content/docs-vi/engineer/skills/debug.md
+++ b/src/content/docs-vi/engineer/skills/debug.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:debug`
+# Debug
 
 Framework debugging toàn diện kết hợp điều tra có hệ thống, root cause tracing và multi-layer validation. Không có fixes mà không hiểu root cause trước.
 

--- a/src/content/docs-vi/engineer/skills/docs.md
+++ b/src/content/docs-vi/engineer/skills/docs.md
@@ -8,7 +8,7 @@ order: 11
 lang: vi
 ---
 
-# `ck:docs`
+# Docs
 
 Quản lý tài liệu dự án với phân tích được hỗ trợ bởi AI. Khởi tạo docs cho các dự án mới, cập nhật sau khi có thay đổi hoặc tạo tóm tắt.
 

--- a/src/content/docs-vi/engineer/skills/find-skills.md
+++ b/src/content/docs-vi/engineer/skills/find-skills.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:find-skills`
+# Find Skills
 
 Cổng vào hệ sinh thái open agent skills. Tìm kiếm, khám phá và cài đặt các khả năng chuyên biệt cho bất kỳ lĩnh vực nào.
 

--- a/src/content/docs-vi/engineer/skills/fix.md
+++ b/src/content/docs-vi/engineer/skills/fix.md
@@ -8,7 +8,7 @@ order: 5
 lang: vi
 ---
 
-# `ck:fix`
+# Fix
 
 Quy trình sửa lỗi đầy đủ với định tuyến thông minh dựa trên độ phức tạp của vấn đề. Tự động kích hoạt trước khi sửa BẤT KỲ lỗi, lỗi kiểm thử, hoặc vấn đề về code nào.
 

--- a/src/content/docs-vi/engineer/skills/frontend-design.md
+++ b/src/content/docs-vi/engineer/skills/frontend-design.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:frontend-design`
+# Frontend Design
 
 Chán với giao diện trông quá chung chung, như thể "AI đã làm cái này"? Skill này giúp bạn tạo ra các thiết kế frontend thực sự được chế tác, đáng nhớ và có chủ đích.
 

--- a/src/content/docs-vi/engineer/skills/frontend-development.md
+++ b/src/content/docs-vi/engineer/skills/frontend-development.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:frontend-development`
+# Frontend Development
 
 Xây dựng ứng dụng React theo cách hiện đại có nghĩa là áp dụng Suspense, lazy loading, và các pattern fetching dữ liệu phù hợp. Skill này hướng dẫn bạn cách làm điều đó.
 

--- a/src/content/docs-vi/engineer/skills/git.md
+++ b/src/content/docs-vi/engineer/skills/git.md
@@ -8,7 +8,7 @@ order: 6
 lang: vi
 ---
 
-# `ck:git`
+# Git
 
 Thực thi các quy trình git với định dạng conventional commit, tự động tách commit theo type/scope, và quét bảo mật để tìm secret.
 

--- a/src/content/docs-vi/engineer/skills/gkg.md
+++ b/src/content/docs-vi/engineer/skills/gkg.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:gkg`
+# GKG
 
 Engine phân tích code ngữ nghĩa sử dụng AST parsing và cơ sở dữ liệu đồ thị KuzuDB. Cho phép điều hướng code như IDE cho các AI assistant.
 

--- a/src/content/docs-vi/engineer/skills/journal.md
+++ b/src/content/docs-vi/engineer/skills/journal.md
@@ -8,7 +8,7 @@ order: 14
 lang: vi
 ---
 
-# `ck:journal`
+# Journal
 
 Viết nhật ký phát triển để ghi lại các quyết định kỹ thuật, thách thức và tiến độ. Hữu ích để duy trì hồ sơ về hành trình phát triển của bạn.
 

--- a/src/content/docs-vi/engineer/skills/kanban.md
+++ b/src/content/docs-vi/engineer/skills/kanban.md
@@ -8,7 +8,7 @@ order: 55
 lang: vi
 ---
 
-# `ck:kanban`
+# Kanban
 
 Bảng điều phối AI agent để trực quan hóa nhiệm vụ và phối hợp các nhóm agent. Xem và quản lý công việc đang tiến hành trên toàn dự án.
 

--- a/src/content/docs-vi/engineer/skills/mcp-builder.md
+++ b/src/content/docs-vi/engineer/skills/mcp-builder.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:mcp-builder`
+# MCP Builder
 
 Bạn muốn cho AI agents truy cập vào các API và dịch vụ bên ngoài? Đó chính xác là những gì MCP servers làm, và skill này hướng dẫn bạn cách xây dựng chúng đúng cách.
 

--- a/src/content/docs-vi/engineer/skills/mcp-management.md
+++ b/src/content/docs-vi/engineer/skills/mcp-management.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:mcp-management`
+# MCP Management
 
 Bạn đã cấu hình MCP servers, nhưng làm thế nào để thực sự sử dụng chúng mà không làm tràn context window với hàng trăm định nghĩa công cụ? Đó là lúc MCP Management phát huy tác dụng.
 

--- a/src/content/docs-vi/engineer/skills/media-processing.md
+++ b/src/content/docs-vi/engineer/skills/media-processing.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:media-processing`
+# Media Processing
 
 Bạn từng cần chuyển đổi định dạng video, thay đổi kích thước 500 ảnh, hoặc xóa nền khỏi ảnh sản phẩm? Đây chính xác là những vấn đề mà FFmpeg, ImageMagick và RMBG giải quyết.
 

--- a/src/content/docs-vi/engineer/skills/mermaidjs-v11.md
+++ b/src/content/docs-vi/engineer/skills/mermaidjs-v11.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:mermaidjs-v11`
+# Mermaid.js v11
 
 Tạo sơ đồ dựa trên văn bản sử dụng cú pháp khai báo Mermaid.js v11. Chuyển đổi code thành SVG/PNG/PDF hoặc render trong trình duyệt và markdown.
 

--- a/src/content/docs-vi/engineer/skills/mintlify.md
+++ b/src/content/docs-vi/engineer/skills/mintlify.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:mintlify`
+# Mintlify
 
 v2.0.0 — Mintlify documentation builder. Bao gồm thiết lập, cấu hình, MDX components, API docs, tính năng AI và triển khai.
 

--- a/src/content/docs-vi/engineer/skills/plan.md
+++ b/src/content/docs-vi/engineer/skills/plan.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:plan`
+# Plan
 
 Tạo các bản thiết kế implementation có cấu trúc, dựa trên nghiên cứu trong thư mục `plans/`. Trước đây được chia thành `/ck:plan:fast`, `/ck:plan:hard` và các lệnh khác — nay được hợp nhất thành một skill duy nhất.
 

--- a/src/content/docs-vi/engineer/skills/preview.md
+++ b/src/content/docs-vi/engineer/skills/preview.md
@@ -8,7 +8,7 @@ order: 56
 lang: vi
 ---
 
-# `ck:preview`
+# Preview
 
 Xem file và thư mục, hoặc tạo giải thích trực quan với ASCII art, sơ đồ Mermaid và slides thuyết trình.
 

--- a/src/content/docs-vi/engineer/skills/project-management.md
+++ b/src/content/docs-vi/engineer/skills/project-management.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:project-management`
+# Project Management
 
 Giám sát dự án sử dụng hệ thống task gốc của Claude với các file plan persistent. Kết nối các phiên, theo dõi tiến độ, phối hợp cập nhật tài liệu và tạo báo cáo trạng thái.
 

--- a/src/content/docs-vi/engineer/skills/react-best-practices.md
+++ b/src/content/docs-vi/engineer/skills/react-best-practices.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:react-best-practices`
+# React Best Practices
 
 Hướng dẫn tối ưu hóa hiệu suất toàn diện cho các ứng dụng React và Next.js, được duy trì bởi Vercel. Chứa 45 quy tắc trên 8 danh mục được ưu tiên theo tác động.
 

--- a/src/content/docs-vi/engineer/skills/remotion.md
+++ b/src/content/docs-vi/engineer/skills/remotion.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:remotion`
+# Remotion
 
 Các phương pháp tốt nhất cho Remotion—tạo video theo chương trình bằng React components, hoạt ảnh và compositions.
 

--- a/src/content/docs-vi/engineer/skills/scout.md
+++ b/src/content/docs-vi/engineer/skills/scout.md
@@ -8,7 +8,7 @@ order: 7
 lang: vi
 ---
 
-# `ck:scout`
+# Scout
 
 Khám phá codebase nhanh, tiết kiệm token bằng các agent song song để tìm các file cần thiết cho task.
 

--- a/src/content/docs-vi/engineer/skills/shader.md
+++ b/src/content/docs-vi/engineer/skills/shader.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:shader`
+# Shader
 
 Viết fragment shaders tăng tốc GPU cho đồ họa thủ tục, texture và hiệu ứng hình ảnh bằng GLSL.
 

--- a/src/content/docs-vi/engineer/skills/tanstack.md
+++ b/src/content/docs-vi/engineer/skills/tanstack.md
@@ -8,7 +8,7 @@ order: 60
 lang: vi
 ---
 
-# `ck:tanstack`
+# Tanstack
 
 Xây dựng ứng dụng React full-stack với TanStack Start, quản lý forms bằng TanStack Form và thêm chat/streaming workflows với TanStack AI.
 

--- a/src/content/docs-vi/engineer/skills/team.md
+++ b/src/content/docs-vi/engineer/skills/team.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:team`
+# Team
 
 Engine điều phối CK-native (v2.1.0) tạo ra các phiên Claude Code độc lập làm teammates, mỗi phiên có cửa sổ context riêng, quyền sở hữu task và bộ nhớ xuyên phiên.
 

--- a/src/content/docs-vi/engineer/skills/test.md
+++ b/src/content/docs-vi/engineer/skills/test.md
@@ -9,7 +9,7 @@ published: true
 lang: vi
 ---
 
-# `ck:test`
+# Test
 
 Framework testing toàn diện cho code và UI. Chạy toàn bộ test stack, phân tích failures, đo lường coverage và tạo báo cáo QA.
 

--- a/src/content/docs-vi/engineer/skills/use-mcp.md
+++ b/src/content/docs-vi/engineer/skills/use-mcp.md
@@ -8,7 +8,7 @@ order: 57
 lang: vi
 ---
 
-# `ck:use-mcp`
+# Use MCP
 
 Sử dụng các công cụ từ máy chủ Model Context Protocol (MCP) được cấu hình trong dự án của bạn. Khám phá và thực thi các khả năng MCP.
 

--- a/src/content/docs-vi/engineer/skills/watzup.md
+++ b/src/content/docs-vi/engineer/skills/watzup.md
@@ -8,7 +8,7 @@ order: 13
 lang: vi
 ---
 
-# `ck:watzup`
+# Watzup
 
 Xem lại các thay đổi gần đây và kết thúc phiên làm việc hiện tại. Tạo bản tóm tắt những gì đã hoàn thành và bước tiếp theo.
 

--- a/src/content/docs-vi/engineer/skills/web-design-guidelines.md
+++ b/src/content/docs-vi/engineer/skills/web-design-guidelines.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:web-design-guidelines`
+# Web Design Guidelines
 
 Xem xét các file để tuân thủ Web Interface Guidelines—kiểm tra accessibility, UX best practices và tiêu chuẩn thiết kế.
 

--- a/src/content/docs-vi/engineer/skills/web-testing.md
+++ b/src/content/docs-vi/engineer/skills/web-testing.md
@@ -8,7 +8,7 @@ order: 50
 lang: vi
 ---
 
-# `ck:web-testing`
+# Web Testing
 
 Testing web toàn diện bao gồm unit, integration, E2E, load, security, visual regression và accessibility testing với các công cụ tiêu chuẩn ngành.
 

--- a/src/content/docs-vi/engineer/skills/worktree.md
+++ b/src/content/docs-vi/engineer/skills/worktree.md
@@ -8,7 +8,7 @@ order: 59
 lang: vi
 ---
 
-# `ck:worktree`
+# Worktree
 
 Tạo git worktrees cô lập cho phát triển song song. Làm việc trên nhiều tính năng đồng thời mà không cần chuyển nhánh.
 

--- a/src/content/docs-vi/marketing/skills/ab-test-setup.md
+++ b/src/content/docs-vi/marketing/skills/ab-test-setup.md
@@ -8,7 +8,7 @@ category: skills
 order: 60
 ---
 
-# `ckm:ab-test-setup`
+# A/B Test Setup
 
 > Chạy thí nghiệm có kiểm soát để ra quyết định dựa trên dữ liệu, không dựa vào phỏng đoán.
 

--- a/src/content/docs-vi/marketing/skills/ads-management.md
+++ b/src/content/docs-vi/marketing/skills/ads-management.md
@@ -7,7 +7,7 @@ category: skills
 order: 10
 ---
 
-# `ckm:ads-management`
+# Ads Management
 
 > Triển khai và tối ưu các chiến dịch trả phí trên nhiều nền tảng với nhắm mục tiêu dựa trên dữ liệu, kiểm thử nội dung và theo dõi ROI.
 

--- a/src/content/docs-vi/marketing/skills/affiliate-marketing.md
+++ b/src/content/docs-vi/marketing/skills/affiliate-marketing.md
@@ -7,7 +7,7 @@ category: skills
 order: 11
 ---
 
-# `ckm:affiliate-marketing`
+# Affiliate Marketing
 
 > Thiết kế chương trình affiliate tạo ra 20-50% khách hàng mới với CAC thấp hơn 30-50% thông qua tuyển dụng đối tác chiến lược.
 

--- a/src/content/docs-vi/marketing/skills/ai-artist.md
+++ b/src/content/docs-vi/marketing/skills/ai-artist.md
@@ -7,7 +7,7 @@ category: skills
 order: 18
 ---
 
-# `ckm:ai-artist`
+# AI Artist
 
 > Tạo prompt hiệu quả cho các mô hình AI (Claude, GPT, Gemini, Midjourney, DALL-E, Stable Diffusion, Imagen, Flux) bằng các mẫu đã được kiểm chứng.
 

--- a/src/content/docs-vi/marketing/skills/ai-multimodal.md
+++ b/src/content/docs-vi/marketing/skills/ai-multimodal.md
@@ -7,7 +7,7 @@ category: skills
 order: 17
 ---
 
-# `ckm:ai-multimodal`
+# AI Multimodal
 
 > Tạo ảnh, video, giọng nói và âm nhạc; phân tích file đa phương tiện và xử lý tài liệu bằng khả năng AI đa phương thức của Google Gemini và MiniMax.
 

--- a/src/content/docs-vi/marketing/skills/analytics.md
+++ b/src/content/docs-vi/marketing/skills/analytics.md
@@ -7,7 +7,7 @@ category: skills
 order: 4
 ---
 
-# `ckm:analytics`
+# Analytics
 
 > Biến dữ liệu marketing thành insights hành động thông qua báo cáo tự động, phân tích phân bổ và theo dõi ROI.
 

--- a/src/content/docs-vi/marketing/skills/analyze.md
+++ b/src/content/docs-vi/marketing/skills/analyze.md
@@ -8,7 +8,7 @@ category: skills
 order: 30
 ---
 
-# `ckm:analyze`
+# Analyze
 
 > Biến dữ liệu marketing thành insights hành động với báo cáo tự động và trực quan hóa.
 

--- a/src/content/docs-vi/marketing/skills/ask.md
+++ b/src/content/docs-vi/marketing/skills/ask.md
@@ -8,7 +8,7 @@ category: skills
 order: 31
 ---
 
-# `ckm:ask`
+# Ask
 
 > Nhận câu trả lời chuyên sâu cho các câu hỏi kỹ thuật và kiến trúc của hệ thống marketing.
 

--- a/src/content/docs-vi/marketing/skills/assets-organizing.md
+++ b/src/content/docs-vi/marketing/skills/assets-organizing.md
@@ -8,7 +8,7 @@ category: skills
 order: 61
 ---
 
-# `ckm:assets-organizing`
+# Assets Organizing
 
 > Giữ cho project gọn gàng bằng cách tổ chức tất cả đầu ra được tạo ra vào một cấu trúc thư mục nhất quán.
 

--- a/src/content/docs-vi/marketing/skills/backend-development.md
+++ b/src/content/docs-vi/marketing/skills/backend-development.md
@@ -8,7 +8,7 @@ category: skills
 order: 62
 ---
 
-# `ckm:backend-development`
+# Backend Development
 
 > Xây dựng API và hệ thống backend production-ready với kiến trúc hiện đại và best practices bảo mật.
 

--- a/src/content/docs-vi/marketing/skills/banner-design.md
+++ b/src/content/docs-vi/marketing/skills/banner-design.md
@@ -8,7 +8,7 @@ category: skills
 order: 63
 ---
 
-# `ckm:banner-design`
+# Banner Design
 
 > Tạo banner chuyên nghiệp cho mọi nền tảng với hướng dẫn thiết kế có cấu trúc và tạo ảnh bằng AI.
 

--- a/src/content/docs-vi/marketing/skills/better-auth.md
+++ b/src/content/docs-vi/marketing/skills/better-auth.md
@@ -8,7 +8,7 @@ category: skills
 order: 64
 ---
 
-# `ckm:better-auth`
+# Better Auth
 
 > Triển khai xác thực an toàn và linh hoạt với Better Auth — framework TypeScript-first mã nguồn mở.
 

--- a/src/content/docs-vi/marketing/skills/brainstorm.md
+++ b/src/content/docs-vi/marketing/skills/brainstorm.md
@@ -8,7 +8,7 @@ category: skills
 order: 112
 ---
 
-# `ckm:brainstorm`
+# Brainstorm
 
 > Nhanh chóng khám phá không gian giải pháp, so sánh phương án và đưa ra quyết định có căn cứ trước khi triển khai.
 

--- a/src/content/docs-vi/marketing/skills/brainstorming.md
+++ b/src/content/docs-vi/marketing/skills/brainstorming.md
@@ -7,7 +7,7 @@ category: skills
 order: 9
 ---
 
-# `ckm:brainstorming`
+# Brainstorming
 
 > Biến ý tưởng thành thiết kế đã được xác nhận thông qua đối thoại có cấu trúc trước khi bất kỳ triển khai nào diễn ra.
 

--- a/src/content/docs-vi/marketing/skills/brand.md
+++ b/src/content/docs-vi/marketing/skills/brand.md
@@ -7,7 +7,7 @@ category: skills
 order: 14
 ---
 
-# `ckm:brand`
+# Brand
 
 > Duy trì tính nhất quán thương hiệu trên tất cả tài liệu marketing với xác nhận tự động, tổ chức tài sản và khung giọng nói.
 

--- a/src/content/docs-vi/marketing/skills/campaign.md
+++ b/src/content/docs-vi/marketing/skills/campaign.md
@@ -7,7 +7,7 @@ category: skills
 order: 7
 ---
 
-# `ckm:campaign`
+# Campaign
 
 > Điều phối chiến dịch đa kênh từ lập kế hoạch đến tổng kết với quy trình có hệ thống và khung tối ưu hóa.
 

--- a/src/content/docs-vi/marketing/skills/chrome-devtools.md
+++ b/src/content/docs-vi/marketing/skills/chrome-devtools.md
@@ -7,7 +7,7 @@ category: skills
 order: 20
 ---
 
-# `ckm:chrome-devtools`
+# Chrome DevTools
 
 > Tự động hóa tác vụ trình duyệt, chụp màn hình, phân tích hiệu suất web và debug ứng dụng web bằng script Puppeteer.
 

--- a/src/content/docs-vi/marketing/skills/cip-design.md
+++ b/src/content/docs-vi/marketing/skills/cip-design.md
@@ -8,7 +8,7 @@ category: skills
 order: 65
 ---
 
-# `ckm:cip-design`
+# CIP Design
 
 > Xây dựng nhận diện thương hiệu toàn diện với hệ thống visual nhất quán trên 50+ loại sản phẩm.
 

--- a/src/content/docs-vi/marketing/skills/ck-help.md
+++ b/src/content/docs-vi/marketing/skills/ck-help.md
@@ -8,7 +8,7 @@ category: skills
 order: 54
 ---
 
-# `ckm:ck-help`
+# ClaudeKit Help
 
 > Hướng dẫn đầy đủ về cách sử dụng ClaudeKit Marketing — skills, agents, workflows và best practices.
 

--- a/src/content/docs-vi/marketing/skills/claude-code.md
+++ b/src/content/docs-vi/marketing/skills/claude-code.md
@@ -8,7 +8,7 @@ category: skills
 order: 66
 ---
 
-# `ckm:claude-code`
+# Claude Code
 
 > Cài đặt và cấu hình Claude Code như một trợ lý marketing AI mạnh mẽ với skills, MCP servers và tích hợp IDE.
 

--- a/src/content/docs-vi/marketing/skills/code-review.md
+++ b/src/content/docs-vi/marketing/skills/code-review.md
@@ -8,7 +8,7 @@ category: skills
 order: 67
 ---
 
-# `ckm:code-review`
+# Code Review
 
 > Đảm bảo chất lượng code marketing tools thông qua review có hệ thống và xử lý phản hồi hiệu quả.
 

--- a/src/content/docs-vi/marketing/skills/competitor-alternatives.md
+++ b/src/content/docs-vi/marketing/skills/competitor-alternatives.md
@@ -8,7 +8,7 @@ category: skills
 order: 68
 ---
 
-# `ckm:competitor-alternatives`
+# Competitor Alternatives
 
 > Chiếm lưu lượng high-intent bằng trang so sánh đối thủ và trang thay thế được tối ưu SEO.
 

--- a/src/content/docs-vi/marketing/skills/competitor.md
+++ b/src/content/docs-vi/marketing/skills/competitor.md
@@ -8,7 +8,7 @@ category: skills
 order: 32
 ---
 
-# `ckm:competitor`
+# Competitor
 
 > Hiểu rõ vị thế cạnh tranh của bạn với phân tích đối thủ có hệ thống và insights thị trường.
 

--- a/src/content/docs-vi/marketing/skills/content-hub.md
+++ b/src/content/docs-vi/marketing/skills/content-hub.md
@@ -7,7 +7,7 @@ category: skills
 order: 16
 ---
 
-# `ckm:content-hub`
+# Content Hub
 
 > Duyệt và quản lý tài sản marketing qua thư viện hình ảnh với thanh bên ngữ cảnh thương hiệu và các nút hành động.
 

--- a/src/content/docs-vi/marketing/skills/content-marketing.md
+++ b/src/content/docs-vi/marketing/skills/content-marketing.md
@@ -7,7 +7,7 @@ category: skills
 order: 2
 ---
 
-# `ckm:content-marketing`
+# Content Marketing
 
 > Xây dựng chương trình nội dung thu hút, tương tác và chuyển đổi thông qua lập kế hoạch chiến lược và thực thi có hệ thống.
 

--- a/src/content/docs-vi/marketing/skills/context-engineering.md
+++ b/src/content/docs-vi/marketing/skills/context-engineering.md
@@ -8,7 +8,7 @@ category: skills
 order: 69
 ---
 
-# `ckm:context-engineering`
+# Context Engineering
 
 > Tối đa hóa hiệu quả AI agent bằng cách quản lý context window thông minh và thiết kế kiến trúc agent tối ưu.
 

--- a/src/content/docs-vi/marketing/skills/cook.md
+++ b/src/content/docs-vi/marketing/skills/cook.md
@@ -8,7 +8,7 @@ category: skills
 order: 113
 ---
 
-# `ckm:cook`
+# Cook
 
 > Triển khai tính năng hoàn chỉnh với pipeline tự động: plan → implement → test → review.
 

--- a/src/content/docs-vi/marketing/skills/copywriting.md
+++ b/src/content/docs-vi/marketing/skills/copywriting.md
@@ -7,7 +7,7 @@ category: skills
 order: 8
 ---
 
-# `ckm:copywriting`
+# Copywriting
 
 > Viết nội dung chuyển đổi cao bằng các công thức đã kiểm chứng, mẫu tiêu đề và phong cách viết tùy chỉnh được trích xuất từ nội dung tốt nhất của bạn.
 

--- a/src/content/docs-vi/marketing/skills/creativity.md
+++ b/src/content/docs-vi/marketing/skills/creativity.md
@@ -7,7 +7,7 @@ category: skills
 order: 15
 ---
 
-# `ckm:creativity`
+# Creativity
 
 > Định hướng chiến dịch sáng tạo một cách có hệ thống với các mẫu phong cách đã được kiểm chứng, khung tâm lý màu sắc và thực hành tốt nhất theo nền tảng cho digital marketing.
 

--- a/src/content/docs-vi/marketing/skills/dashboard.md
+++ b/src/content/docs-vi/marketing/skills/dashboard.md
@@ -8,7 +8,7 @@ category: skills
 order: 33
 ---
 
-# `ckm:dashboard`
+# Dashboard
 
 > Khởi chạy Marketing Dashboard để theo dõi KPI và hiệu suất chiến dịch theo thời gian thực.
 

--- a/src/content/docs-vi/marketing/skills/databases.md
+++ b/src/content/docs-vi/marketing/skills/databases.md
@@ -8,7 +8,7 @@ category: skills
 order: 70
 ---
 
-# `ckm:databases`
+# Databases
 
 > Thiết kế, truy vấn và tối ưu databases cho marketing applications với PostgreSQL và MongoDB.
 

--- a/src/content/docs-vi/marketing/skills/debugging.md
+++ b/src/content/docs-vi/marketing/skills/debugging.md
@@ -8,7 +8,7 @@ category: skills
 order: 71
 ---
 
-# `ckm:debugging`
+# Debugging
 
 > Xác định và sửa bugs nhanh chóng thông qua quy trình debugging có cấu trúc và phân tích nguyên nhân gốc rễ.
 

--- a/src/content/docs-vi/marketing/skills/design-system.md
+++ b/src/content/docs-vi/marketing/skills/design-system.md
@@ -8,7 +8,7 @@ category: skills
 order: 73
 ---
 
-# `ckm:design-system`
+# Design System
 
 > Xây dựng hệ thống thiết kế nhất quán với design tokens, component specs và documentation để scale visual identity.
 

--- a/src/content/docs-vi/marketing/skills/design.md
+++ b/src/content/docs-vi/marketing/skills/design.md
@@ -8,7 +8,7 @@ category: skills
 order: 72
 ---
 
-# `ckm:design`
+# Design
 
 > Điểm vào thống nhất cho mọi tác vụ thiết kế — tự động định tuyến đến skill chuyên biệt phù hợp.
 

--- a/src/content/docs-vi/marketing/skills/devops.md
+++ b/src/content/docs-vi/marketing/skills/devops.md
@@ -8,7 +8,7 @@ category: skills
 order: 74
 ---
 
-# `ckm:devops`
+# Devops
 
 > Deploy marketing tools lên production nhanh chóng và đáng tin cậy với Cloudflare, Docker và GCP.
 

--- a/src/content/docs-vi/marketing/skills/docs-seeker.md
+++ b/src/content/docs-vi/marketing/skills/docs-seeker.md
@@ -8,7 +8,7 @@ category: skills
 order: 75
 ---
 
-# `ckm:docs-seeker`
+# Docs Seeker
 
 > Truy cập tài liệu kỹ thuật cập nhật nhất thông qua llms.txt index — không cần tìm kiếm thủ công.
 

--- a/src/content/docs-vi/marketing/skills/docs.md
+++ b/src/content/docs-vi/marketing/skills/docs.md
@@ -8,7 +8,7 @@ category: skills
 order: 34
 ---
 
-# `ckm:docs`
+# Docs
 
 > Quản lý tài liệu dự án marketing — từ khởi tạo đến cập nhật và tóm tắt nhanh.
 

--- a/src/content/docs-vi/marketing/skills/elevenlabs.md
+++ b/src/content/docs-vi/marketing/skills/elevenlabs.md
@@ -8,7 +8,7 @@ category: skills
 order: 76
 ---
 
-# `ckm:elevenlabs`
+# ElevenLabs
 
 > Tạo voiceover marketing, podcast, và nội dung audio chuyên nghiệp với ElevenLabs AI.
 

--- a/src/content/docs-vi/marketing/skills/email-marketing.md
+++ b/src/content/docs-vi/marketing/skills/email-marketing.md
@@ -7,7 +7,7 @@ category: skills
 order: 5
 ---
 
-# `ckm:email-marketing`
+# Email Marketing
 
 > Xây dựng chiến dịch email có tỷ lệ chuyển đổi cao với quy trình tự động, nội dung tối ưu và thực hành tốt nhất về khả năng giao.
 

--- a/src/content/docs-vi/marketing/skills/email.md
+++ b/src/content/docs-vi/marketing/skills/email.md
@@ -8,7 +8,7 @@ category: skills
 order: 35
 ---
 
-# `ckm:email`
+# Email
 
 > Tạo nội dung email marketing hiệu quả — từ email đơn lẻ đến chuỗi nurture và luồng tự động hóa.
 

--- a/src/content/docs-vi/marketing/skills/fix.md
+++ b/src/content/docs-vi/marketing/skills/fix.md
@@ -8,7 +8,7 @@ category: skills
 order: 114
 ---
 
-# `ckm:fix`
+# Fix
 
 > Sửa lỗi nhanh chóng và chính xác với pipeline tự động: diagnose → fix → test → verify.
 

--- a/src/content/docs-vi/marketing/skills/form-cro.md
+++ b/src/content/docs-vi/marketing/skills/form-cro.md
@@ -8,7 +8,7 @@ category: skills
 order: 77
 ---
 
-# `ckm:form-cro`
+# Form CRO
 
 > Tăng tỷ lệ chuyển đổi form bằng cách áp dụng CRO best practices và tối ưu trải nghiệm người dùng.
 

--- a/src/content/docs-vi/marketing/skills/free-tool-strategy.md
+++ b/src/content/docs-vi/marketing/skills/free-tool-strategy.md
@@ -8,7 +8,7 @@ category: skills
 order: 78
 ---
 
-# `ckm:free-tool-strategy`
+# Free Tool Strategy
 
 > Xây dựng công cụ miễn phí viral để thu hút leads chất lượng cao và backlinks tự nhiên.
 

--- a/src/content/docs-vi/marketing/skills/frontend-design.md
+++ b/src/content/docs-vi/marketing/skills/frontend-design.md
@@ -8,7 +8,7 @@ category: skills
 order: 79
 ---
 
-# `ckm:frontend-design`
+# Frontend Design
 
 > Chuyển đổi designs và screenshots thành frontend code chất lượng cao với pixel-perfect accuracy.
 

--- a/src/content/docs-vi/marketing/skills/frontend-development.md
+++ b/src/content/docs-vi/marketing/skills/frontend-development.md
@@ -8,7 +8,7 @@ category: skills
 order: 80
 ---
 
-# `ckm:frontend-development`
+# Frontend Development
 
 > Xây dựng frontend marketing applications hiệu suất cao với React, TypeScript và modern patterns.
 

--- a/src/content/docs-vi/marketing/skills/funnel.md
+++ b/src/content/docs-vi/marketing/skills/funnel.md
@@ -8,7 +8,7 @@ category: skills
 order: 36
 ---
 
-# `ckm:funnel`
+# Funnel
 
 > Thiết kế phễu chuyển đổi từ nhận thức đến mua hàng và tối ưu từng bước để tăng doanh thu.
 

--- a/src/content/docs-vi/marketing/skills/gamification-marketing.md
+++ b/src/content/docs-vi/marketing/skills/gamification-marketing.md
@@ -7,7 +7,7 @@ category: skills
 order: 12
 ---
 
-# `ckm:gamification-marketing`
+# Gamification Marketing
 
 > Thúc đẩy tương tác và giữ chân thông qua cơ chế trò chơi tận dụng tâm lý hành vi và động lực nội tại.
 

--- a/src/content/docs-vi/marketing/skills/git.md
+++ b/src/content/docs-vi/marketing/skills/git.md
@@ -8,7 +8,7 @@ category: skills
 order: 115
 ---
 
-# `ckm:git`
+# Git
 
 > Quản lý Git workflow chuyên nghiệp với conventional commits, bảo vệ secrets và best practices an toàn.
 

--- a/src/content/docs-vi/marketing/skills/google-adk-python.md
+++ b/src/content/docs-vi/marketing/skills/google-adk-python.md
@@ -8,7 +8,7 @@ category: skills
 order: 81
 ---
 
-# `ckm:google-adk-python`
+# Google ADK Python
 
 > Xây dựng hệ thống multi-agent marketing mạnh mẽ với Google Agent Development Kit (ADK) Python.
 

--- a/src/content/docs-vi/marketing/skills/hub.md
+++ b/src/content/docs-vi/marketing/skills/hub.md
@@ -8,7 +8,7 @@ category: skills
 order: 37
 ---
 
-# `ckm:hub`
+# Hub
 
 > Trung tâm điều phối toàn bộ hoạt động marketing — Content Hub và Dashboard trong một lệnh.
 

--- a/src/content/docs-vi/marketing/skills/init.md
+++ b/src/content/docs-vi/marketing/skills/init.md
@@ -8,7 +8,7 @@ category: skills
 order: 38
 ---
 
-# `ckm:init`
+# Init
 
 > Khởi động dự án marketing mới với thiết lập hoàn chỉnh trong vài phút thay vì vài giờ.
 

--- a/src/content/docs-vi/marketing/skills/journal.md
+++ b/src/content/docs-vi/marketing/skills/journal.md
@@ -8,7 +8,7 @@ category: skills
 order: 39
 ---
 
-# `ckm:journal`
+# Journal
 
 > Ghi lại và phân tích những gì đã thay đổi trong dự án — quyết định, thí nghiệm, kết quả.
 

--- a/src/content/docs-vi/marketing/skills/kanban.md
+++ b/src/content/docs-vi/marketing/skills/kanban.md
@@ -8,7 +8,7 @@ category: skills
 order: 40
 ---
 
-# `ckm:kanban`
+# Kanban
 
 > Điều phối nhiều AI agents làm việc song song với bảng Kanban trực quan.
 

--- a/src/content/docs-vi/marketing/skills/kit-builder.md
+++ b/src/content/docs-vi/marketing/skills/kit-builder.md
@@ -8,7 +8,7 @@ category: skills
 order: 82
 ---
 
-# `ckm:kit-builder`
+# Kit Builder
 
 > Tạo skills, agents và workflows tùy chỉnh để mở rộng ClaudeKit Marketing cho nhu cầu cụ thể của bạn.
 

--- a/src/content/docs-vi/marketing/skills/launch-strategy.md
+++ b/src/content/docs-vi/marketing/skills/launch-strategy.md
@@ -8,7 +8,7 @@ category: skills
 order: 83
 ---
 
-# `ckm:launch-strategy`
+# Launch Strategy
 
 > Tối đa hóa impact của product launches và feature announcements với chiến lược có cấu trúc.
 

--- a/src/content/docs-vi/marketing/skills/logo-design.md
+++ b/src/content/docs-vi/marketing/skills/logo-design.md
@@ -8,7 +8,7 @@ category: skills
 order: 84
 ---
 
-# `ckm:logo-design`
+# Logo Design
 
 > Tạo logo chuyên nghiệp với hướng dẫn phong cách đầy đủ, bảng màu phong phú và AI generation.
 

--- a/src/content/docs-vi/marketing/skills/markdown-novel-viewer.md
+++ b/src/content/docs-vi/marketing/skills/markdown-novel-viewer.md
@@ -8,7 +8,7 @@ category: skills
 order: 116
 ---
 
-# `ckm:markdown-novel-viewer`
+# Markdown Novel Viewer
 
 > Biến file markdown thành tài liệu đẹp với trải nghiệm đọc chuyên nghiệp, Mermaid diagrams và dark mode.
 

--- a/src/content/docs-vi/marketing/skills/marketing-dashboard.md
+++ b/src/content/docs-vi/marketing/skills/marketing-dashboard.md
@@ -8,7 +8,7 @@ category: skills
 order: 85
 ---
 
-# `ckm:marketing-dashboard`
+# Marketing Dashboard
 
 > Xây dựng marketing command center để quản lý toàn bộ hoạt động từ một nơi.
 

--- a/src/content/docs-vi/marketing/skills/marketing-ideas.md
+++ b/src/content/docs-vi/marketing/skills/marketing-ideas.md
@@ -8,7 +8,7 @@ category: skills
 order: 86
 ---
 
-# `ckm:marketing-ideas`
+# Marketing Ideas
 
 > Kho 140 chiến thuật marketing đã được chứng minh, phân loại theo giai đoạn và nguồn lực.
 

--- a/src/content/docs-vi/marketing/skills/marketing-planning.md
+++ b/src/content/docs-vi/marketing/skills/marketing-planning.md
@@ -8,7 +8,7 @@ category: skills
 order: 87
 ---
 
-# `ckm:marketing-planning`
+# Marketing Planning
 
 > Xây dựng chiến lược marketing toàn diện với các framework đã được chứng minh.
 

--- a/src/content/docs-vi/marketing/skills/marketing-psychology.md
+++ b/src/content/docs-vi/marketing/skills/marketing-psychology.md
@@ -8,7 +8,7 @@ category: skills
 order: 88
 ---
 
-# `ckm:marketing-psychology`
+# Marketing Psychology
 
 > Ứng dụng tâm lý học hành vi và khoa học nhận thức để tạo ra marketing thuyết phục và ethical.
 

--- a/src/content/docs-vi/marketing/skills/marketing-research.md
+++ b/src/content/docs-vi/marketing/skills/marketing-research.md
@@ -8,7 +8,7 @@ category: skills
 order: 89
 ---
 
-# `ckm:marketing-research`
+# Marketing Research
 
 > Biến dữ liệu thô thành insights chiến lược thông qua nghiên cứu thị trường có cấu trúc và phân tích đa chiều.
 

--- a/src/content/docs-vi/marketing/skills/mcp-builder.md
+++ b/src/content/docs-vi/marketing/skills/mcp-builder.md
@@ -8,7 +8,7 @@ category: skills
 order: 90
 ---
 
-# `ckm:mcp-builder`
+# MCP Builder
 
 > Xây dựng MCP (Model Context Protocol) server để kết nối Claude với bất kỳ dịch vụ hoặc API nào.
 

--- a/src/content/docs-vi/marketing/skills/mcp-management.md
+++ b/src/content/docs-vi/marketing/skills/mcp-management.md
@@ -8,7 +8,7 @@ category: skills
 order: 91
 ---
 
-# `ckm:mcp-management`
+# MCP Management
 
 > Kiểm soát toàn bộ vòng đời MCP server — từ khám phá tools đến thực thi và giám sát.
 

--- a/src/content/docs-vi/marketing/skills/media-processing.md
+++ b/src/content/docs-vi/marketing/skills/media-processing.md
@@ -7,7 +7,7 @@ category: skills
 order: 19
 ---
 
-# `ckm:media-processing`
+# Media Processing
 
 > Chuyển đổi, thay đổi kích thước, tối ưu hóa và thao tác file media bằng các công cụ tiêu chuẩn ngành cho video, audio và ảnh.
 

--- a/src/content/docs-vi/marketing/skills/mermaidjs-v11.md
+++ b/src/content/docs-vi/marketing/skills/mermaidjs-v11.md
@@ -8,7 +8,7 @@ category: skills
 order: 92
 ---
 
-# `ckm:mermaidjs-v11`
+# Mermaid.js v11
 
 > Tạo sơ đồ trực quan chuyên nghiệp với cú pháp Mermaid.js v11 chính xác và nhất quán.
 

--- a/src/content/docs-vi/marketing/skills/onboarding-cro.md
+++ b/src/content/docs-vi/marketing/skills/onboarding-cro.md
@@ -8,7 +8,7 @@ category: skills
 order: 93
 ---
 
-# `ckm:onboarding-cro`
+# Onboarding CRO
 
 > Biến người đăng ký thành người dùng tích cực thông qua tối ưu hóa luồng onboarding dựa trên dữ liệu.
 

--- a/src/content/docs-vi/marketing/skills/paid-ads.md
+++ b/src/content/docs-vi/marketing/skills/paid-ads.md
@@ -8,7 +8,7 @@ category: skills
 order: 94
 ---
 
-# `ckm:paid-ads`
+# Paid Ads
 
 > Tối đa hóa ROI quảng cáo trả phí thông qua chiến lược nhắm mục tiêu chính xác và tối ưu liên tục.
 

--- a/src/content/docs-vi/marketing/skills/payment-integration.md
+++ b/src/content/docs-vi/marketing/skills/payment-integration.md
@@ -8,7 +8,7 @@ category: skills
 order: 95
 ---
 
-# `ckm:payment-integration`
+# Payment Integration
 
 > Tích hợp thanh toán an toàn và đáng tin cậy cho sản phẩm SaaS với các cổng thanh toán phổ biến.
 

--- a/src/content/docs-vi/marketing/skills/persona.md
+++ b/src/content/docs-vi/marketing/skills/persona.md
@@ -8,7 +8,7 @@ category: skills
 order: 41
 ---
 
-# `ckm:persona`
+# Persona
 
 > Xây dựng và quản lý chân dung khách hàng chi tiết để cá nhân hóa mọi hoạt động marketing.
 

--- a/src/content/docs-vi/marketing/skills/plan.md
+++ b/src/content/docs-vi/marketing/skills/plan.md
@@ -8,7 +8,7 @@ category: skills
 order: 42
 ---
 
-# `ckm:plan`
+# Plan
 
 > Lập kế hoạch marketing thông minh với cải thiện prompt tự động và phân tích rủi ro.
 

--- a/src/content/docs-vi/marketing/skills/plans-kanban.md
+++ b/src/content/docs-vi/marketing/skills/plans-kanban.md
@@ -8,7 +8,7 @@ category: skills
 order: 96
 ---
 
-# `ckm:plans-kanban`
+# Plans Kanban
 
 > Quản lý kế hoạch dự án với dashboard trực quan, theo dõi tiến độ realtime và timeline kanban.
 

--- a/src/content/docs-vi/marketing/skills/preview.md
+++ b/src/content/docs-vi/marketing/skills/preview.md
@@ -8,7 +8,7 @@ category: skills
 order: 43
 ---
 
-# `ckm:preview`
+# Preview
 
 > Xem trước file markdown và kế hoạch dự án ngay trong terminal hoặc trình duyệt.
 

--- a/src/content/docs-vi/marketing/skills/pricing-strategy.md
+++ b/src/content/docs-vi/marketing/skills/pricing-strategy.md
@@ -8,7 +8,7 @@ category: skills
 order: 97
 ---
 
-# `ckm:pricing-strategy`
+# Pricing Strategy
 
 > Thiết kế cấu trúc giá tối ưu hóa doanh thu và tỷ lệ chuyển đổi thông qua phân tích giá trị và tâm lý học giá.
 

--- a/src/content/docs-vi/marketing/skills/problem-solving.md
+++ b/src/content/docs-vi/marketing/skills/problem-solving.md
@@ -8,7 +8,7 @@ category: skills
 order: 98
 ---
 
-# `ckm:problem-solving`
+# Problem Solving
 
 > Giải quyết các vấn đề phức tạp một cách có hệ thống thông qua phân tích đa chiều và khung tư duy có cấu trúc.
 

--- a/src/content/docs-vi/marketing/skills/referral-program-building.md
+++ b/src/content/docs-vi/marketing/skills/referral-program-building.md
@@ -7,7 +7,7 @@ category: skills
 order: 13
 ---
 
-# `ckm:referral-program-building`
+# Referral Program Building
 
 > Xây dựng chương trình giới thiệu tạo tỷ lệ chuyển đổi cao hơn 2-3 lần với tỷ lệ giữ chân tốt hơn 37% bằng cơ chế viral đã được kiểm chứng.
 

--- a/src/content/docs-vi/marketing/skills/remotion.md
+++ b/src/content/docs-vi/marketing/skills/remotion.md
@@ -8,7 +8,7 @@ category: skills
 order: 99
 ---
 
-# `ckm:remotion`
+# Remotion
 
 > Tạo video chuyên nghiệp bằng React code — từ explainer video đến social media content tự động hóa.
 

--- a/src/content/docs-vi/marketing/skills/repomix.md
+++ b/src/content/docs-vi/marketing/skills/repomix.md
@@ -8,7 +8,7 @@ category: skills
 order: 100
 ---
 
-# `ckm:repomix`
+# Repomix
 
 > Chuyển đổi codebase thành context AI-ready — gộp toàn bộ repository thành một file để phân tích chuyên sâu.
 

--- a/src/content/docs-vi/marketing/skills/research.md
+++ b/src/content/docs-vi/marketing/skills/research.md
@@ -7,7 +7,7 @@ category: skills
 order: 21
 ---
 
-# `ckm:research`
+# Research
 
 > Thực hiện nghiên cứu kỹ lưỡng với thu thập thông tin có hệ thống, xác nhận chéo và insights hành động.
 

--- a/src/content/docs-vi/marketing/skills/scout.md
+++ b/src/content/docs-vi/marketing/skills/scout.md
@@ -8,7 +8,7 @@ category: skills
 order: 101
 ---
 
-# `ckm:scout`
+# Scout
 
 > Khám phá codebase lớn trong vài giây với agent song song chạy đồng thời trên nhiều phần code.
 

--- a/src/content/docs-vi/marketing/skills/seo.md
+++ b/src/content/docs-vi/marketing/skills/seo.md
@@ -7,7 +7,7 @@ category: skills
 order: 3
 ---
 
-# `ckm:seo`
+# SEO
 
 > Tăng khả năng hiển thị tìm kiếm thông qua nghiên cứu từ khóa dựa trên dữ liệu, kiểm toán kỹ thuật và chiến lược SEO lập trình.
 

--- a/src/content/docs-vi/marketing/skills/sequential-thinking.md
+++ b/src/content/docs-vi/marketing/skills/sequential-thinking.md
@@ -8,7 +8,7 @@ category: skills
 order: 102
 ---
 
-# `ckm:sequential-thinking`
+# Sequential Thinking
 
 > Giải quyết vấn đề phức tạp thông qua chuỗi suy nghĩ có thể chỉnh sửa, phân nhánh và điều chỉnh động.
 

--- a/src/content/docs-vi/marketing/skills/shader.md
+++ b/src/content/docs-vi/marketing/skills/shader.md
@@ -8,7 +8,7 @@ category: skills
 order: 103
 ---
 
-# `ckm:shader`
+# Shader
 
 > Tạo visual effects ấn tượng với GLSL shaders cho WebGL, Three.js và Shadertoy.
 

--- a/src/content/docs-vi/marketing/skills/shopify.md
+++ b/src/content/docs-vi/marketing/skills/shopify.md
@@ -8,7 +8,7 @@ category: skills
 order: 104
 ---
 
-# `ckm:shopify`
+# Shopify
 
 > Xây dựng ứng dụng và customization Shopify chuyên nghiệp với Shopify CLI, App Bridge và Polaris Design System.
 

--- a/src/content/docs-vi/marketing/skills/skill-creator.md
+++ b/src/content/docs-vi/marketing/skills/skill-creator.md
@@ -8,7 +8,7 @@ category: skills
 order: 105
 ---
 
-# `ckm:skill-creator`
+# Skill Creator
 
 > Tạo skills mới cho ClaudeKit với cấu trúc chuẩn, prompt engineering tối ưu và tích hợp đầy đủ.
 

--- a/src/content/docs-vi/marketing/skills/slides.md
+++ b/src/content/docs-vi/marketing/skills/slides.md
@@ -8,7 +8,7 @@ category: skills
 order: 44
 ---
 
-# `ckm:slides`
+# Slides
 
 > Tạo slide thuyết trình chuyên nghiệp cho chiến lược marketing, báo cáo kết quả và pitch.
 

--- a/src/content/docs-vi/marketing/skills/social-media.md
+++ b/src/content/docs-vi/marketing/skills/social-media.md
@@ -7,7 +7,7 @@ category: skills
 order: 6
 ---
 
-# `ckm:social-media`
+# Social Media
 
 > Tạo nội dung mạng xã hội được tối ưu cho từng nền tảng với các mẫu đã được kiểm chứng, chiến lược tương tác và quy trình đăng chéo.
 

--- a/src/content/docs-vi/marketing/skills/social.md
+++ b/src/content/docs-vi/marketing/skills/social.md
@@ -8,7 +8,7 @@ category: skills
 order: 45
 ---
 
-# `ckm:social`
+# Social
 
 > Tạo nội dung mạng xã hội hấp dẫn cho mọi nền tảng và lên lịch phân phối chiến lược.
 

--- a/src/content/docs-vi/marketing/skills/storage.md
+++ b/src/content/docs-vi/marketing/skills/storage.md
@@ -8,7 +8,7 @@ category: skills
 order: 46
 ---
 
-# `ckm:storage`
+# Storage
 
 > Quản lý tài sản marketing trên S3-compatible storage — tải lên, đồng bộ, tìm kiếm và chia sẻ.
 

--- a/src/content/docs-vi/marketing/skills/template-skill.md
+++ b/src/content/docs-vi/marketing/skills/template-skill.md
@@ -8,7 +8,7 @@ category: skills
 order: 106
 ---
 
-# `ckm:template-skill`
+# Template Skill
 
 > Điểm khởi đầu nhanh cho mọi Claude skill mới với cấu trúc chuẩn và hướng dẫn rõ ràng.
 

--- a/src/content/docs-vi/marketing/skills/test.md
+++ b/src/content/docs-vi/marketing/skills/test.md
@@ -8,7 +8,7 @@ category: skills
 order: 47
 ---
 
-# `ckm:test`
+# Test
 
 > Kiểm thử tự động cho landing pages, email workflows và marketing automation pipelines.
 

--- a/src/content/docs-vi/marketing/skills/threejs.md
+++ b/src/content/docs-vi/marketing/skills/threejs.md
@@ -8,7 +8,7 @@ category: skills
 order: 107
 ---
 
-# `ckm:threejs`
+# Three.js
 
 > Tạo trải nghiệm 3D web ấn tượng với Three.js — từ product visualization đến interactive marketing experiences.
 

--- a/src/content/docs-vi/marketing/skills/ui-styling.md
+++ b/src/content/docs-vi/marketing/skills/ui-styling.md
@@ -8,7 +8,7 @@ category: skills
 order: 108
 ---
 
-# `ckm:ui-styling`
+# UI Styling
 
 > Xây dựng UI đẹp và accessible với shadcn/ui components, Radix UI primitives và Tailwind CSS utilities.
 

--- a/src/content/docs-vi/marketing/skills/ui-ux-pro-max.md
+++ b/src/content/docs-vi/marketing/skills/ui-ux-pro-max.md
@@ -8,7 +8,7 @@ category: skills
 order: 109
 ---
 
-# `ckm:ui-ux-pro-max`
+# UI/UX Pro Max
 
 > Thiết kế UI/UX đẳng cấp thế giới với thư viện phong cách khổng lồ — 50 styles, 21 palettes, 9 stacks.
 

--- a/src/content/docs-vi/marketing/skills/use-mcp.md
+++ b/src/content/docs-vi/marketing/skills/use-mcp.md
@@ -8,7 +8,7 @@ category: skills
 order: 48
 ---
 
-# `ckm:use-mcp`
+# Use MCP
 
 > Kết nối và sử dụng các công cụ từ MCP servers để mở rộng khả năng marketing AI.
 

--- a/src/content/docs-vi/marketing/skills/video.md
+++ b/src/content/docs-vi/marketing/skills/video.md
@@ -8,7 +8,7 @@ category: skills
 order: 49
 ---
 
-# `ckm:video`
+# Video
 
 > Tạo nội dung video marketing — từ kịch bản, storyboard đến video clips AI-generated.
 

--- a/src/content/docs-vi/marketing/skills/watzup.md
+++ b/src/content/docs-vi/marketing/skills/watzup.md
@@ -8,7 +8,7 @@ category: skills
 order: 50
 ---
 
-# `ckm:watzup`
+# Watzup
 
 > Nhanh chóng nắm bắt những gì đã xảy ra — tổng kết phiên làm việc và thay đổi gần đây.
 

--- a/src/content/docs-vi/marketing/skills/web-design-guidelines.md
+++ b/src/content/docs-vi/marketing/skills/web-design-guidelines.md
@@ -8,7 +8,7 @@ category: skills
 order: 110
 ---
 
-# `ckm:web-design-guidelines`
+# Web Design Guidelines
 
 > Đảm bảo giao diện web đạt chuẩn chất lượng cao với đánh giá có hệ thống theo Web Interface Guidelines.
 

--- a/src/content/docs-vi/marketing/skills/web-frameworks.md
+++ b/src/content/docs-vi/marketing/skills/web-frameworks.md
@@ -8,7 +8,7 @@ category: skills
 order: 111
 ---
 
-# `ckm:web-frameworks`
+# Web Frameworks
 
 > Xây dựng ứng dụng web hiện đại với Next.js App Router và quản lý monorepo Turborepo.
 

--- a/src/content/docs-vi/marketing/skills/worktree.md
+++ b/src/content/docs-vi/marketing/skills/worktree.md
@@ -8,7 +8,7 @@ category: skills
 order: 51
 ---
 
-# `ckm:worktree`
+# Worktree
 
 > Tạo git worktrees riêng biệt để nhiều AI agents có thể làm việc song song mà không xung đột.
 

--- a/src/content/docs-vi/marketing/skills/write.md
+++ b/src/content/docs-vi/marketing/skills/write.md
@@ -8,7 +8,7 @@ category: skills
 order: 52
 ---
 
-# `ckm:write`
+# Write
 
 > Viết copy marketing chuyển đổi cao — từ headline, landing page đến bài blog và long-form content.
 

--- a/src/content/docs-vi/marketing/skills/youtube.md
+++ b/src/content/docs-vi/marketing/skills/youtube.md
@@ -8,7 +8,7 @@ category: skills
 order: 53
 ---
 
-# `ckm:youtube`
+# YouTube
 
 > Tái sử dụng video YouTube thành bài blog, social posts và nội dung đa kênh tự động.
 

--- a/src/content/docs/engineer/skills/agent-browser.md
+++ b/src/content/docs/engineer/skills/agent-browser.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:agent-browser`
+# Agent Browser
 
 Browser automation designed specifically for AI agents. Uses a "snapshot + refs" paradigm for 93% less context than traditional tools.
 

--- a/src/content/docs/engineer/skills/ai-multimodal.md
+++ b/src/content/docs/engineer/skills/ai-multimodal.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:ai-multimodal`
+# AI Multimodal
 
 You know that feeling when you need to analyze a 2-hour podcast, extract text from a complex PDF, or generate images that actually match your vision? That's where AI Multimodal comes in.
 

--- a/src/content/docs/engineer/skills/ask.md
+++ b/src/content/docs/engineer/skills/ask.md
@@ -7,7 +7,7 @@ category: skills
 order: 10
 ---
 
-# `ck:ask`
+# Ask
 
 Answer technical and architectural questions about your codebase. This skill provides focused, researched answers rather than superficial responses.
 

--- a/src/content/docs/engineer/skills/better-auth.md
+++ b/src/content/docs/engineer/skills/better-auth.md
@@ -114,7 +114,7 @@ npx @better-auth/cli migrate   # Apply migrations
 
 ---
 
-# `ck:better-auth`
+# Better Auth
 
 ## Key Takeaway
 

--- a/src/content/docs/engineer/skills/bootstrap.md
+++ b/src/content/docs/engineer/skills/bootstrap.md
@@ -8,7 +8,7 @@ order: 50
 published: true
 ---
 
-# `ck:bootstrap`
+# Bootstrap
 
 End-to-end project scaffolding orchestrator. Takes a requirement from zero to running, tested, reviewed code by delegating through research, planning, and implementation in sequence.
 

--- a/src/content/docs/engineer/skills/brainstorm.md
+++ b/src/content/docs/engineer/skills/brainstorm.md
@@ -7,7 +7,7 @@ category: skills
 order: 2
 ---
 
-# `ck:brainstorm`
+# Brainstorm
 
 Your elite technical advisor for architecture decisions, system design, and strategic planning. This skill brings brutal honesty and deep expertise to help you make the right technical choices.
 

--- a/src/content/docs/engineer/skills/chrome-devtools.md
+++ b/src/content/docs/engineer/skills/chrome-devtools.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:chrome-devtools`
+# Chrome DevTools
 
 Need to automate browser interactions, take screenshots of web pages, or debug JavaScript issues? That's exactly what Chrome DevTools skill does using Puppeteer.
 

--- a/src/content/docs/engineer/skills/ck-help.md
+++ b/src/content/docs/engineer/skills/ck-help.md
@@ -7,7 +7,7 @@ category: skills
 order: 1
 ---
 
-# `ck:help`
+# Help
 
 ClaudeKit usage guide and skill discovery. Helps you find the right skill for any task and understand how to use ClaudeKit effectively.
 

--- a/src/content/docs/engineer/skills/coding-level.md
+++ b/src/content/docs/engineer/skills/coding-level.md
@@ -7,7 +7,7 @@ category: skills
 order: 52
 ---
 
-# `ck:coding-level`
+# Coding Level
 
 Set your coding experience level so ClaudeKit tailors its explanations, code comments, and output complexity to match your expertise.
 

--- a/src/content/docs/engineer/skills/context-engineering.md
+++ b/src/content/docs/engineer/skills/context-engineering.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:context-engineering`
+# Context Engineering
 
 The art and science of curating the smallest high-signal token set for maximum LLM reasoning quality while minimizing token usage.
 

--- a/src/content/docs/engineer/skills/cook.md
+++ b/src/content/docs/engineer/skills/cook.md
@@ -7,7 +7,7 @@ category: skills
 order: 4
 ---
 
-# `ck:cook`
+# Cook
 
 Your complete feature implementation engine. Replaces the old `/code` command with smart workflow detection, research phases, and quality gates.
 

--- a/src/content/docs/engineer/skills/copywriting.md
+++ b/src/content/docs/engineer/skills/copywriting.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:copywriting`
+# Copywriting
 
 High-converting copy formulas, templates, and writing style extraction for marketing, landing pages, emails, and product descriptions.
 

--- a/src/content/docs/engineer/skills/debug.md
+++ b/src/content/docs/engineer/skills/debug.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:debug`
+# Debug
 
 Comprehensive debugging framework that combines systematic investigation, root cause tracing, and multi-layer validation. No fixes without understanding the root cause first.
 

--- a/src/content/docs/engineer/skills/devops.md
+++ b/src/content/docs/engineer/skills/devops.md
@@ -114,7 +114,7 @@ gcloud run deploy my-service \
 
 ---
 
-# `ck:devops`
+# Devops
 
 ## Key Takeaway
 

--- a/src/content/docs/engineer/skills/docs.md
+++ b/src/content/docs/engineer/skills/docs.md
@@ -7,7 +7,7 @@ category: skills
 order: 11
 ---
 
-# `ck:docs`
+# Docs
 
 Manage project documentation with AI-powered analysis. Initialize docs for new projects, update after changes, or generate summaries.
 

--- a/src/content/docs/engineer/skills/find-skills.md
+++ b/src/content/docs/engineer/skills/find-skills.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:find-skills`
+# Find Skills
 
 Your gateway to the open agent skills ecosystem. Search, discover, and install specialized capabilities for any domain.
 

--- a/src/content/docs/engineer/skills/fix.md
+++ b/src/content/docs/engineer/skills/fix.md
@@ -7,7 +7,7 @@ category: skills
 order: 5
 ---
 
-# `ck:fix`
+# Fix
 
 Complete bug fixing workflow with intelligent routing based on issue complexity. Automatically activates before fixing ANY bug, error, test failure, or code problem.
 

--- a/src/content/docs/engineer/skills/frontend-design.md
+++ b/src/content/docs/engineer/skills/frontend-design.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:frontend-design`
+# Frontend Design
 
 Tired of generic-looking interfaces that scream "AI made this"? This skill helps you create frontend designs that feel genuinely crafted, memorable, and intentional.
 

--- a/src/content/docs/engineer/skills/frontend-development.md
+++ b/src/content/docs/engineer/skills/frontend-development.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:frontend-development`
+# Frontend Development
 
 Building React applications the modern way means embracing Suspense, lazy loading, and proper data fetching patterns. This skill shows you how.
 

--- a/src/content/docs/engineer/skills/git.md
+++ b/src/content/docs/engineer/skills/git.md
@@ -7,7 +7,7 @@ category: skills
 order: 6
 ---
 
-# `ck:git`
+# Git
 
 Execute git workflows with conventional commit format, intelligent commit splitting, and security scanning for secrets.
 

--- a/src/content/docs/engineer/skills/gkg.md
+++ b/src/content/docs/engineer/skills/gkg.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:gkg`
+# GKG
 
 Semantic code analysis engine using AST parsing and KuzuDB graph database. Enables IDE-like code navigation for AI assistants.
 

--- a/src/content/docs/engineer/skills/journal.md
+++ b/src/content/docs/engineer/skills/journal.md
@@ -7,7 +7,7 @@ category: skills
 order: 14
 ---
 
-# `ck:journal`
+# Journal
 
 Write development journal entries to document technical decisions, challenges, and progress. Useful for maintaining a record of your development journey.
 

--- a/src/content/docs/engineer/skills/kanban.md
+++ b/src/content/docs/engineer/skills/kanban.md
@@ -7,7 +7,7 @@ category: skills
 order: 55
 ---
 
-# `ck:kanban`
+# Kanban
 
 AI agent orchestration board for visualizing tasks and coordinating agent teams. View and manage work in progress across your project.
 

--- a/src/content/docs/engineer/skills/mcp-builder.md
+++ b/src/content/docs/engineer/skills/mcp-builder.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:mcp-builder`
+# MCP Builder
 
 Want to give AI agents access to external APIs and services? That's exactly what MCP servers do, and this skill shows you how to build them properly.
 

--- a/src/content/docs/engineer/skills/mcp-management.md
+++ b/src/content/docs/engineer/skills/mcp-management.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:mcp-management`
+# MCP Management
 
 You've got MCP servers configured, but how do you actually use them without flooding your context window with hundreds of tool definitions? That's where MCP Management comes in.
 

--- a/src/content/docs/engineer/skills/media-processing.md
+++ b/src/content/docs/engineer/skills/media-processing.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:media-processing`
+# Media Processing
 
 Ever needed to convert a video format, resize 500 images, or remove backgrounds from product photos? These are exactly the problems FFmpeg, ImageMagick, and RMBG solve.
 

--- a/src/content/docs/engineer/skills/mermaidjs-v11.md
+++ b/src/content/docs/engineer/skills/mermaidjs-v11.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:mermaidjs-v11`
+# Mermaid.js v11
 
 Text-based diagram creation using Mermaid.js v11 declarative syntax. Convert code to SVG/PNG/PDF or render in browsers and markdown.
 

--- a/src/content/docs/engineer/skills/mintlify.md
+++ b/src/content/docs/engineer/skills/mintlify.md
@@ -8,7 +8,7 @@ order: 50
 published: true
 ---
 
-# `ck:mintlify`
+# Mintlify
 
 v2.0.0 — Mintlify documentation builder. Covers setup, configuration, MDX components, API docs, AI features, and deployment.
 

--- a/src/content/docs/engineer/skills/plan.md
+++ b/src/content/docs/engineer/skills/plan.md
@@ -8,7 +8,7 @@ order: 3
 published: true
 ---
 
-# `ck:plan`
+# Plan
 
 Creates structured, research-backed implementation plans in your `plans/` directory. Formerly split across `/ck:plan:fast`, `/ck:plan:hard`, and other commands—now consolidated into one skill.
 

--- a/src/content/docs/engineer/skills/preview.md
+++ b/src/content/docs/engineer/skills/preview.md
@@ -7,7 +7,7 @@ category: skills
 order: 56
 ---
 
-# `ck:preview`
+# Preview
 
 View files and directories, or generate visual explanations with ASCII art, Mermaid diagrams, and slide presentations.
 

--- a/src/content/docs/engineer/skills/project-management.md
+++ b/src/content/docs/engineer/skills/project-management.md
@@ -8,7 +8,7 @@ order: 50
 published: true
 ---
 
-# `ck:project-management`
+# Project Management
 
 Project oversight using Claude's native task system with persistent plan files. Bridges sessions, tracks progress, coordinates docs updates, and generates status reports.
 

--- a/src/content/docs/engineer/skills/react-best-practices.md
+++ b/src/content/docs/engineer/skills/react-best-practices.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:react-best-practices`
+# React Best Practices
 
 Comprehensive performance optimization guide for React and Next.js applications, maintained by Vercel. Contains 45 rules across 8 categories prioritized by impact.
 

--- a/src/content/docs/engineer/skills/remotion.md
+++ b/src/content/docs/engineer/skills/remotion.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:remotion`
+# Remotion
 
 Best practices for Remotion—create videos programmatically using React components, animations, and compositions.
 

--- a/src/content/docs/engineer/skills/scout.md
+++ b/src/content/docs/engineer/skills/scout.md
@@ -7,7 +7,7 @@ category: skills
 order: 7
 ---
 
-# `ck:scout`
+# Scout
 
 Fast, token-efficient codebase scouting using parallel agents to find files needed for tasks.
 

--- a/src/content/docs/engineer/skills/shader.md
+++ b/src/content/docs/engineer/skills/shader.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:shader`
+# Shader
 
 Write GPU-accelerated fragment shaders for procedural graphics, textures, and visual effects using GLSL.
 

--- a/src/content/docs/engineer/skills/tanstack.md
+++ b/src/content/docs/engineer/skills/tanstack.md
@@ -7,7 +7,7 @@ category: skills
 order: 60
 ---
 
-# `ck:tanstack`
+# Tanstack
 
 Build full-stack React applications with TanStack Start, manage forms with TanStack Form, and add chat/streaming workflows with TanStack AI.
 

--- a/src/content/docs/engineer/skills/team.md
+++ b/src/content/docs/engineer/skills/team.md
@@ -8,7 +8,7 @@ order: 50
 published: true
 ---
 
-# `ck:team`
+# Team
 
 CK-native orchestration engine (v2.1.0) that spawns independent Claude Code sessions as teammates, each with their own context window, task ownership, and cross-session memory.
 

--- a/src/content/docs/engineer/skills/test.md
+++ b/src/content/docs/engineer/skills/test.md
@@ -8,7 +8,7 @@ order: 12
 published: true
 ---
 
-# `ck:test`
+# Test
 
 Comprehensive testing framework for code and UI. Runs the full test stack, analyzes failures, measures coverage, and produces QA reports.
 

--- a/src/content/docs/engineer/skills/use-mcp.md
+++ b/src/content/docs/engineer/skills/use-mcp.md
@@ -7,7 +7,7 @@ category: skills
 order: 57
 ---
 
-# `ck:use-mcp`
+# Use MCP
 
 Utilize tools from Model Context Protocol (MCP) servers configured in your project. Discovers and executes MCP capabilities.
 

--- a/src/content/docs/engineer/skills/watzup.md
+++ b/src/content/docs/engineer/skills/watzup.md
@@ -7,7 +7,7 @@ category: skills
 order: 13
 ---
 
-# `ck:watzup`
+# Watzup
 
 Review recent changes and wrap up your current work session. Generates a summary of what was accomplished and what's next.
 

--- a/src/content/docs/engineer/skills/web-design-guidelines.md
+++ b/src/content/docs/engineer/skills/web-design-guidelines.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:web-design-guidelines`
+# Web Design Guidelines
 
 Review files for compliance with Web Interface Guidelines—checking accessibility, UX best practices, and design standards.
 

--- a/src/content/docs/engineer/skills/web-testing.md
+++ b/src/content/docs/engineer/skills/web-testing.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ck:web-testing`
+# Web Testing
 
 Comprehensive web testing covering unit, integration, E2E, load, security, visual regression, and accessibility testing with industry-standard tools.
 

--- a/src/content/docs/engineer/skills/worktree.md
+++ b/src/content/docs/engineer/skills/worktree.md
@@ -7,7 +7,7 @@ category: skills
 order: 59
 ---
 
-# `ck:worktree`
+# Worktree
 
 Create isolated git worktrees for parallel development. Work on multiple features simultaneously without switching branches.
 

--- a/src/content/docs/marketing/skills/ab-test-setup.md
+++ b/src/content/docs/marketing/skills/ab-test-setup.md
@@ -6,7 +6,7 @@ category: skills
 order: 60
 ---
 
-# `ckm:ab-test-setup`
+# A/B Test Setup
 
 > Design rigorous A/B tests, calculate sample sizes, and validate results with statistical confidence.
 

--- a/src/content/docs/marketing/skills/ads-management.md
+++ b/src/content/docs/marketing/skills/ads-management.md
@@ -6,7 +6,7 @@ category: skills
 order: 10
 ---
 
-# `ckm:ads-management`
+# Ads Management
 
 > Launch and optimize paid campaigns across major platforms with data-driven targeting, copy testing, and ROI tracking.
 

--- a/src/content/docs/marketing/skills/affiliate-marketing.md
+++ b/src/content/docs/marketing/skills/affiliate-marketing.md
@@ -6,7 +6,7 @@ category: skills
 order: 11
 ---
 
-# `ckm:affiliate-marketing`
+# Affiliate Marketing
 
 > Design affiliate programs that generate 20-50% of customer acquisition with 30-50% lower CAC through strategic partner recruitment.
 

--- a/src/content/docs/marketing/skills/ai-artist.md
+++ b/src/content/docs/marketing/skills/ai-artist.md
@@ -6,7 +6,7 @@ category: skills
 order: 18
 ---
 
-# `ckm:ai-artist`
+# AI Artist
 
 > Craft effective prompts for AI models (Claude, GPT, Gemini, Midjourney, DALL-E, Stable Diffusion, Imagen, Flux) using proven patterns.
 

--- a/src/content/docs/marketing/skills/ai-multimodal.md
+++ b/src/content/docs/marketing/skills/ai-multimodal.md
@@ -6,7 +6,7 @@ category: skills
 order: 17
 ---
 
-# `ckm:ai-multimodal`
+# AI Multimodal
 
 > Generate images, videos, music, and speech; analyze multimedia files; and process documents using Google Gemini and MiniMax multimodal AI capabilities.
 

--- a/src/content/docs/marketing/skills/analytics.md
+++ b/src/content/docs/marketing/skills/analytics.md
@@ -6,7 +6,7 @@ category: skills
 order: 4
 ---
 
-# `ckm:analytics`
+# Analytics
 
 > Transform marketing data into actionable insights through automated reporting, attribution analysis, and ROI tracking.
 

--- a/src/content/docs/marketing/skills/analyze.md
+++ b/src/content/docs/marketing/skills/analyze.md
@@ -7,7 +7,7 @@ category: skills
 order: 30
 ---
 
-# `ckm:analyze`
+# Analyze
 
 > Turn raw marketing data into actionable performance insights and reports.
 

--- a/src/content/docs/marketing/skills/ask.md
+++ b/src/content/docs/marketing/skills/ask.md
@@ -7,7 +7,7 @@ category: skills
 order: 31
 ---
 
-# `ckm:ask`
+# Ask
 
 > Get direct answers to technical, strategic, and architectural marketing questions.
 

--- a/src/content/docs/marketing/skills/assets-organizing.md
+++ b/src/content/docs/marketing/skills/assets-organizing.md
@@ -6,7 +6,7 @@ category: skills
 order: 61
 ---
 
-# `ckm:assets-organizing`
+# Assets Organizing
 
 > Keep every agent output, creative asset, and campaign artifact organized and instantly retrievable.
 

--- a/src/content/docs/marketing/skills/backend-development.md
+++ b/src/content/docs/marketing/skills/backend-development.md
@@ -6,7 +6,7 @@ category: skills
 order: 62
 ---
 
-# `ckm:backend-development`
+# Backend Development
 
 > Build production-grade backend systems and APIs to power marketing automations, data pipelines, and custom tools.
 

--- a/src/content/docs/marketing/skills/banner-design.md
+++ b/src/content/docs/marketing/skills/banner-design.md
@@ -6,7 +6,7 @@ category: skills
 order: 63
 ---
 
-# `ckm:banner-design`
+# Banner Design
 
 > Generate on-brand banners for every placement — social media, display ads, email headers, and website heroes.
 

--- a/src/content/docs/marketing/skills/better-auth.md
+++ b/src/content/docs/marketing/skills/better-auth.md
@@ -6,7 +6,7 @@ category: skills
 order: 64
 ---
 
-# `ckm:better-auth`
+# Better Auth
 
 > Implement production-ready authentication with Better Auth — the type-safe, extensible auth framework for TypeScript applications.
 

--- a/src/content/docs/marketing/skills/brainstorm.md
+++ b/src/content/docs/marketing/skills/brainstorm.md
@@ -7,7 +7,7 @@ category: skills
 order: 112
 ---
 
-# `ckm:brainstorm`
+# Brainstorm
 
 > Explore solutions through structured dialogue, compare approaches with trade-offs, and validate decisions before writing a single line of code.
 

--- a/src/content/docs/marketing/skills/brainstorming.md
+++ b/src/content/docs/marketing/skills/brainstorming.md
@@ -6,7 +6,7 @@ category: skills
 order: 9
 ---
 
-# `ckm:brainstorming`
+# Brainstorming
 > Transform ideas into validated designs through structured dialogue before any implementation.
 
 ## What This Skill Does

--- a/src/content/docs/marketing/skills/brand.md
+++ b/src/content/docs/marketing/skills/brand.md
@@ -6,7 +6,7 @@ category: skills
 order: 14
 ---
 
-# `ckm:brand`
+# Brand
 
 > Maintain brand consistency across all marketing materials with automated validation, asset organization, and voice frameworks.
 

--- a/src/content/docs/marketing/skills/campaign.md
+++ b/src/content/docs/marketing/skills/campaign.md
@@ -6,7 +6,7 @@ category: skills
 order: 7
 ---
 
-# `ckm:campaign`
+# Campaign
 
 > Orchestrate multi-channel campaigns from planning to post-mortem with systematic workflows and optimization frameworks.
 

--- a/src/content/docs/marketing/skills/chrome-devtools.md
+++ b/src/content/docs/marketing/skills/chrome-devtools.md
@@ -6,7 +6,7 @@ category: skills
 order: 20
 ---
 
-# `ckm:chrome-devtools`
+# Chrome DevTools
 
 > Automate browser tasks, capture screenshots, analyze web performance, and debug web applications using Puppeteer scripts.
 

--- a/src/content/docs/marketing/skills/cip-design.md
+++ b/src/content/docs/marketing/skills/cip-design.md
@@ -6,7 +6,7 @@ category: skills
 order: 65
 ---
 
-# `ckm:cip-design`
+# CIP Design
 
 > Build comprehensive Corporate Identity Programs with 50+ deliverables spanning logo, typography, color, and brand collateral.
 

--- a/src/content/docs/marketing/skills/ck-help.md
+++ b/src/content/docs/marketing/skills/ck-help.md
@@ -7,7 +7,7 @@ category: skills
 order: 54
 ---
 
-# `ckm:ck-help`
+# ClaudeKit Help
 
 > Get instant guidance on ClaudeKit commands, skills, and workflows for the marketing toolkit.
 

--- a/src/content/docs/marketing/skills/claude-code.md
+++ b/src/content/docs/marketing/skills/claude-code.md
@@ -6,7 +6,7 @@ category: skills
 order: 66
 ---
 
-# `ckm:claude-code`
+# Claude Code
 
 > Configure and extend Claude Code with custom skills, MCP server integrations, and workflow automation hooks.
 

--- a/src/content/docs/marketing/skills/code-review.md
+++ b/src/content/docs/marketing/skills/code-review.md
@@ -6,7 +6,7 @@ category: skills
 order: 67
 ---
 
-# `ckm:code-review`
+# Code Review
 
 > Apply structured code review to catch bugs, enforce quality standards, and improve maintainability before shipping.
 

--- a/src/content/docs/marketing/skills/competitor-alternatives.md
+++ b/src/content/docs/marketing/skills/competitor-alternatives.md
@@ -6,7 +6,7 @@ category: skills
 order: 68
 ---
 
-# `ckm:competitor-alternatives`
+# Competitor Alternatives
 
 > Capture high-intent buyer traffic by building SEO-optimized comparison and alternatives pages that win at the decision stage.
 

--- a/src/content/docs/marketing/skills/competitor.md
+++ b/src/content/docs/marketing/skills/competitor.md
@@ -7,7 +7,7 @@ category: skills
 order: 32
 ---
 
-# `ckm:competitor`
+# Competitor
 
 > Map the competitive landscape and extract actionable intelligence to sharpen positioning.
 

--- a/src/content/docs/marketing/skills/content-hub.md
+++ b/src/content/docs/marketing/skills/content-hub.md
@@ -6,7 +6,7 @@ category: skills
 order: 16
 ---
 
-# `ckm:content-hub`
+# Content Hub
 > Browse and manage marketing assets through visual gallery with brand context sidebar and action buttons.
 
 ## What This Skill Does

--- a/src/content/docs/marketing/skills/content-marketing.md
+++ b/src/content/docs/marketing/skills/content-marketing.md
@@ -6,7 +6,7 @@ category: skills
 order: 2
 ---
 
-# `ckm:content-marketing`
+# Content Marketing
 
 > Build content programs that attract, engage, and convert through strategic planning and systematic execution.
 

--- a/src/content/docs/marketing/skills/context-engineering.md
+++ b/src/content/docs/marketing/skills/context-engineering.md
@@ -6,7 +6,7 @@ category: skills
 order: 69
 ---
 
-# `ckm:context-engineering`
+# Context Engineering
 
 > Maximize AI agent performance by engineering context windows, optimizing token usage, and designing efficient multi-agent architectures.
 

--- a/src/content/docs/marketing/skills/cook.md
+++ b/src/content/docs/marketing/skills/cook.md
@@ -7,7 +7,7 @@ category: skills
 order: 113
 ---
 
-# `ckm:cook`
+# Cook
 
 > Implement complete features end-to-end with smart agent routing — automatically selecting planner, coder, tester, and reviewer based on task complexity.
 

--- a/src/content/docs/marketing/skills/copywriting.md
+++ b/src/content/docs/marketing/skills/copywriting.md
@@ -6,7 +6,7 @@ category: skills
 order: 8
 ---
 
-# `ckm:copywriting`
+# Copywriting
 
 > Write high-converting copy using proven formulas, headline templates, and custom writing styles extracted from your best content.
 

--- a/src/content/docs/marketing/skills/creativity.md
+++ b/src/content/docs/marketing/skills/creativity.md
@@ -6,7 +6,7 @@ category: skills
 order: 15
 ---
 
-# `ckm:creativity`
+# Creativity
 
 > Systematically direct creative campaigns with proven style templates, color psychology frameworks, and platform-specific best practices for digital marketing.
 

--- a/src/content/docs/marketing/skills/dashboard.md
+++ b/src/content/docs/marketing/skills/dashboard.md
@@ -7,7 +7,7 @@ category: skills
 order: 33
 ---
 
-# `ckm:dashboard`
+# Dashboard
 
 > Launch a live marketing dashboard to monitor KPIs, campaign metrics, and channel performance in real time.
 

--- a/src/content/docs/marketing/skills/databases.md
+++ b/src/content/docs/marketing/skills/databases.md
@@ -6,7 +6,7 @@ category: skills
 order: 70
 ---
 
-# `ckm:databases`
+# Databases
 
 > Design efficient schemas, write optimized queries, and manage data at scale for marketing tools and analytics pipelines.
 

--- a/src/content/docs/marketing/skills/debugging.md
+++ b/src/content/docs/marketing/skills/debugging.md
@@ -6,7 +6,7 @@ category: skills
 order: 71
 ---
 
-# `ckm:debugging`
+# Debugging
 
 > Diagnose and fix bugs systematically — from reproduction to root cause to verified resolution.
 

--- a/src/content/docs/marketing/skills/design-system.md
+++ b/src/content/docs/marketing/skills/design-system.md
@@ -6,7 +6,7 @@ category: skills
 order: 73
 ---
 
-# `ckm:design-system`
+# Design System
 
 > Build systematic design foundations — token architecture, component specs, and style guides that scale across your entire product.
 

--- a/src/content/docs/marketing/skills/design.md
+++ b/src/content/docs/marketing/skills/design.md
@@ -6,7 +6,7 @@ category: skills
 order: 72
 ---
 
-# `ckm:design`
+# Design
 
 > The universal design entry point — routes your task to the right specialist skill automatically.
 

--- a/src/content/docs/marketing/skills/devops.md
+++ b/src/content/docs/marketing/skills/devops.md
@@ -6,7 +6,7 @@ category: skills
 order: 74
 ---
 
-# `ckm:devops`
+# Devops
 
 > Deploy marketing tools reliably with CI/CD, infrastructure-as-code, and production-grade security across Cloudflare, Docker, and GCP.
 

--- a/src/content/docs/marketing/skills/docs-seeker.md
+++ b/src/content/docs/marketing/skills/docs-seeker.md
@@ -6,7 +6,7 @@ category: skills
 order: 75
 ---
 
-# `ckm:docs-seeker`
+# Docs Seeker
 
 > Find authoritative, up-to-date technical documentation for any library or framework before implementing.
 

--- a/src/content/docs/marketing/skills/docs.md
+++ b/src/content/docs/marketing/skills/docs.md
@@ -7,7 +7,7 @@ category: skills
 order: 34
 ---
 
-# `ckm:docs`
+# Docs
 
 > Keep marketing project documentation accurate, complete, and up to date.
 

--- a/src/content/docs/marketing/skills/elevenlabs.md
+++ b/src/content/docs/marketing/skills/elevenlabs.md
@@ -6,7 +6,7 @@ category: skills
 order: 76
 ---
 
-# `ckm:elevenlabs`
+# ElevenLabs
 
 > Create professional voiceovers, clone brand voices, and generate audio content at scale with ElevenLabs.
 

--- a/src/content/docs/marketing/skills/email-marketing.md
+++ b/src/content/docs/marketing/skills/email-marketing.md
@@ -6,7 +6,7 @@ category: skills
 order: 5
 ---
 
-# `ckm:email-marketing`
+# Email Marketing
 
 > Build high-converting email campaigns with automation workflows, optimized copy, and deliverability best practices.
 

--- a/src/content/docs/marketing/skills/email.md
+++ b/src/content/docs/marketing/skills/email.md
@@ -7,7 +7,7 @@ category: skills
 order: 35
 ---
 
-# `ckm:email`
+# Email
 
 > Write high-converting emails, build sequences, and design automation flows for every stage of the funnel.
 

--- a/src/content/docs/marketing/skills/fix.md
+++ b/src/content/docs/marketing/skills/fix.md
@@ -7,7 +7,7 @@ category: skills
 order: 114
 ---
 
-# `ckm:fix`
+# Fix
 
 > Fix bugs efficiently with intelligent routing — simple fixes applied immediately, complex issues diagnosed systematically before touching code.
 

--- a/src/content/docs/marketing/skills/form-cro.md
+++ b/src/content/docs/marketing/skills/form-cro.md
@@ -6,7 +6,7 @@ category: skills
 order: 77
 ---
 
-# `ckm:form-cro`
+# Form CRO
 
 > Increase form completion rates with CRO principles, friction reduction, and behavioral psychology — without sacrificing lead quality.
 

--- a/src/content/docs/marketing/skills/free-tool-strategy.md
+++ b/src/content/docs/marketing/skills/free-tool-strategy.md
@@ -6,7 +6,7 @@ category: skills
 order: 78
 ---
 
-# `ckm:free-tool-strategy`
+# Free Tool Strategy
 
 > Turn free tools into your highest-converting lead magnets — building SEO authority and capturing qualified leads at scale.
 

--- a/src/content/docs/marketing/skills/frontend-design.md
+++ b/src/content/docs/marketing/skills/frontend-design.md
@@ -6,7 +6,7 @@ category: skills
 order: 79
 ---
 
-# `ckm:frontend-design`
+# Frontend Design
 
 > Translate designs, screenshots, and mockups into pixel-accurate, responsive frontend components — fast.
 

--- a/src/content/docs/marketing/skills/frontend-development.md
+++ b/src/content/docs/marketing/skills/frontend-development.md
@@ -6,7 +6,7 @@ category: skills
 order: 80
 ---
 
-# `ckm:frontend-development`
+# Frontend Development
 
 > Build fast, maintainable React/TypeScript frontends with modern patterns — Suspense, lazy loading, and optimized rendering.
 

--- a/src/content/docs/marketing/skills/funnel.md
+++ b/src/content/docs/marketing/skills/funnel.md
@@ -7,7 +7,7 @@ category: skills
 order: 36
 ---
 
-# `ckm:funnel`
+# Funnel
 
 > Design, map, and optimize marketing funnels to improve conversion rates at every stage.
 

--- a/src/content/docs/marketing/skills/gamification-marketing.md
+++ b/src/content/docs/marketing/skills/gamification-marketing.md
@@ -6,7 +6,7 @@ category: skills
 order: 12
 ---
 
-# `ckm:gamification-marketing`
+# Gamification Marketing
 
 > Drive engagement and retention through game mechanics that leverage behavioral psychology and intrinsic motivation.
 

--- a/src/content/docs/marketing/skills/git.md
+++ b/src/content/docs/marketing/skills/git.md
@@ -7,7 +7,7 @@ category: skills
 order: 115
 ---
 
-# `ckm:git`
+# Git
 
 > Manage git workflows with conventional commit enforcement, automatic secret scanning, branch strategy, and GitHub PR creation.
 

--- a/src/content/docs/marketing/skills/google-adk-python.md
+++ b/src/content/docs/marketing/skills/google-adk-python.md
@@ -6,7 +6,7 @@ category: skills
 order: 81
 ---
 
-# `ckm:google-adk-python`
+# Google ADK Python
 
 > Build production-grade AI agent workflows with Google ADK Python — orchestrate multi-agent marketing systems that run autonomously.
 

--- a/src/content/docs/marketing/skills/hub.md
+++ b/src/content/docs/marketing/skills/hub.md
@@ -7,7 +7,7 @@ category: skills
 order: 37
 ---
 
-# `ckm:hub`
+# Hub
 
 > Open the Content Hub and Marketing Dashboard together in a unified workspace.
 

--- a/src/content/docs/marketing/skills/init.md
+++ b/src/content/docs/marketing/skills/init.md
@@ -7,7 +7,7 @@ category: skills
 order: 38
 ---
 
-# `ckm:init`
+# Init
 
 > Bootstrap a new marketing project with directory structure, documentation, and configuration in one command.
 

--- a/src/content/docs/marketing/skills/journal.md
+++ b/src/content/docs/marketing/skills/journal.md
@@ -7,7 +7,7 @@ category: skills
 order: 39
 ---
 
-# `ckm:journal`
+# Journal
 
 > Capture and analyze recent marketing changes in structured journal entries for learning and accountability.
 

--- a/src/content/docs/marketing/skills/kanban.md
+++ b/src/content/docs/marketing/skills/kanban.md
@@ -7,7 +7,7 @@ category: skills
 order: 40
 ---
 
-# `ckm:kanban`
+# Kanban
 
 > Visualize and orchestrate AI agent tasks on a Kanban board for transparent, parallel marketing workflows.
 

--- a/src/content/docs/marketing/skills/kit-builder.md
+++ b/src/content/docs/marketing/skills/kit-builder.md
@@ -6,7 +6,7 @@ category: skills
 order: 82
 ---
 
-# `ckm:kit-builder`
+# Kit Builder
 
 > Extend ClaudeKit Marketing by building custom skills, agents, and workflow commands tailored to your marketing stack.
 

--- a/src/content/docs/marketing/skills/launch-strategy.md
+++ b/src/content/docs/marketing/skills/launch-strategy.md
@@ -6,7 +6,7 @@ category: skills
 order: 83
 ---
 
-# `ckm:launch-strategy`
+# Launch Strategy
 
 > Plan and execute product launches that build momentum — from pre-launch hype to post-launch retention.
 

--- a/src/content/docs/marketing/skills/logo-design.md
+++ b/src/content/docs/marketing/skills/logo-design.md
@@ -6,7 +6,7 @@ category: skills
 order: 84
 ---
 
-# `ckm:logo-design`
+# Logo Design
 
 > Create distinctive, scalable logos with AI generation, 55 curated styles, and 30 color palettes — from concept to production-ready SVG.
 

--- a/src/content/docs/marketing/skills/markdown-novel-viewer.md
+++ b/src/content/docs/marketing/skills/markdown-novel-viewer.md
@@ -7,7 +7,7 @@ category: skills
 order: 116
 ---
 
-# `ckm:markdown-novel-viewer`
+# Markdown Novel Viewer
 
 > Open any markdown file in a beautiful, distraction-free reader with rendered Mermaid diagrams, syntax-highlighted code, and a calm typography-first design.
 

--- a/src/content/docs/marketing/skills/marketing-dashboard.md
+++ b/src/content/docs/marketing/skills/marketing-dashboard.md
@@ -6,7 +6,7 @@ category: skills
 order: 85
 ---
 
-# `ckm:marketing-dashboard`
+# Marketing Dashboard
 
 > Your personal marketing command center — all metrics, campaigns, and AI agent activity in one unified dashboard.
 

--- a/src/content/docs/marketing/skills/marketing-ideas.md
+++ b/src/content/docs/marketing/skills/marketing-ideas.md
@@ -6,7 +6,7 @@ category: skills
 order: 86
 ---
 
-# `ckm:marketing-ideas`
+# Marketing Ideas
 
 > Access a curated library of 140 proven marketing approaches — filtered by growth stage, channel, and team size.
 

--- a/src/content/docs/marketing/skills/marketing-planning.md
+++ b/src/content/docs/marketing/skills/marketing-planning.md
@@ -6,7 +6,7 @@ category: skills
 order: 87
 ---
 
-# `ckm:marketing-planning`
+# Marketing Planning
 
 > Build rigorous marketing strategies using proven frameworks — from situation analysis to OKRs to quarterly execution plans.
 

--- a/src/content/docs/marketing/skills/marketing-psychology.md
+++ b/src/content/docs/marketing/skills/marketing-psychology.md
@@ -6,7 +6,7 @@ category: skills
 order: 88
 ---
 
-# `ckm:marketing-psychology`
+# Marketing Psychology
 
 > Apply behavioral science and mental models to every marketing decision — from pricing to copy to onboarding flows.
 

--- a/src/content/docs/marketing/skills/marketing-research.md
+++ b/src/content/docs/marketing/skills/marketing-research.md
@@ -7,7 +7,7 @@ category: skills
 order: 89
 ---
 
-# `ckm:marketing-research`
+# Marketing Research
 
 > Turn market signals into actionable intelligence through systematic research, competitor analysis, and audience insight extraction.
 

--- a/src/content/docs/marketing/skills/mcp-builder.md
+++ b/src/content/docs/marketing/skills/mcp-builder.md
@@ -7,7 +7,7 @@ category: skills
 order: 90
 ---
 
-# `ckm:mcp-builder`
+# MCP Builder
 
 > Build MCP (Model Context Protocol) servers that give Claude and other LLMs direct access to your APIs, databases, and external tools.
 

--- a/src/content/docs/marketing/skills/mcp-management.md
+++ b/src/content/docs/marketing/skills/mcp-management.md
@@ -7,7 +7,7 @@ category: skills
 order: 91
 ---
 
-# `ckm:mcp-management`
+# MCP Management
 
 > Discover, configure, and orchestrate MCP servers to extend Claude's capabilities with external tools and services.
 

--- a/src/content/docs/marketing/skills/media-processing.md
+++ b/src/content/docs/marketing/skills/media-processing.md
@@ -6,7 +6,7 @@ category: skills
 order: 19
 ---
 
-# `ckm:media-processing`
+# Media Processing
 
 > Convert, resize, optimize, and manipulate media files using industry-standard tools for video, audio, and images.
 

--- a/src/content/docs/marketing/skills/mermaidjs-v11.md
+++ b/src/content/docs/marketing/skills/mermaidjs-v11.md
@@ -7,7 +7,7 @@ category: skills
 order: 92
 ---
 
-# `ckm:mermaidjs-v11`
+# Mermaid.js v11
 
 > Generate accurate, rendereable Mermaid.js v11 diagrams with proper syntax, theme support, and advanced layout features.
 

--- a/src/content/docs/marketing/skills/onboarding-cro.md
+++ b/src/content/docs/marketing/skills/onboarding-cro.md
@@ -7,7 +7,7 @@ category: skills
 order: 93
 ---
 
-# `ckm:onboarding-cro`
+# Onboarding CRO
 
 > Turn signups into activated users by mapping friction points, optimizing key flows, and personalizing the path to value.
 

--- a/src/content/docs/marketing/skills/paid-ads.md
+++ b/src/content/docs/marketing/skills/paid-ads.md
@@ -7,7 +7,7 @@ category: skills
 order: 94
 ---
 
-# `ckm:paid-ads`
+# Paid Ads
 
 > Build high-performing paid campaigns with platform-specific creative frameworks, bid strategies, and optimization workflows.
 

--- a/src/content/docs/marketing/skills/payment-integration.md
+++ b/src/content/docs/marketing/skills/payment-integration.md
@@ -7,7 +7,7 @@ category: skills
 order: 95
 ---
 
-# `ckm:payment-integration`
+# Payment Integration
 
 > Add payment processing to your product with battle-tested implementations for SePay (Vietnam), Polar (open source), and Stripe (global).
 

--- a/src/content/docs/marketing/skills/persona.md
+++ b/src/content/docs/marketing/skills/persona.md
@@ -7,7 +7,7 @@ category: skills
 order: 41
 ---
 
-# `ckm:persona`
+# Persona
 
 > Build detailed customer personas grounded in real data to sharpen targeting, messaging, and product positioning.
 

--- a/src/content/docs/marketing/skills/plan.md
+++ b/src/content/docs/marketing/skills/plan.md
@@ -7,7 +7,7 @@ category: skills
 order: 42
 ---
 
-# `ckm:plan`
+# Plan
 
 > Transform a vague marketing goal into a structured, actionable implementation plan.
 

--- a/src/content/docs/marketing/skills/plans-kanban.md
+++ b/src/content/docs/marketing/skills/plans-kanban.md
@@ -7,7 +7,7 @@ category: skills
 order: 96
 ---
 
-# `ckm:plans-kanban`
+# Plans Kanban
 
 > Visualize implementation plans as Kanban boards with phase tracking, task statuses, and progress dashboards.
 

--- a/src/content/docs/marketing/skills/preview.md
+++ b/src/content/docs/marketing/skills/preview.md
@@ -7,7 +7,7 @@ category: skills
 order: 43
 ---
 
-# `ckm:preview`
+# Preview
 
 > Render and preview marketing documents, plans, and content collections in a readable format.
 

--- a/src/content/docs/marketing/skills/pricing-strategy.md
+++ b/src/content/docs/marketing/skills/pricing-strategy.md
@@ -7,7 +7,7 @@ category: skills
 order: 97
 ---
 
-# `ckm:pricing-strategy`
+# Pricing Strategy
 
 > Build pricing strategy that maximizes revenue, reduces churn, and aligns with customer value perception using proven SaaS frameworks.
 

--- a/src/content/docs/marketing/skills/problem-solving.md
+++ b/src/content/docs/marketing/skills/problem-solving.md
@@ -7,7 +7,7 @@ category: skills
 order: 98
 ---
 
-# `ckm:problem-solving`
+# Problem Solving
 
 > Break through complex problems with structured decomposition, root cause analysis, and systematic solution generation.
 

--- a/src/content/docs/marketing/skills/referral-program-building.md
+++ b/src/content/docs/marketing/skills/referral-program-building.md
@@ -6,7 +6,7 @@ category: skills
 order: 13
 ---
 
-# `ckm:referral-program-building`
+# Referral Program Building
 
 > Build referral programs that drive 2-3x higher conversion rates with 37% better retention using proven viral mechanics.
 

--- a/src/content/docs/marketing/skills/remotion.md
+++ b/src/content/docs/marketing/skills/remotion.md
@@ -7,7 +7,7 @@ category: skills
 order: 99
 ---
 
-# `ckm:remotion`
+# Remotion
 
 > Build videos programmatically with React components, CSS animations, and Remotion's rendering pipeline for scalable video content.
 

--- a/src/content/docs/marketing/skills/repomix.md
+++ b/src/content/docs/marketing/skills/repomix.md
@@ -7,7 +7,7 @@ category: skills
 order: 100
 ---
 
-# `ckm:repomix`
+# Repomix
 
 > Convert any repository into a single optimized file that LLMs can fully understand for code review, documentation, and analysis.
 

--- a/src/content/docs/marketing/skills/research.md
+++ b/src/content/docs/marketing/skills/research.md
@@ -6,7 +6,7 @@ category: skills
 order: 21
 ---
 
-# `ckm:research`
+# Research
 
 > Conduct thorough research with systematic information gathering, cross-validation, and actionable insights.
 

--- a/src/content/docs/marketing/skills/scout.md
+++ b/src/content/docs/marketing/skills/scout.md
@@ -7,7 +7,7 @@ category: skills
 order: 101
 ---
 
-# `ckm:scout`
+# Scout
 
 > Map unfamiliar codebases in minutes using parallel agents that explore structure, patterns, and conventions simultaneously.
 

--- a/src/content/docs/marketing/skills/seo.md
+++ b/src/content/docs/marketing/skills/seo.md
@@ -6,7 +6,7 @@ category: skills
 order: 3
 ---
 
-# `ckm:seo`
+# SEO
 
 > Increase search visibility through data-driven keyword research, technical audits, and programmatic SEO strategies.
 

--- a/src/content/docs/marketing/skills/sequential-thinking.md
+++ b/src/content/docs/marketing/skills/sequential-thinking.md
@@ -7,7 +7,7 @@ category: skills
 order: 102
 ---
 
-# `ckm:sequential-thinking`
+# Sequential Thinking
 
 > Work through complex problems one step at a time with the ability to revise earlier reasoning as new information emerges.
 

--- a/src/content/docs/marketing/skills/shader.md
+++ b/src/content/docs/marketing/skills/shader.md
@@ -7,7 +7,7 @@ category: skills
 order: 103
 ---
 
-# `ckm:shader`
+# Shader
 
 > Create stunning procedural visuals and real-time effects with GLSL fragment shaders for web applications and creative coding.
 

--- a/src/content/docs/marketing/skills/shopify.md
+++ b/src/content/docs/marketing/skills/shopify.md
@@ -7,7 +7,7 @@ category: skills
 order: 104
 ---
 
-# `ckm:shopify`
+# Shopify
 
 > Build production-ready Shopify apps and customizations using the Shopify App Bridge, GraphQL API, and Polaris design system.
 

--- a/src/content/docs/marketing/skills/skill-creator.md
+++ b/src/content/docs/marketing/skills/skill-creator.md
@@ -7,7 +7,7 @@ category: skills
 order: 105
 ---
 
-# `ckm:skill-creator`
+# Skill Creator
 
 > Build new Claude skills from scratch or update existing ones to meet Skillmark benchmark standards with proper spec files and test coverage.
 

--- a/src/content/docs/marketing/skills/slides.md
+++ b/src/content/docs/marketing/skills/slides.md
@@ -7,7 +7,7 @@ category: skills
 order: 44
 ---
 
-# `ckm:slides`
+# Slides
 
 > Transform marketing strategy, campaign results, and proposals into polished presentation slides.
 

--- a/src/content/docs/marketing/skills/social-media.md
+++ b/src/content/docs/marketing/skills/social-media.md
@@ -6,7 +6,7 @@ category: skills
 order: 6
 ---
 
-# `ckm:social-media`
+# Social Media
 
 > Create platform-optimized social content with proven templates, engagement strategies, and cross-posting workflows.
 

--- a/src/content/docs/marketing/skills/social.md
+++ b/src/content/docs/marketing/skills/social.md
@@ -7,7 +7,7 @@ category: skills
 order: 45
 ---
 
-# `ckm:social`
+# Social
 
 > Generate platform-optimized social media content and build content calendars for consistent publishing.
 

--- a/src/content/docs/marketing/skills/storage.md
+++ b/src/content/docs/marketing/skills/storage.md
@@ -7,7 +7,7 @@ category: skills
 order: 46
 ---
 
-# `ckm:storage`
+# Storage
 
 > Manage marketing assets in S3 storage — upload, sync, list, and retrieve public URLs.
 

--- a/src/content/docs/marketing/skills/template-skill.md
+++ b/src/content/docs/marketing/skills/template-skill.md
@@ -7,7 +7,7 @@ category: skills
 order: 106
 ---
 
-# `ckm:template-skill`
+# Template Skill
 
 > Bootstrap new Claude skills from a minimal, production-ready template that follows ClaudeKit skill conventions.
 

--- a/src/content/docs/marketing/skills/test.md
+++ b/src/content/docs/marketing/skills/test.md
@@ -7,7 +7,7 @@ category: skills
 order: 47
 ---
 
-# `ckm:test`
+# Test
 
 > Validate marketing workflows, landing pages, and automation sequences with automated testing.
 

--- a/src/content/docs/marketing/skills/threejs.md
+++ b/src/content/docs/marketing/skills/threejs.md
@@ -7,7 +7,7 @@ category: skills
 order: 107
 ---
 
-# `ckm:threejs`
+# Three.js
 
 > Create immersive 3D web experiences, product visualizations, and interactive graphics with Three.js and modern WebGL/WebGPU rendering.
 

--- a/src/content/docs/marketing/skills/ui-styling.md
+++ b/src/content/docs/marketing/skills/ui-styling.md
@@ -7,7 +7,7 @@ category: skills
 order: 108
 ---
 
-# `ckm:ui-styling`
+# UI Styling
 
 > Build polished, accessible user interfaces using shadcn/ui components, Radix UI primitives, and Tailwind CSS with built-in dark mode and theming.
 

--- a/src/content/docs/marketing/skills/ui-ux-pro-max.md
+++ b/src/content/docs/marketing/skills/ui-ux-pro-max.md
@@ -7,7 +7,7 @@ category: skills
 order: 109
 ---
 
-# `ckm:ui-ux-pro-max`
+# UI/UX Pro Max
 
 > Design exceptional UIs with a curated library of 50 visual styles, 21 palettes, and multi-stack implementation across 9 technology options.
 

--- a/src/content/docs/marketing/skills/use-mcp.md
+++ b/src/content/docs/marketing/skills/use-mcp.md
@@ -7,7 +7,7 @@ category: skills
 order: 48
 ---
 
-# `ckm:use-mcp`
+# Use MCP
 
 > Connect to and use external tools through Model Context Protocol (MCP) servers.
 

--- a/src/content/docs/marketing/skills/video.md
+++ b/src/content/docs/marketing/skills/video.md
@@ -7,7 +7,7 @@ category: skills
 order: 49
 ---
 
-# `ckm:video`
+# Video
 
 > Produce video scripts, storyboards, and AI-generated video clips for marketing campaigns.
 

--- a/src/content/docs/marketing/skills/watzup.md
+++ b/src/content/docs/marketing/skills/watzup.md
@@ -7,7 +7,7 @@ category: skills
 order: 50
 ---
 
-# `ckm:watzup`
+# Watzup
 
 > Review everything that changed in the current session and produce a clean wrap-up summary.
 

--- a/src/content/docs/marketing/skills/web-design-guidelines.md
+++ b/src/content/docs/marketing/skills/web-design-guidelines.md
@@ -7,7 +7,7 @@ category: skills
 order: 110
 ---
 
-# `ckm:web-design-guidelines`
+# Web Design Guidelines
 
 > Audit web interfaces against established design guidelines to surface accessibility issues, visual inconsistencies, and UX anti-patterns before they ship.
 

--- a/src/content/docs/marketing/skills/web-frameworks.md
+++ b/src/content/docs/marketing/skills/web-frameworks.md
@@ -7,7 +7,7 @@ category: skills
 order: 111
 ---
 
-# `ckm:web-frameworks`
+# Web Frameworks
 
 > Build scalable web applications using Next.js 14+ App Router, Turborepo monorepos, and modern full-stack TypeScript architecture patterns.
 

--- a/src/content/docs/marketing/skills/worktree.md
+++ b/src/content/docs/marketing/skills/worktree.md
@@ -7,7 +7,7 @@ category: skills
 order: 51
 ---
 
-# `ckm:worktree`
+# Worktree
 
 > Create isolated git worktrees so multiple marketing tasks can run in parallel without conflicts.
 

--- a/src/content/docs/marketing/skills/write.md
+++ b/src/content/docs/marketing/skills/write.md
@@ -7,7 +7,7 @@ category: skills
 order: 52
 ---
 
-# `ckm:write`
+# Write
 
 > Write high-quality marketing content — blog posts, landing page copy, CRO content, and creative pieces.
 

--- a/src/content/docs/marketing/skills/youtube.md
+++ b/src/content/docs/marketing/skills/youtube.md
@@ -7,7 +7,7 @@ category: skills
 order: 53
 ---
 
-# `ckm:youtube`
+# YouTube
 
 > Transform YouTube videos into SEO-optimized blog posts, social media content, and newsletter material.
 


### PR DESCRIPTION
## Summary

- Replace code-styled h1 (`<code>ckm:seo</code>`) with readable text headings (`# SEO`, `# Cook`, `# AI Multimodal`)
- Root cause: `remark-directive` parsed colons as directives, `<code>` tag color matched background
- 288 files updated across EN + VI, engineer + marketing skills

## Test plan

- [x] Build: 549 pages, 2014 links validated, 0 broken
- [x] Verified rendered HTML shows plain `<h1>` without `<code>` wrapper
- [x] Matches existing pattern from better-auth page (`# Better Auth Skill`)