### PR TITLE
docs: add hook diagnostics dashboard guidance

### DIFF
--- a/src/content/docs/cli/configuration.md
+++ b/src/content/docs/cli/configuration.md
@@ -9,6 +9,19 @@ order: 9
 
 > Customize ClaudeKit CLI behavior with config files, environment variables, and project-specific settings.
 
+## Config Dashboard
+
+Use `ck config` to open the local configuration dashboard.
+
+### Hook Diagnostics Panel
+
+The System view includes a Hook Diagnostics panel that reads structured hook logs from:
+
+- Global installs: `~/.claude/hooks/.logs/hook-log.jsonl`
+- Project installs: `<project>/.claude/hooks/.logs/hook-log.jsonl`
+
+The panel lets you switch between global and project scope, refresh recent entries, and inspect warning, block, and crash counts without manually opening JSONL files.
+
 ## Configuration Files
 
 ClaudeKit CLI uses multiple configuration files at different levels.

--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -16,7 +16,9 @@ Hooks allow you to extend Claude Code with custom scripts that run at specific p
 
 Hooks are configured in `.claude/settings.json` and execute shell commands in response to Claude Code events.
 
-> **Always-on diagnostics (v2.11.0+):** All built-in hooks are wrapped in crash handlers that automatically capture errors and write them to `.claude/hooks/logs/`. Hook failures are logged but do not interrupt your session.
+> **Always-on diagnostics (v2.11.0+):** Built-in hooks fail open and write diagnostics to `.claude/hooks/.logs/hook-log.jsonl`. Recent ClaudeKit releases log both crashes and key hook outcomes, so you can inspect failures without interrupting the session.
+
+> **Dashboard visibility (CLI):** `ck config` now reads these hook logs and shows recent hook activity, warnings, blocks, and crashes for both global and project scopes.
 
 ### Available Hook Events
 


### PR DESCRIPTION
## Summary
- document the new hook diagnostics panel in `ck config`
- update engineer hook docs with the structured hook log path and dashboard visibility

## Validation
- bun install
- bun run build

## References
- claudekit-cli#487
- claudekit-engineer#568