### PR TITLE
feat(nav): improve sidebar IA for agents and skills

### DIFF
--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -427,10 +427,13 @@ docsSchema = z.object({
 ### 2. Navigation System
 
 **SidebarNav.astro** (Enhanced through Phases 01-03):
-- Groups docs by logical sections from frontmatter category field
-- Sorts by `order` field (lower = higher)
-- Collapsible sections with localStorage persistence
-- Auto-expands "Getting Started" by default
+- Detects the active docs section from the URL and delegates rendering to shared section nav components
+- Groups docs by frontmatter category, then applies per-section metadata from `src/lib/sidebar-nav-section-config.ts`
+- Engineer/Marketing `agents` and `skills` pin their overview page first, sort by slug, and render A-Z group headings
+- Skill labels in alpha-grouped sidebars trim `ck:` / `ckm:` prefixes for scanability while leaving page titles and URLs unchanged
+- Collapsible sections persist in `sessionStorage` under `claudekit-sidebar-collapse-state`
+- Collapse keys are namespaced by section/category (`engineer:skills`, `marketing:agents`, etc.)
+- Active category auto-expands so the current page is not hidden by saved collapse state
 - Active page highlighting with 2px blue left border
 - File/folder icons (Lucide-style inline SVG)
 - Enhanced section-based organization improving content discoverability
@@ -439,6 +442,7 @@ docsSchema = z.object({
 - **Phase 02**: Section-specific navigation components with smart detection
 - **Phase 02**: Enhanced mobile responsiveness and active state highlighting
 - **Phase 02**: Fixed nested command navigation hierarchy
+- **Current branch**: Shared nav helpers live in `src/lib/section-nav.ts` and alpha-grouped category rendering lives in `src/components/nav/SectionNavCategory.astro`
 
 **Navigation Improvements**:
 - Section-based categorization replaces flat hierarchy
@@ -459,7 +463,7 @@ docsSchema = z.object({
 
 **Remaining Navigation Issues**:
 - Commands have nested subdirectories (`commands/fix/hard.md`) but sidebar shows flat list. Hierarchical nav still needed for command subcategories (partially addressed in Phase 02, may need further refinement).
-- `troubleshooting` category navigation integration needs verification.
+- Alpha grouping is currently targeted at the largest Engineer/Marketing categories only; other sections still use their existing layouts.
 
 ### 3. Internationalization (i18n)
 
@@ -872,7 +876,7 @@ npm run preview      # Preview build
 
 ## Unresolved Questions
 
-1. Should `troubleshooting` category be added to SidebarNav or removed from schema?
+1. Should A-Z grouping stay limited to Engineer/Marketing `agents` and `skills`, or expand to other large sections later?
 2. How to implement hierarchical navigation for nested command categories?
 3. What's the timeline for OpenRouter API backend integration?
 4. Should Vietnamese translations be auto-synced or manually maintained?

--- a/docs/system-architecture.md
+++ b/docs/system-architecture.md
@@ -226,36 +226,46 @@ Desktop (>= 1024px):
 ```
 Content Collection (all docs)
     ↓
-Filter by category
+Filter by current section
     ↓
-Sort by order field
+Group by top-level category
     ↓
-Group into sections
+Apply section/category nav metadata
+    ↓
+Pin overview pages and sort items
+    ↓
+Optional A-Z grouping for large categories
     ↓
 Render collapsible tree
     ↓
-localStorage persistence
+sessionStorage persistence
 ```
 
-**Categories**:
+**Navigation Contract**:
 ```typescript
-categories = {
-  'getting-started': { title: t('nav.getting-started'), docs: [...] },
-  'cli': { title: t('nav.cli'), docs: [...] },
-  'core-concepts': { title: t('nav.core-concepts'), docs: [...] },
-  'agents': { title: t('nav.agents'), docs: [...] },
-  'commands': { title: t('nav.commands'), docs: [...] },
-  'skills': { title: t('nav.skills'), docs: [...] },
-  'use-cases': { title: t('nav.use-cases'), docs: [...] },
-  // 'troubleshooting': MISSING (known issue)
-}
+categoryMeta = {
+  agents: {
+    groupMode: 'alpha',
+    pinnedSlugSegments: ['agents', 'index'],
+    sortKey: 'slug',
+    sortMode: 'alpha',
+  },
+  skills: {
+    groupMode: 'alpha',
+    pinnedSlugSegments: ['skills', 'index'],
+    sortKey: 'slug',
+    sortMode: 'alpha',
+    displayLabelMode: 'trim-skill-prefix',
+  },
+};
 ```
 
 **State Management**:
-- Collapse state stored in `localStorage`
-- Key format: `sidebar-section-${sectionName}`
-- Values: `'collapsed'` | `'expanded'`
-- Default: "Getting Started" expanded, others collapsed
+- Collapse state stored in `sessionStorage`
+- Root key: `claudekit-sidebar-collapse-state`
+- Category keys are namespaced as `${section}:${category}`
+- Active category always expands so the current page stays visible
+- Inactive categories default to collapsed unless the user expanded them earlier in the tab session
 
 **Active Page Highlighting**:
 ```typescript
@@ -306,10 +316,9 @@ window.addEventListener('storage', (e) => {
 
 #### 4.3 Known Issues
 
-1. **Flat Navigation**: Commands have nested structure (`commands/fix/hard.md`) but sidebar shows flat list
-2. **Missing Category**: `troubleshooting` in schema but not in SidebarNav
-3. **No Breadcrumbs**: Users can't see path hierarchy
-4. **Marketing Nav Missing**: WorkflowsNav only shows engineer workflows (marketing TBD)
+1. **Flat Command Navigation**: Commands still have nested structure (`commands/fix/hard.md`) but sidebar remains one level deep
+2. **No Breadcrumbs**: Users can't see path hierarchy from the page itself
+3. **Targeted IA Only**: A-Z grouping is enabled for large Engineer/Marketing `agents` and `skills` sections, not every section
 
 ### 5. AI Integration System (Planned)
 
@@ -651,7 +660,7 @@ spec:
 - OpenRouter API backend for AI chat
 - Pagefind search integration
 - Hierarchical sidebar navigation
-- Add `troubleshooting` category to sidebar
+- Extend grouped sidebar patterns where other sections become hard to scan
 
 **Phase 2** (Q2 2026):
 - Light/dark theme toggle
@@ -675,14 +684,13 @@ spec:
 
 **Current Issues**:
 1. Sidebar flat navigation (need hierarchical)
-2. Missing troubleshooting category
-3. AI backend not connected
-4. Search not implemented
-5. Vietnamese translations may lag behind English
+2. AI backend not connected
+3. Search not implemented
+4. Vietnamese translations may lag behind English
 
 **Prioritization**:
 - P0: AI backend, search
-- P1: Hierarchical nav, troubleshooting category
+- P1: Hierarchical nav for commands and other nested sections
 - P2: Theme toggle, analytics
 - P3: Versioning, additional locales
 

--- a/src/components/SidebarNav.astro
+++ b/src/components/SidebarNav.astro
@@ -106,32 +106,58 @@ const sectionDocs = allDocs.filter(doc => doc.data.section === section);
   // State persistence logic (runs client-side)
   const COLLAPSE_KEY = 'claudekit-sidebar-collapse-state';
 
+  function readSidebarState() {
+    try {
+      const saved = sessionStorage.getItem(COLLAPSE_KEY);
+      if (!saved) return {};
+
+      const parsed = JSON.parse(saved);
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
   function initSidebarState() {
-    const saved = sessionStorage.getItem(COLLAPSE_KEY);
-    const state = saved ? JSON.parse(saved) : {};
+    const state = readSidebarState();
 
     // Apply saved collapse state
     document.querySelectorAll('[data-collapsible]').forEach(section => {
-      const key = section.getAttribute('data-category');
-      const isCollapsed = state[key] ?? true; // Default collapsed
+      if (!(section instanceof HTMLElement)) return;
 
+      const key = section.getAttribute('data-category');
+      if (!key) return;
+
+      const defaultExpanded = section.getAttribute('data-default-expanded') === 'true';
       const button = section.querySelector('button');
       const items = section.querySelector('.nav-items');
+      const shouldCollapse = defaultExpanded ? false : state[key] ?? true;
 
-      if (isCollapsed) {
+      if (shouldCollapse) {
         section.classList.add('collapsed');
         items?.setAttribute('hidden', '');
       } else {
         section.classList.remove('collapsed');
         items?.removeAttribute('hidden');
       }
+
+      button?.setAttribute('aria-expanded', String(!shouldCollapse));
     });
 
     // Add click handlers
     document.querySelectorAll('[data-collapsible] button').forEach(button => {
-      button.addEventListener('click', (e) => {
+      if (!(button instanceof HTMLButtonElement)) return;
+      if (button.dataset.sidebarBound === 'true') return;
+
+      button.dataset.sidebarBound = 'true';
+
+      button.addEventListener('click', () => {
         const section = button.closest('[data-collapsible]');
+        if (!(section instanceof HTMLElement)) return;
+
         const key = section.getAttribute('data-category');
+        if (!key) return;
+
         const items = section.querySelector('.nav-items');
 
         const isCollapsed = section.classList.toggle('collapsed');
@@ -142,9 +168,10 @@ const sectionDocs = allDocs.filter(doc => doc.data.section === section);
           items?.removeAttribute('hidden');
         }
 
+        button.setAttribute('aria-expanded', String(!isCollapsed));
+
         // Save state
-        const saved = sessionStorage.getItem(COLLAPSE_KEY);
-        const state = saved ? JSON.parse(saved) : {};
+        const state = readSidebarState();
         state[key] = isCollapsed;
         sessionStorage.setItem(COLLAPSE_KEY, JSON.stringify(state));
       });

--- a/src/components/nav/SectionNav.astro
+++ b/src/components/nav/SectionNav.astro
@@ -4,6 +4,8 @@
 
 import { getLangFromUrl, getDocPath } from '../../i18n/utils';
 import { NAV_SECTION_CONFIGS } from '../../lib/sidebar-nav-section-config';
+import { capitalizeCategoryLabel, groupDocsByCategory, sortDocs } from '../../lib/section-nav';
+import SectionNavCategory from './SectionNavCategory.astro';
 
 interface Props {
   docs: any[];
@@ -19,41 +21,18 @@ if (!config) {
   throw new Error(`Unknown nav section: ${section}`);
 }
 
-// Helper to capitalize words
-const capitalize = (str: string) => {
-  return str.split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
-};
-
-// Sort items by order
-const sortItems = (items: any[]) => {
-  return items.sort((a, b) => (a.data.order || 999) - (b.data.order || 999));
-};
-
 // Filter docs if needed
 let filteredDocs = docs;
 if (config.filterIndex) {
   filteredDocs = docs.filter(doc => !doc.slug.endsWith('index') && doc.slug !== section);
 }
 
-// Group docs by top-level category (first segment before '/')
-// e.g., 'commands/core' and 'commands/plan' both group under 'commands'
-const groupByCategory = (docs: any[]) => {
-  const groups: Record<string, any[]> = {};
-  docs.forEach(doc => {
-    const fullCategory = doc.data.category || 'overview';
-    // For categorized layout, group by first segment only
-    const category = config.layout === 'categorized'
-      ? fullCategory.split('/')[0]
-      : fullCategory;
-    if (!groups[category]) groups[category] = [];
-    groups[category].push(doc);
-  });
-  return groups;
-};
-
 const categories = (config.layout === 'categorized' || config.layout === 'grouped')
-  ? groupByCategory(filteredDocs)
+  ? groupDocsByCategory(filteredDocs, config.layout)
   : {};
+const orphanCategories = Object.keys(categories)
+  .filter((key) => !new Set(config.categoryOrder || []).has(key))
+  .sort((left, right) => left.localeCompare(right));
 ---
 
 <div class="section-nav" style={`--section-accent: ${config.accentColor}`}>
@@ -75,78 +54,38 @@ const categories = (config.layout === 'categorized' || config.layout === 'groupe
         if (!items || items.length === 0) return null;
 
         return (
-          <div class="nav-section" data-category={categoryKey} data-collapsible>
-            <button class="nav-section-title" aria-expanded="false">
-              <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="m9 18 6-6-6-6"></path>
-              </svg>
-              {config.categoryIcons && config.categoryIcons[categoryKey] && (
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="category-icon" set:html={config.categoryIcons[categoryKey]} />
-              )}
-              {capitalize(categoryKey)}
-              <span class="item-count">({items.length})</span>
-            </button>
-
-            <div class="nav-items" hidden>
-              {sortItems(items).map(doc => {
-                const href = getDocPath(doc.slug, currentLocale);
-                const isActive = currentPath === href || currentPath === href + '/';
-                return (
-                  <a href={href} class:list={['nav-link', { active: isActive }]}>
-                    <span>{doc.data.title}</span>
-                  </a>
-                );
-              })}
-            </div>
-          </div>
+          <SectionNavCategory
+            categoryKey={categoryKey}
+            currentPath={currentPath}
+            docs={items}
+            icon={config.categoryIcons?.[categoryKey]}
+            meta={config.categoryMeta?.[categoryKey]}
+            stateKey={`${section}:${categoryKey}`}
+          />
         );
       })}
 
-      {/* Render orphan categories not in categoryOrder */}
-      {(() => {
-        const knownCategories = new Set(config.categoryOrder || []);
-        const orphanCategories = Object.keys(categories).filter(k => !knownCategories.has(k));
+      {orphanCategories.map((categoryKey) => {
+        const items = categories[categoryKey];
+        if (!items || items.length === 0) return null;
 
-        return orphanCategories.map(categoryKey => {
-          const items = categories[categoryKey];
-          if (!items || items.length === 0) return null;
-
-          // Use default overview icon for orphans
-          const defaultIcon = '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline>';
-
-          return (
-            <div class="nav-section" data-category={categoryKey} data-collapsible>
-              <button class="nav-section-title" aria-expanded="false">
-                <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d="m9 18 6-6-6-6"></path>
-                </svg>
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="category-icon" set:html={defaultIcon} />
-                {capitalize(categoryKey)}
-                <span class="item-count">({items.length})</span>
-              </button>
-
-              <div class="nav-items" hidden>
-                {sortItems(items).map(doc => {
-                  const href = getDocPath(doc.slug, currentLocale);
-                  const isActive = currentPath === href || currentPath === href + '/';
-                  return (
-                    <a href={href} class:list={['nav-link', { active: isActive }]}>
-                      <span>{doc.data.title}</span>
-                    </a>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        });
-      })()}
+        return (
+          <SectionNavCategory
+            categoryKey={categoryKey}
+            currentPath={currentPath}
+            docs={items}
+            meta={config.categoryMeta?.[categoryKey]}
+            stateKey={`${section}:${categoryKey}`}
+          />
+        );
+      })}
     </>
   )}
 
   {config.layout === 'flat' && (
     <div class="nav-section">
       <div class="nav-items">
-        {sortItems(filteredDocs).map(doc => {
+        {sortDocs(filteredDocs, config.categoryMeta?.uncategorized).map(doc => {
           const href = getDocPath(doc.slug, currentLocale);
           const isActive = currentPath === href || currentPath === href + '/';
           return (
@@ -168,7 +107,7 @@ const categories = (config.layout === 'categorized' || config.layout === 'groupe
   {config.layout === 'grouped' && config.categoryMeta && (
     <>
       {Object.entries(categories).map(([category, categoryDocs]) => {
-        const meta = config.categoryMeta![category] || { title: capitalize(category), collapsible: false };
+        const meta = config.categoryMeta![category] || { title: capitalizeCategoryLabel(category), collapsible: false };
 
         return (
           <div class="nav-section">
@@ -190,7 +129,7 @@ const categories = (config.layout === 'categorized' || config.layout === 'groupe
             </div>
 
             <ul class="nav-items">
-              {sortItems(categoryDocs).map(doc => {
+              {sortDocs(categoryDocs, meta).map(doc => {
                 const href = getDocPath(doc.slug, currentLocale);
                 const isActive = currentPath === href || currentPath === href + '/';
 

--- a/src/components/nav/SectionNavCategory.astro
+++ b/src/components/nav/SectionNavCategory.astro
@@ -1,0 +1,113 @@
+---
+import { getLangFromUrl, getDocPath } from '../../i18n/utils';
+import type { NavCategoryMeta } from '../../lib/sidebar-nav-section-config';
+import {
+  buildAlphaGroups,
+  capitalizeCategoryLabel,
+  getDocDisplayLabel,
+  splitPinnedDocs,
+} from '../../lib/section-nav';
+
+interface Props {
+  categoryKey: string;
+  currentPath: string;
+  docs: any[];
+  icon?: string;
+  meta?: NavCategoryMeta;
+  stateKey?: string;
+}
+
+const { categoryKey, currentPath, docs, icon, meta, stateKey = categoryKey } = Astro.props;
+const currentLocale = getLangFromUrl(Astro.url);
+const categoryLabel = meta?.title ?? capitalizeCategoryLabel(categoryKey);
+const { pinnedDocs, remainingDocs } = splitPinnedDocs(docs, meta);
+const alphaGroups = meta?.groupMode === 'alpha' ? buildAlphaGroups(remainingDocs, meta) : [];
+const hasActiveItem = docs.some((doc) => {
+  const href = getDocPath(doc.slug, currentLocale);
+  return currentPath === href || currentPath === `${href}/`;
+});
+const defaultCategoryIcon =
+  '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline>';
+---
+
+<div
+  class="nav-section"
+  data-category={stateKey}
+  data-collapsible
+  data-default-expanded={hasActiveItem ? 'true' : 'false'}
+>
+  <button class="nav-section-title" aria-expanded={hasActiveItem ? 'true' : 'false'}>
+    <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="m9 18 6-6-6-6"></path>
+    </svg>
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="category-icon"
+      set:html={icon ?? defaultCategoryIcon}
+    />
+    {categoryLabel}
+    <span class="item-count">({docs.length})</span>
+  </button>
+
+  <div class="nav-items" hidden={!hasActiveItem}>
+    {pinnedDocs.map((doc) => {
+      const href = getDocPath(doc.slug, currentLocale);
+      const isActive = currentPath === href || currentPath === `${href}/`;
+      return (
+        <a href={href} class:list={['nav-link', { active: isActive }]}>
+          <span>{getDocDisplayLabel(doc, meta)}</span>
+        </a>
+      );
+    })}
+
+    {alphaGroups.length > 0 ? (
+      alphaGroups.map((group) => (
+        <div class="alpha-group">
+          <div class="alpha-label">{group.key}</div>
+          {group.items.map((doc) => {
+            const href = getDocPath(doc.slug, currentLocale);
+            const isActive = currentPath === href || currentPath === `${href}/`;
+            return (
+              <a href={href} class:list={['nav-link', { active: isActive }]}>
+                <span>{getDocDisplayLabel(doc, meta)}</span>
+              </a>
+            );
+          })}
+        </div>
+      ))
+    ) : (
+      remainingDocs.map((doc) => {
+        const href = getDocPath(doc.slug, currentLocale);
+        const isActive = currentPath === href || currentPath === `${href}/`;
+        return (
+          <a href={href} class:list={['nav-link', { active: isActive }]}>
+            <span>{getDocDisplayLabel(doc, meta)}</span>
+          </a>
+        );
+      })
+    )}
+  </div>
+</div>
+
+<style>
+  .alpha-group + .alpha-group {
+    margin-top: var(--space-2);
+  }
+
+  .alpha-label {
+    padding: var(--space-2) var(--space-3);
+    padding-left: calc(var(--space-3) + 32px);
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-weight: var(--font-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+</style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,5 +1,14 @@
 import { defineCollection, z } from 'astro:content';
 
+const validCategoryRootsBySection: Record<string, string[]> = {
+  'getting-started': ['getting-started'],
+  engineer: ['overview', 'agents', 'skills', 'configuration'],
+  marketing: ['overview', 'agents', 'skills', 'features', 'dashboard'],
+  support: ['support', 'troubleshooting'],
+  tools: ['tools'],
+  workflows: ['engineer', 'marketing'],
+};
+
 const docsSchema = z.object({
   title: z.string(),
   description: z.string().min(10).max(160), // SEO constraint
@@ -20,6 +29,21 @@ const docsSchema = z.object({
   order: z.number().optional().default(999),
   published: z.boolean().default(true),
   lastUpdated: z.date().optional(),
+}).superRefine((data, ctx) => {
+  if (!data.category) return;
+
+  const validRoots = validCategoryRootsBySection[data.section];
+  if (!validRoots) return;
+
+  const categoryRoot = data.category.split('/')[0];
+
+  if (!validRoots.includes(categoryRoot)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['category'],
+      message: `Invalid category root "${categoryRoot}" for section "${data.section}". Expected one of: ${validRoots.join(', ')}.`,
+    });
+  }
 });
 
 const docs = defineCollection({

--- a/src/content/docs-vi/engineer/configuration/claude-md.md
+++ b/src/content/docs-vi/engineer/configuration/claude-md.md
@@ -3,7 +3,7 @@ title: CLAUDE.md
 description: Tài liệu hướng dẫn sử dụng file CLAUDE.md
 section: engineer
 kit: engineer
-category: docs/configuration
+category: configuration
 order: 2
 published: true
 lang: vi

--- a/src/content/docs-vi/engineer/configuration/mcp-setup.md
+++ b/src/content/docs-vi/engineer/configuration/mcp-setup.md
@@ -3,7 +3,7 @@ title: "Thiết lập MCP"
 description: "Tài liệu hướng dẫn thiết lập MCP (Model Context Protocol)"
 section: engineer
 kit: engineer
-category: docs/configuration
+category: configuration
 order: 3
 published: true
 lang: vi

--- a/src/content/docs-vi/engineer/configuration/workflows.md
+++ b/src/content/docs-vi/engineer/configuration/workflows.md
@@ -3,7 +3,7 @@ title: Workflows
 description: Documentation for workflows
 section: engineer
 kit: engineer
-category: docs/configuration
+category: configuration
 order: 3
 published: true
 lang: vi

--- a/src/content/docs-vi/engineer/skills/index.md
+++ b/src/content/docs-vi/engineer/skills/index.md
@@ -3,7 +3,7 @@ title: Kỹ Năng (Skills)
 description: Tài liệu hướng dẫn sử dụng Skills trong ClaudeKit
 section: engineer
 kit: engineer
-category: docs/skills
+category: skills
 order: 1
 published: true
 lang: vi

--- a/src/lib/section-nav.ts
+++ b/src/lib/section-nav.ts
@@ -1,0 +1,144 @@
+import type { NavCategoryMeta, NavSectionConfig } from './sidebar-nav-section-config';
+
+export interface SectionNavDoc {
+  slug: string;
+  data: {
+    title?: string;
+    order?: number;
+    category?: string;
+  };
+}
+
+export interface AlphaGroup {
+  key: string;
+  items: SectionNavDoc[];
+}
+
+const collator = new Intl.Collator(['vi', 'en'], {
+  numeric: true,
+  sensitivity: 'base',
+});
+
+export function capitalizeCategoryLabel(label: string) {
+  return label
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function groupDocsByCategory(
+  docs: SectionNavDoc[],
+  layout: NavSectionConfig['layout']
+) {
+  const groups: Record<string, SectionNavDoc[]> = {};
+
+  docs.forEach((doc) => {
+    const fullCategory = doc.data.category || 'overview';
+    const category = layout === 'categorized' ? fullCategory.split('/')[0] : fullCategory;
+
+    groups[category] ??= [];
+    groups[category].push(doc);
+  });
+
+  return groups;
+}
+
+export function sortDocs(docs: SectionNavDoc[], meta?: NavCategoryMeta) {
+  const sortMode = meta?.sortMode ?? 'order';
+  const sortedDocs = [...docs];
+
+  if (sortMode === 'alpha') {
+    return sortedDocs.sort((left, right) => {
+      const labelCompare = collator.compare(
+        getDocSortLabel(left, meta),
+        getDocSortLabel(right, meta)
+      );
+
+      if (labelCompare !== 0) return labelCompare;
+      return (left.data.order ?? 999) - (right.data.order ?? 999);
+    });
+  }
+
+  return sortedDocs.sort((left, right) => {
+    const orderCompare = (left.data.order ?? 999) - (right.data.order ?? 999);
+
+    if (orderCompare !== 0) return orderCompare;
+    return collator.compare(getDocSortLabel(left, meta), getDocSortLabel(right, meta));
+  });
+}
+
+export function splitPinnedDocs(docs: SectionNavDoc[], meta?: NavCategoryMeta) {
+  const pinnedSlugSegments = new Set(meta?.pinnedSlugSegments ?? []);
+  const pinnedDocs: SectionNavDoc[] = [];
+  const remainingDocs: SectionNavDoc[] = [];
+
+  docs.forEach((doc) => {
+    if (pinnedSlugSegments.has(getDocLeafSlug(doc))) {
+      pinnedDocs.push(doc);
+      return;
+    }
+
+    remainingDocs.push(doc);
+  });
+
+  return {
+    pinnedDocs: sortDocs(pinnedDocs, { ...meta, sortMode: 'order' }),
+    remainingDocs: sortDocs(remainingDocs, meta),
+  };
+}
+
+export function buildAlphaGroups(docs: SectionNavDoc[], meta?: NavCategoryMeta): AlphaGroup[] {
+  const groupedDocs = new Map<string, SectionNavDoc[]>();
+
+  sortDocs(docs, meta).forEach((doc) => {
+    const groupKey = getAlphaGroupKey(doc, meta);
+    const existingGroup = groupedDocs.get(groupKey);
+
+    if (existingGroup) {
+      existingGroup.push(doc);
+      return;
+    }
+
+    groupedDocs.set(groupKey, [doc]);
+  });
+
+  return Array.from(groupedDocs.entries()).map(([key, items]) => ({ key, items }));
+}
+
+export function getDocDisplayLabel(doc: SectionNavDoc, meta?: NavCategoryMeta) {
+  const label = doc.data.title || getDocLeafSlug(doc);
+
+  if (meta?.displayLabelMode === 'trim-skill-prefix') {
+    return trimSkillPrefix(label) || label;
+  }
+
+  return label;
+}
+
+function getDocLeafSlug(doc: SectionNavDoc) {
+  return doc.slug.split('/').at(-1) ?? doc.slug;
+}
+
+function getDocSortLabel(doc: SectionNavDoc, meta?: NavCategoryMeta) {
+  if (meta?.sortKey === 'slug') {
+    return normalizeSortLabel(getDocLeafSlug(doc));
+  }
+
+  return normalizeSortLabel(getDocDisplayLabel(doc, meta));
+}
+
+function getAlphaGroupKey(doc: SectionNavDoc, meta?: NavCategoryMeta) {
+  const [firstCharacter = '#'] = getDocSortLabel(doc, meta);
+  return /^[a-z]/i.test(firstCharacter) ? firstCharacter.toUpperCase() : '#';
+}
+
+function normalizeSortLabel(value: string) {
+  return trimSkillPrefix(value)
+    .replace(/[-_]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function trimSkillPrefix(value: string) {
+  return value.replace(/^ckm?:/i, '').trim();
+}

--- a/src/lib/sidebar-nav-section-config.ts
+++ b/src/lib/sidebar-nav-section-config.ts
@@ -9,9 +9,19 @@ export interface NavSectionConfig {
   layout: 'categorized' | 'flat' | 'grouped'; // categorized = collapsible categories, flat = simple list, grouped = non-collapsible groups
   categoryOrder?: string[];
   categoryIcons?: Record<string, string>;
-  categoryMeta?: Record<string, { title: string; collapsible?: boolean }>;
+  categoryMeta?: Record<string, NavCategoryMeta>;
   filterIndex?: boolean; // ToolsNav filters out index pages
   showDocIcon?: boolean; // CLINav shows document icon per nav item
+}
+
+export interface NavCategoryMeta {
+  title?: string;
+  collapsible?: boolean;
+  groupMode?: 'none' | 'alpha';
+  pinnedSlugSegments?: string[];
+  sortKey?: 'title' | 'slug';
+  sortMode?: 'order' | 'alpha';
+  displayLabelMode?: 'title' | 'trim-skill-prefix';
 }
 
 export const NAV_SECTION_CONFIGS: Record<string, NavSectionConfig> = {
@@ -21,6 +31,21 @@ export const NAV_SECTION_CONFIGS: Record<string, NavSectionConfig> = {
     badgeStyle: 'filled',
     layout: 'categorized',
     categoryOrder: ['overview', 'agents', 'skills', 'configuration'],
+    categoryMeta: {
+      agents: {
+        groupMode: 'alpha',
+        pinnedSlugSegments: ['agents', 'index'],
+        sortKey: 'slug',
+        sortMode: 'alpha',
+      },
+      skills: {
+        groupMode: 'alpha',
+        pinnedSlugSegments: ['skills', 'index'],
+        sortKey: 'slug',
+        sortMode: 'alpha',
+        displayLabelMode: 'trim-skill-prefix',
+      },
+    },
     categoryIcons: {
       overview: '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
       agents: '<circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 0 0-16 0"/>',
@@ -35,6 +60,21 @@ export const NAV_SECTION_CONFIGS: Record<string, NavSectionConfig> = {
     badgeStyle: 'filled',
     layout: 'categorized',
     categoryOrder: ['overview', 'agents', 'skills', 'dashboard'],
+    categoryMeta: {
+      agents: {
+        groupMode: 'alpha',
+        pinnedSlugSegments: ['agents', 'index'],
+        sortKey: 'slug',
+        sortMode: 'alpha',
+      },
+      skills: {
+        groupMode: 'alpha',
+        pinnedSlugSegments: ['skills', 'index'],
+        sortKey: 'slug',
+        sortMode: 'alpha',
+        displayLabelMode: 'trim-skill-prefix',
+      },
+    },
     categoryIcons: {
       overview: '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
       agents: '<circle cx="12" cy="8" r="5"/><path d="M20 21a8 8 0 0 0-16 0"/>',


### PR DESCRIPTION
## Summary
- improve Engineer and Marketing sidebar scanability with config-driven A-Z grouping for agents and skills
- pin overview pages first, clean skill labels in sidebar display, and keep the active category visible
- fix miscategorized Vietnamese Engineer pages and document the updated sidebar architecture

## Validation
- bun run build
- bunx astro check (repo still has unrelated pre-existing diagnostics; changed sidebar files are clean)

Closes #111