### PR TITLE
fix(nav): restore sidebar category item styles

### DIFF
--- a/src/components/nav/SectionNavCategory.astro
+++ b/src/components/nav/SectionNavCategory.astro
@@ -97,6 +97,103 @@ const defaultCategoryIcon =
 </div>
 
 <style>
+  .nav-section {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--space-2);
+  }
+
+  .nav-section-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    background: transparent;
+    border: none;
+    color: var(--color-text-secondary);
+    font-size: var(--text-xs);
+    font-weight: var(--font-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    cursor: pointer;
+    border-radius: var(--radius-md);
+    transition: all 0.15s;
+    text-align: left;
+    width: 100%;
+  }
+
+  .nav-section-title:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+  }
+
+  .chevron {
+    transition: transform 0.2s;
+    color: var(--color-text-muted);
+    width: 14px;
+    height: 14px;
+  }
+
+  .nav-section.collapsed .chevron {
+    transform: rotate(0deg);
+  }
+
+  .nav-section:not(.collapsed) .chevron {
+    transform: rotate(90deg);
+  }
+
+  .category-icon {
+    color: var(--section-accent);
+    width: 16px;
+    height: 16px;
+  }
+
+  .item-count {
+    margin-left: auto;
+    font-size: var(--text-xs);
+    color: var(--color-text-muted);
+    font-weight: var(--font-normal);
+  }
+
+  .nav-items {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .nav-items[hidden] {
+    display: none;
+  }
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    padding-left: calc(var(--space-3) + 32px);
+    font-size: var(--text-sm);
+    color: var(--color-text-secondary);
+    border-radius: var(--radius-md);
+    transition: all 0.15s;
+    text-decoration: none;
+  }
+
+  .nav-link:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text-primary);
+    text-decoration: none;
+  }
+
+  .nav-link.active {
+    background: var(--color-bg-tertiary);
+    color: var(--section-accent);
+    border-left: 2px solid var(--section-accent);
+    padding-left: calc(var(--space-3) + 30px);
+  }
+
   .alpha-group + .alpha-group {
     margin-top: var(--space-2);
   }


### PR DESCRIPTION
## Summary
- restore the extracted sidebar category styles inside `SectionNavCategory.astro`
- preserve the A-Z grouped sidebar layout for skills and agents pages
- keep the fix scoped to the extracted nav category component

## Root Cause
Astro component styles are scoped. After the category UI was extracted into `SectionNavCategory.astro`, the sidebar styles defined in the parent component no longer applied to the rendered links.

## Validation
- `bun run build`
- local browser verification on `http://127.0.0.1:4323/docs/engineer/skills/ai-multimodal/`

Closes #113
