### PR TITLE
fix: resolve Docker build 8 broken links in CLI docs

### DIFF
--- a/src/content/docs-vi/cli/content.md
+++ b/src/content/docs-vi/cli/content.md
@@ -1,0 +1,272 @@
+---
+title: "ck content"
+description: "Daemon tạo content tự động từ hoạt động git và đăng lên mạng xã hội"
+section: docs
+category: docs/cli
+order: 11
+published: true
+---
+
+# ck content
+
+Daemon tạo content tự động. Quét hoạt động git (commit, PR, release), tạo bài đăng mạng xã hội với Claude, và publish lên X/Twitter và Facebook.
+
+## Tổng Quan
+
+`ck content` là daemon chạy nền biến hoạt động phát triển thành nội dung mạng xã hội. Giám sát git event trên các repository, dùng Claude tạo bài đăng phù hợp từng nền tảng, và đăng theo lịch cấu hình. Hỗ trợ quy trình review (auto, manual, hybrid) và theo dõi engagement để tự cải thiện.
+
+## Cú Pháp
+
+```bash
+ck content <subcommand> [options]
+```
+
+### Subcommand
+
+| Lệnh | Mô Tả |
+|-------|-------|
+| `ck content start` | Khởi động content daemon |
+| `ck content stop` | Dừng daemon đang chạy |
+| `ck content status` | Hiển thị trạng thái, cấu hình, thời gian scan gần nhất |
+| `ck content logs` | In log content hôm nay |
+| `ck content setup` | Wizard cài đặt tương tác cho cấu hình platform |
+| `ck content queue` | Liệt kê nội dung chờ review |
+| `ck content approve <id>` | Phê duyệt nội dung |
+| `ck content reject <id> [reason]` | Từ chối nội dung |
+
+### Tùy Chọn Chung
+
+| Flag | Mặc Định | Mô Tả |
+|------|----------|-------|
+| `--dry-run` | `false` | Tạo content nhưng không publish |
+| `--verbose` | `false` | Bật debug output |
+| `--force` | `false` | Dừng daemon hiện tại và khởi động lại |
+| `--tail` | `false` | Theo dõi log realtime (cho subcommand `logs`) |
+
+## Yêu Cầu
+
+- **GitHub CLI** (`gh`) đã cài đặt và xác thực
+- **Git** repository (hoặc thư mục chứa nhiều git repo)
+- **API credential của platform** cấu hình qua `ck content setup`:
+  - X/Twitter: API key, API secret, access token, access secret
+  - Facebook: Page access token, Page ID
+
+## Cách Hoạt Động
+
+### Pipeline Tạo Content
+
+```
+Git Scan → Phân Loại Event → Tạo Content → Review → Publish → Engagement
+```
+
+### Quy Trình Chi Tiết
+
+1. **Git Scan** — Quét repository tìm commit mới, PR đã merge, tag, release, plan hoàn thành
+2. **Phân Loại Event** — Lọc nhiễu, phân loại event theo mức độ quan trọng (high/medium/low)
+3. **Tạo Content** — Claude tạo bài đăng theo từng platform kèm hashtag, hook line, CTA
+4. **Review** — Tùy theo `reviewMode`:
+   - `auto` — Đăng ngay nếu qua kiểm tra chất lượng
+   - `manual` — Xếp hàng chờ duyệt qua `ck content queue/approve/reject`
+   - `hybrid` — Tự đăng content chất lượng cao, xếp hàng content cần xem xét
+5. **Publish** — Đăng lên platform đã bật, tuân thủ rate limit và giờ nghỉ
+6. **Theo Dõi Engagement** — Định kỳ kiểm tra hiệu suất bài đăng và phản hồi để cải thiện
+
+### Git Event Được Hỗ Trợ
+
+| Loại Event | Trigger | Ví Dụ |
+|-----------|---------|-------|
+| `commit` | Commit mới trên nhánh mặc định | Feature commit, bug fix |
+| `pr_merged` | Pull request được merge | Feature PR, dependency update |
+| `tag` | Git tag mới | Phát hành phiên bản |
+| `release` | GitHub release | Phát hành lớn |
+| `plan_completed` | ClaudeKit plan hoàn thành | Mốc dự án hoàn thành |
+
+### Platform Được Hỗ Trợ
+
+| Platform | Loại Bài | Giới Hạn |
+|----------|---------|----------|
+| **X/Twitter** | Bài đơn, thread (tối đa 6 phần) | 280 ký tự/bài, cấu hình max bài/ngày |
+| **Facebook** | Bài trên Page | Cấu hình max bài/ngày |
+
+## Cấu Hình
+
+Lưu trong `.ck.json` dưới key `content`:
+
+```json
+{
+  "content": {
+    "enabled": false,
+    "pollIntervalMs": 60000,
+    "platforms": {
+      "x": {
+        "enabled": false,
+        "maxPostsPerDay": 5,
+        "threadMaxParts": 6
+      },
+      "facebook": {
+        "enabled": false,
+        "maxPostsPerDay": 3
+      }
+    },
+    "reviewMode": "auto",
+    "schedule": {
+      "timezone": "UTC",
+      "quietHoursStart": "23:00",
+      "quietHoursEnd": "06:00"
+    },
+    "selfImprovement": {
+      "enabled": true,
+      "engagementCheckIntervalHours": 6,
+      "topPerformingCount": 10
+    },
+    "firstScanLookbackDays": 30,
+    "maxContentPerDay": 10,
+    "contentDir": "~/.claudekit/content/",
+    "dbPath": "~/.claudekit/content.db"
+  }
+}
+```
+
+### Tùy Chọn Cấu Hình Chính
+
+| Key | Mặc Định | Mô Tả |
+|-----|----------|-------|
+| `enabled` | `false` | Công tắc chính (thiết lập qua `ck content setup`) |
+| `pollIntervalMs` | `60000` | Khoảng thời gian quét git (1 phút) |
+| `reviewMode` | `auto` | Chế độ duyệt content: `auto`, `manual`, `hybrid` |
+| `schedule.timezone` | `UTC` | Múi giờ cho giờ nghỉ |
+| `schedule.quietHoursStart` | `23:00` | Không đăng sau giờ này |
+| `schedule.quietHoursEnd` | `06:00` | Tiếp tục đăng sau giờ này |
+| `firstScanLookbackDays` | `30` | Số ngày quét lại lần chạy đầu |
+| `maxContentPerDay` | `10` | Giới hạn bài đăng hàng ngày trên tất cả platform |
+| `selfImprovement.enabled` | `true` | Học từ engagement metric |
+
+## Ví Dụ
+
+### Bắt Đầu
+
+```bash
+# Setup tương tác — cấu hình platform và API key
+ck content setup
+
+# Khởi động daemon
+ck content start
+
+# Kiểm tra trạng thái
+ck content status
+```
+
+### Quy Trình Review Thủ Công
+
+```bash
+# Đặt reviewMode thành "manual" trong .ck.json, sau đó:
+ck content start
+
+# Kiểm tra content chờ duyệt
+ck content queue
+
+# Phê duyệt hoặc từ chối
+ck content approve 42
+ck content reject 43 "Quá quảng cáo"
+```
+
+### Giám Sát
+
+```bash
+# Xem log hôm nay
+ck content logs
+
+# Theo dõi log realtime
+ck content logs --tail
+
+# Test mà không đăng
+ck content start --dry-run --verbose
+```
+
+### Quản Lý Daemon
+
+```bash
+# Dừng daemon
+ck content stop
+
+# Khởi động lại
+ck content start --force
+```
+
+## Vòng Đời Content
+
+Mỗi nội dung đi qua các trạng thái:
+
+```
+draft → scheduled → reviewing → approved → publishing → published
+                                                      → failed (retry tối đa 3 lần trong 24h)
+```
+
+## Cơ Sở Dữ Liệu
+
+Dữ liệu content lưu trong SQLite tại `~/.claudekit/content.db`:
+
+- **git_events** — Hoạt động git được theo dõi kèm phân loại mức độ quan trọng
+- **content_items** — Bài đăng đã tạo kèm platform, text, hashtag, trạng thái
+- **publications** — Tham chiếu bài đã đăng (post ID, URL, timestamp)
+
+Dọn dẹp data tự động chạy mỗi 24 giờ.
+
+## Bảo Mật
+
+- **Process Lock** — Chỉ một daemon chạy cùng lúc (`~/.claudekit/locks/ck-content.lock`)
+- **Cách Ly Credential** — API key platform lưu riêng, không trong git
+- **Rate Limiting** — Giới hạn hàng ngày theo platform và giờ nghỉ cấu hình
+- **Bảo Vệ Retry** — Tạo content thất bại retry tối đa 3 lần, publish thất bại retry trong 24h
+
+## Xử Lý Sự Cố
+
+### "Content engine not enabled"
+
+Chạy setup wizard:
+
+```bash
+ck content setup
+```
+
+### "Content daemon already running"
+
+Dừng hoặc restart:
+
+```bash
+ck content stop
+# hoặc
+ck content start --force
+```
+
+### Bài không được đăng
+
+- Kiểm tra API credential qua `ck content setup`
+- Kiểm tra giờ nghỉ trong config — bài không đăng trong giờ nghỉ
+- Xem giới hạn `maxPostsPerDay`
+- Kiểm tra log: `ck content logs --tail`
+
+### Không tạo được content
+
+- Đảm bảo repo có hoạt động git gần đây
+- Kiểm tra `firstScanLookbackDays` nếu là lần chạy đầu
+- Xem phân loại event trong log — một số event có thể bị lọc là nhiễu
+
+## Khi Nào Nên Dùng
+
+- **Developer advocacy** — Tự động chia sẻ tốc độ ship của team
+- **Open source** — Cập nhật follower về release và tính năng mới
+- **Changelog broadcasting** — Biến release thành thông báo mạng xã hội
+- **Content marketing** — Tạo bài đăng nháp từ hoạt động phát triển
+
+## Giới Hạn
+
+- Platform hiện hỗ trợ X/Twitter và Facebook
+- Yêu cầu API key platform (tài khoản developer)
+- Chất lượng content phụ thuộc vào chất lượng commit message
+- Self-improvement cần lịch sử bài đăng đủ lớn
+
+## Liên Quan
+
+- [CLI Tổng Quan](/docs/cli)
+- [ck watch](/docs/cli/watch) — Giám sát GitHub issue tự động

--- a/src/content/docs-vi/cli/watch.md
+++ b/src/content/docs-vi/cli/watch.md
@@ -1,0 +1,217 @@
+---
+title: "ck watch"
+description: "Giám sát GitHub issue tự động, phân tích, lập kế hoạch và triển khai với AI"
+section: docs
+category: docs/cli
+order: 10
+published: true
+---
+
+# ck watch
+
+Giám sát GitHub issue tự động chạy dài hạn. Poll issue, phân tích với Claude, tạo kế hoạch, đợi chủ repo phê duyệt, rồi tự động triển khai qua PR.
+
+## Tổng Quan
+
+`ck watch` biến terminal thành trợ lý AI chạy qua đêm. Liên tục theo dõi GitHub issue của repository (hoặc nhiều repo), dùng Claude để phân tích và lập kế hoạch, đăng plan dưới dạng comment, và — khi chủ repo phê duyệt — tạo branch, triển khai code, và mở PR. Thiết kế cho hoạt động không giám sát 6-8+ giờ.
+
+## Cú Pháp
+
+```bash
+ck watch [options]
+```
+
+### Tùy Chọn
+
+| Flag | Mặc Định | Mô Tả |
+|------|----------|-------|
+| `--interval <ms>` | `30000` | Khoảng thời gian poll (ms) |
+| `--dry-run` | `false` | Phát hiện issue và ghi log, nhưng không đăng lên GitHub |
+| `--force` | `false` | Dừng process `ck watch` đang chạy và khởi động lại |
+| `--verbose` | `false` | Bật debug output |
+
+## Yêu Cầu
+
+- **GitHub CLI** (`gh`) đã cài đặt và xác thực
+- **Git** repository (hoặc thư mục chứa nhiều git repo cho chế độ multi-repo)
+- **Node.js 18+** / Bun runtime
+- **ClaudeKit Engineer** đã cài đặt trong project
+
+## Cách Hoạt Động
+
+### Vòng Đời Issue
+
+Mỗi issue đi qua các trạng thái:
+
+```
+new → brainstorming → clarifying → planning → plan_posted
+→ awaiting_approval → implementing → completed
+```
+
+### Quy Trình Chi Tiết
+
+1. **Poll** — Lấy danh sách issue mở từ GitHub qua `gh` CLI
+2. **Brainstorm** — Gọi Claude phân tích issue, đặt câu hỏi làm rõ
+3. **Clarify** — Nếu Claude cần thêm thông tin, đăng câu hỏi dưới dạng comment và đợi tác giả trả lời
+4. **Plan** — Khi đã hiểu vấn đề, Claude tạo kế hoạch triển khai
+5. **Post Plan** — Đăng plan dưới dạng GitHub comment, chuyển sang `awaiting_approval`
+6. **Approval** — Theo dõi comment phê duyệt từ chủ repo (dùng Claude để phát hiện ý định phê duyệt)
+7. **Implement** — Tạo branch, chạy `ck cook` với plan, push code
+8. **PR** — Mở pull request liên kết với issue gốc
+9. **Complete** — Đăng comment hoàn thành kèm link PR
+
+### Single-Repo vs Multi-Repo
+
+- **Single-repo**: Chạy `ck watch` trong git repository. Giám sát issue của repo đó.
+- **Multi-repo**: Chạy `ck watch` trong thư mục cha chứa nhiều git repo. Tự động phát hiện và giám sát tất cả sub-repo.
+
+## Cấu Hình
+
+Lưu trong `.ck.json` dưới key `watch`:
+
+```json
+{
+  "watch": {
+    "pollIntervalMs": 30000,
+    "maxTurnsPerIssue": 10,
+    "maxIssuesPerHour": 10,
+    "excludeAuthors": [],
+    "showBranding": true,
+    "logMaxBytes": 0,
+    "timeouts": {
+      "brainstormSec": 300,
+      "planSec": 600,
+      "implementSec": 18000
+    }
+  }
+}
+```
+
+| Key | Mặc Định | Mô Tả |
+|-----|----------|-------|
+| `pollIntervalMs` | `30000` | Tần suất kiểm tra issue mới (tối thiểu 10s) |
+| `maxTurnsPerIssue` | `10` | Số lượt hội thoại tối đa trước khi dừng |
+| `maxIssuesPerHour` | `10` | Giới hạn số issue xử lý mỗi giờ |
+| `excludeAuthors` | `[]` | Danh sách GitHub username bỏ qua |
+| `showBranding` | `true` | Hiển thị branding ClaudeKit trong comment |
+| `logMaxBytes` | `0` | Giới hạn kích thước log (0 = không giới hạn) |
+| `timeouts.brainstormSec` | `300` | Timeout phân tích (5 phút) |
+| `timeouts.planSec` | `600` | Timeout tạo plan (10 phút) |
+| `timeouts.implementSec` | `18000` | Timeout triển khai (5 giờ) |
+
+## Ví Dụ
+
+### Sử Dụng Cơ Bản
+
+```bash
+# Bắt đầu giám sát repo hiện tại
+ck watch
+
+# Tùy chỉnh khoảng thời gian poll (60 giây)
+ck watch --interval 60000
+
+# Test mà không đăng lên GitHub
+ck watch --dry-run
+
+# Khởi động lại nếu đã chạy
+ck watch --force
+```
+
+### Chạy Qua Đêm
+
+```bash
+# Bắt đầu watch trước khi đi ngủ
+ck watch --verbose 2>&1 | tee watch-session.log
+
+# Sáng hôm sau: kiểm tra kết quả
+cat ~/.claudekit/logs/ck-watch-*.log
+```
+
+### Multi-Repo
+
+```bash
+# Cấu trúc thư mục:
+# ~/projects/
+#   ├── api-server/      (git repo)
+#   ├── web-frontend/    (git repo)
+#   └── shared-utils/    (git repo)
+
+cd ~/projects
+ck watch
+# Giám sát cả 3 repo đồng thời
+```
+
+## Bảo Mật
+
+- **Process Lock** — Chỉ một instance `ck watch` chạy cùng lúc (`~/.claudekit/locks/ck-watch.lock`)
+- **Quét Credential** — Chặn đăng nếu phát hiện secret trong nội dung tạo ra
+- **Sanitize Input** — Cắt input xuống 8K ký tự, loại bỏ injection pattern
+- **Phát Hiện Comment Của Bot** — Dùng HTML marker (`<!-- ck-watch-bot -->`) để tránh trả lời chính mình
+- **Loại Bỏ Mention** — Xóa `@mention` khỏi output AI để tránh notification không mong muốn
+- **stdin-Only Claude** — Truyền prompt qua stdin, không qua command-line argument
+
+## Lưu Trữ Trạng Thái
+
+Trạng thái runtime lưu trong `.ck.json` dưới `watch.state`:
+
+- Issue đang hoạt động kèm trạng thái lifecycle
+- Lịch sử hội thoại (tối đa 10 tin nhắn mỗi issue)
+- Hàng đợi triển khai (issue đã phê duyệt chờ implement)
+- Danh sách issue đã xử lý (tối đa 500)
+
+Khi shutdown (Ctrl+C), issue đang xử lý được revert về trạng thái an toàn để tiếp tục lần chạy sau.
+
+## Log
+
+File log được ghi vào `~/.claudekit/logs/`:
+
+```
+~/.claudekit/logs/ck-watch-20260327.log
+```
+
+## Xử Lý Sự Cố
+
+### "Watch daemon already running"
+
+Có process `ck watch` khác đang chạy. Dùng `--force` để restart:
+
+```bash
+ck watch --force
+```
+
+### Issue không được phát hiện
+
+- Kiểm tra xác thực `gh`: `gh auth status`
+- Kiểm tra repo có issue mở: `gh issue list`
+- Xem danh sách `excludeAuthors` trong `.ck.json`
+
+### Triển khai thất bại
+
+- Kiểm tra `timeouts.implementSec` — issue phức tạp có thể cần hơn 5 giờ
+- Xem chi tiết lỗi trong log file
+- Issue sẽ revert về `awaiting_approval` để thử lại
+
+### Comment không được đăng
+
+- Đảm bảo `gh` có quyền write vào repository
+- Kiểm tra `--dry-run` không bật
+- Xem log để kiểm tra credential scanning block
+
+## Khi Nào Nên Dùng
+
+- **Xử lý qua đêm** — Tạo issue trước khi ngủ, sáng dậy có PR
+- **Triage liên tục** — Để Claude phân tích và lập kế hoạch trong khi bạn tập trung việc khác
+- **Giám sát multi-repo** — Theo dõi tất cả repo của team từ một terminal
+- **Hackathon mode** — Prototyping nhanh với AI hỗ trợ triển khai
+
+## Giới Hạn
+
+- Triển khai tuần tự (một issue mỗi lần)
+- Yêu cầu chủ repo phê duyệt cho mỗi lần triển khai
+- Giới hạn GitHub API rate limit qua `gh` CLI
+- Claude CLI phải khả dụng và đã xác thực
+
+## Liên Quan
+
+- [CLI Tổng Quan](/docs/cli)
+- [ck content](/docs/cli/content) — Tạo content tự động từ hoạt động git

--- a/src/content/docs/cli/content.md
+++ b/src/content/docs/cli/content.md
@@ -1,0 +1,272 @@
+---
+title: "ck content"
+description: "Autonomous content daemon that scans git activity and publishes to social media platforms"
+section: docs
+category: cli
+order: 11
+published: true
+---
+
+# ck content
+
+Autonomous content creation daemon. Scans git activity (commits, PRs, releases), generates platform-specific social media posts with Claude, and publishes to X/Twitter and Facebook.
+
+## Overview
+
+`ck content` is a background daemon that turns your development activity into social media content. It monitors git events across your repositories, uses Claude to craft engaging posts tailored to each platform, and publishes them on a configurable schedule. Supports review workflows (auto, manual, hybrid) and tracks engagement metrics for self-improvement.
+
+## Syntax
+
+```bash
+ck content <subcommand> [options]
+```
+
+### Subcommands
+
+| Command | Description |
+|---------|-------------|
+| `ck content start` | Launch the content daemon |
+| `ck content stop` | Stop a running daemon |
+| `ck content status` | Show daemon state, config summary, and last scan time |
+| `ck content logs` | Print today's content log |
+| `ck content setup` | Interactive onboarding wizard for platform configuration |
+| `ck content queue` | List pending review items |
+| `ck content approve <id>` | Approve a content item for publishing |
+| `ck content reject <id> [reason]` | Reject a content item |
+
+### Global Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Generate content but never publish |
+| `--verbose` | `false` | Enable debug output |
+| `--force` | `false` | Kill existing daemon and start fresh |
+| `--tail` | `false` | Follow log output in real-time (for `logs` subcommand) |
+
+## Prerequisites
+
+- **GitHub CLI** (`gh`) installed and authenticated
+- **Git** repository (or directory containing git repos)
+- **Platform API credentials** configured via `ck content setup`:
+  - X/Twitter: API key, API secret, access token, access secret
+  - Facebook: Page access token, Page ID
+
+## How It Works
+
+### Content Pipeline
+
+```
+Git Scan → Event Classification → Content Creation → Review → Publish → Engage
+```
+
+### Step-by-Step Flow
+
+1. **Git Scan** — Scans repositories for new commits, merged PRs, tags, releases, and completed plans
+2. **Event Classification** — Filters noise, classifies events by importance (high/medium/low)
+3. **Content Creation** — Claude generates platform-specific posts with hashtags, hook lines, and CTAs
+4. **Review** — Based on `reviewMode`:
+   - `auto` — Publishes immediately if quality checks pass
+   - `manual` — Queues for human approval via `ck content queue/approve/reject`
+   - `hybrid` — Auto-publishes high-confidence content, queues borderline items
+5. **Publish** — Posts to enabled platforms respecting rate limits and quiet hours
+6. **Engagement Tracking** — Periodically checks post performance and feeds insights back into content generation
+
+### Supported Git Events
+
+| Event Type | Trigger | Example |
+|-----------|---------|---------|
+| `commit` | New commits on default branch | Feature commits, bug fixes |
+| `pr_merged` | Pull request merged | Feature PRs, dependency updates |
+| `tag` | New git tag created | Version releases |
+| `release` | GitHub release published | Major releases |
+| `plan_completed` | ClaudeKit plan marked done | Milestone completions |
+
+### Supported Platforms
+
+| Platform | Post Types | Limits |
+|----------|-----------|--------|
+| **X/Twitter** | Single posts, threads (up to 6 parts) | 280 chars/post, configurable max posts/day |
+| **Facebook** | Page posts | Configurable max posts/day |
+
+## Configuration
+
+Stored in `.ck.json` under the `content` key:
+
+```json
+{
+  "content": {
+    "enabled": false,
+    "pollIntervalMs": 60000,
+    "platforms": {
+      "x": {
+        "enabled": false,
+        "maxPostsPerDay": 5,
+        "threadMaxParts": 6
+      },
+      "facebook": {
+        "enabled": false,
+        "maxPostsPerDay": 3
+      }
+    },
+    "reviewMode": "auto",
+    "schedule": {
+      "timezone": "UTC",
+      "quietHoursStart": "23:00",
+      "quietHoursEnd": "06:00"
+    },
+    "selfImprovement": {
+      "enabled": true,
+      "engagementCheckIntervalHours": 6,
+      "topPerformingCount": 10
+    },
+    "firstScanLookbackDays": 30,
+    "maxContentPerDay": 10,
+    "contentDir": "~/.claudekit/content/",
+    "dbPath": "~/.claudekit/content.db"
+  }
+}
+```
+
+### Key Configuration Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Master switch (set via `ck content setup`) |
+| `pollIntervalMs` | `60000` | Git scan interval (1 minute) |
+| `reviewMode` | `auto` | Content approval mode: `auto`, `manual`, `hybrid` |
+| `schedule.timezone` | `UTC` | Timezone for quiet hours |
+| `schedule.quietHoursStart` | `23:00` | No publishing after this time |
+| `schedule.quietHoursEnd` | `06:00` | Resume publishing after this time |
+| `firstScanLookbackDays` | `30` | Days to scan on first run |
+| `maxContentPerDay` | `10` | Global daily post limit across all platforms |
+| `selfImprovement.enabled` | `true` | Learn from engagement metrics |
+
+## Examples
+
+### Getting Started
+
+```bash
+# Interactive setup — configure platforms and API keys
+ck content setup
+
+# Start the daemon
+ck content start
+
+# Check status
+ck content status
+```
+
+### Manual Review Workflow
+
+```bash
+# Set reviewMode to "manual" in .ck.json, then:
+ck content start
+
+# Check pending content
+ck content queue
+
+# Approve or reject
+ck content approve 42
+ck content reject 43 "Too promotional"
+```
+
+### Monitoring
+
+```bash
+# View today's logs
+ck content logs
+
+# Follow logs in real-time
+ck content logs --tail
+
+# Test without publishing
+ck content start --dry-run --verbose
+```
+
+### Daemon Management
+
+```bash
+# Stop the daemon
+ck content stop
+
+# Force restart
+ck content start --force
+```
+
+## Content Lifecycle
+
+Each piece of content flows through these states:
+
+```
+draft → scheduled → reviewing → approved → publishing → published
+                                                      → failed (retries up to 3x within 24h)
+```
+
+## Database
+
+Content data is stored in a SQLite database at `~/.claudekit/content.db`:
+
+- **git_events** — Tracked git activity with importance classification
+- **content_items** — Generated posts with platform, text, hashtags, status
+- **publications** — Published post references (post ID, URL, timestamp)
+
+Data retention cleanup runs automatically every 24 hours.
+
+## Security
+
+- **Process Lock** — Only one daemon instance at a time (`~/.claudekit/locks/ck-content.lock`)
+- **Credential Isolation** — Platform API keys stored separately, never in git
+- **Rate Limiting** — Per-platform daily limits and configurable quiet hours
+- **Retry Protection** — Failed content creation retries max 3 times, failed publishing retries within 24h window
+
+## Troubleshooting
+
+### "Content engine not enabled"
+
+Run the setup wizard first:
+
+```bash
+ck content setup
+```
+
+### "Content daemon already running"
+
+Stop or force-restart:
+
+```bash
+ck content stop
+# or
+ck content start --force
+```
+
+### Posts not publishing
+
+- Verify platform API credentials via `ck content setup`
+- Check quiet hours in config — posts won't publish during quiet hours
+- Review `maxPostsPerDay` limits
+- Check logs: `ck content logs --tail`
+
+### No content generated
+
+- Ensure the repo has recent git activity
+- Check `firstScanLookbackDays` if this is the first run
+- Review event classification in logs — some events may be filtered as noise
+
+## When to Use
+
+- **Developer advocacy** — Auto-share your team's shipping velocity
+- **Open source projects** — Keep followers updated on releases and features
+- **Changelog broadcasting** — Turn releases into social announcements
+- **Content marketing** — Generate draft posts from development activity
+
+## Limitations
+
+- Platforms currently limited to X/Twitter and Facebook
+- Requires platform API keys (developer accounts)
+- Content quality depends on git commit message quality
+- Self-improvement requires sufficient published post history
+
+## Related
+
+- [CLI Overview](/docs/cli)
+- [ck watch](/docs/cli/watch) — Autonomous GitHub issue monitor

--- a/src/content/docs/cli/watch.md
+++ b/src/content/docs/cli/watch.md
@@ -1,0 +1,219 @@
+---
+title: "ck watch"
+description: "Autonomous GitHub issue monitor that polls, analyzes, plans, and implements issues with AI"
+section: docs
+category: cli
+order: 10
+published: true
+---
+
+# ck watch
+
+Autonomous long-running GitHub issue monitor. Polls issues, brainstorms with Claude, generates plans, waits for owner approval, then auto-implements via PR.
+
+## Overview
+
+`ck watch` turns your terminal into an overnight AI assistant. It continuously monitors GitHub issues for a repository (or multiple repos), uses Claude to analyze and plan solutions, posts the plan as a comment, and — once the repo owner approves — creates a branch, implements the fix, and opens a PR. Designed for 6-8+ hour unattended operation.
+
+## Syntax
+
+```bash
+ck watch [options]
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--interval <ms>` | `30000` | Poll interval in milliseconds |
+| `--dry-run` | `false` | Detect issues and log actions, but never post to GitHub |
+| `--force` | `false` | Kill any existing `ck watch` process and start fresh |
+| `--verbose` | `false` | Enable debug output |
+
+## Prerequisites
+
+- **GitHub CLI** (`gh`) installed and authenticated
+- **Git** repository (or directory containing git repos for multi-repo mode)
+- **Node.js 18+** / Bun runtime
+- **ClaudeKit Engineer** installed in the project
+
+## How It Works
+
+### Issue Lifecycle
+
+Every issue goes through a defined lifecycle:
+
+```
+new → brainstorming → clarifying → planning → plan_posted
+→ awaiting_approval → implementing → completed
+```
+
+### Step-by-Step Flow
+
+1. **Poll** — Fetches open issues from GitHub via `gh` CLI
+2. **Brainstorm** — Invokes Claude to analyze the issue, ask clarifying questions
+3. **Clarify** — If Claude needs more info, posts questions as a comment and waits for the author's reply
+4. **Plan** — Once the problem is understood, Claude generates an implementation plan
+5. **Post Plan** — Posts the plan as a GitHub comment, transitions to `awaiting_approval`
+6. **Approval** — Monitors for the repo owner's approval comment (uses Claude to detect approval intent)
+7. **Implement** — Creates a branch, runs `ck cook` with the plan, pushes code
+8. **PR** — Opens a pull request linking the original issue
+9. **Complete** — Posts a completion comment with the PR link
+
+### Single-Repo vs Multi-Repo
+
+- **Single-repo**: Run `ck watch` inside a git repository. Monitors that repo's issues.
+- **Multi-repo**: Run `ck watch` in a parent directory containing multiple git repos. Discovers and monitors all sub-repos.
+
+## Configuration
+
+Stored in `.ck.json` under the `watch` key:
+
+```json
+{
+  "watch": {
+    "pollIntervalMs": 30000,
+    "maxTurnsPerIssue": 10,
+    "maxIssuesPerHour": 10,
+    "excludeAuthors": [],
+    "showBranding": true,
+    "logMaxBytes": 0,
+    "timeouts": {
+      "brainstormSec": 300,
+      "planSec": 600,
+      "implementSec": 18000
+    }
+  }
+}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `pollIntervalMs` | `30000` | How often to check for new issues (min 10s) |
+| `maxTurnsPerIssue` | `10` | Max conversation turns before giving up |
+| `maxIssuesPerHour` | `10` | Rate limit for new issue processing |
+| `excludeAuthors` | `[]` | GitHub usernames to ignore |
+| `showBranding` | `true` | Include ClaudeKit branding in posted comments |
+| `logMaxBytes` | `0` | Log file size limit (0 = unlimited) |
+| `timeouts.brainstormSec` | `300` | Brainstorm phase timeout (5 min) |
+| `timeouts.planSec` | `600` | Plan generation timeout (10 min) |
+| `timeouts.implementSec` | `18000` | Implementation timeout (5 hours) |
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Start watching current repo
+ck watch
+
+# Custom poll interval (60 seconds)
+ck watch --interval 60000
+
+# Test without posting to GitHub
+ck watch --dry-run
+
+# Restart if already running
+ck watch --force
+```
+
+### Overnight Workflow
+
+```bash
+# Start watch before leaving for the night
+ck watch --verbose 2>&1 | tee watch-session.log
+
+# Next morning: check what happened
+cat ~/.claudekit/logs/ck-watch-*.log
+```
+
+### Multi-Repo Setup
+
+```bash
+# Directory structure:
+# ~/projects/
+#   ├── api-server/      (git repo)
+#   ├── web-frontend/    (git repo)
+#   └── shared-utils/    (git repo)
+
+cd ~/projects
+ck watch
+# Monitors all 3 repos simultaneously
+```
+
+## Security Features
+
+- **Process Lock** — Only one `ck watch` instance can run at a time (`~/.claudekit/locks/ck-watch.lock`)
+- **Credential Scanning** — Blocks posting if secrets are detected in generated content
+- **Input Sanitization** — Truncates input to 8K characters, strips injection patterns
+- **Own-Comment Detection** — Uses HTML markers (`<!-- ck-watch-bot -->`) to avoid responding to its own comments
+- **Mention Stripping** — Removes `@mentions` from AI output to prevent unwanted notifications
+- **stdin-Only Claude** — Passes prompts via stdin, never as command-line arguments
+
+## State Persistence
+
+Runtime state is saved to `.ck.json` under `watch.state`:
+
+- Active issues with their current lifecycle status
+- Conversation history (capped at 10 messages per issue)
+- Implementation queue (approved issues waiting to be implemented)
+- Processed issues list (capped at 500 to prevent unbounded growth)
+
+On graceful shutdown (`Ctrl+C`), in-progress issues revert to safe states so they can be resumed on next run.
+
+## Logging
+
+Log files are written to `~/.claudekit/logs/`:
+
+```
+~/.claudekit/logs/ck-watch-20260327.log
+```
+
+Logs include timestamps, log levels, and structured context for each action.
+
+## Troubleshooting
+
+### "Watch daemon already running"
+
+Another `ck watch` process is active. Use `--force` to kill it and restart:
+
+```bash
+ck watch --force
+```
+
+### Issues not being picked up
+
+- Verify `gh` authentication: `gh auth status`
+- Check the repo has open issues: `gh issue list`
+- Review excluded authors in `.ck.json`
+
+### Implementation fails
+
+- Check `timeouts.implementSec` — complex issues may need more than 5 hours
+- Review the log file for error details
+- The issue will revert to `awaiting_approval` so you can retry
+
+### Comments not posted
+
+- Ensure `gh` has write permissions to the repository
+- Check `--dry-run` is not enabled
+- Review logs for credential scanning blocks
+
+## When to Use
+
+- **Overnight processing** — Queue up issues before bed, wake up to PRs
+- **Continuous triage** — Let Claude brainstorm and plan while you focus on other work
+- **Multi-repo monitoring** — Watch all your team's repos from a single terminal
+- **Hackathon mode** — Rapid prototyping with AI-assisted implementation
+
+## Limitations
+
+- Sequential implementation only (one issue at a time)
+- Requires repo owner approval for each implementation
+- GitHub API rate limits apply via `gh` CLI
+- Claude CLI must be available and authenticated
+
+## Related
+
+- [CLI Overview](/docs/cli)
+- [ck content](/docs/cli/content) — Autonomous content creation from git activity


### PR DESCRIPTION
## Summary
- Move `watch.md` and `content.md` from wrong path `src/content/docs/docs/cli/` to correct `src/content/docs/cli/` (EN + VI)
- Remove broken links to non-existent `/docs/commands/content/fast` and `/docs/commands/content/good`
- Fixes #124 Docker build failure (8 broken internal links detected by build-time validator)

## Test plan
- [x] `bun run build` passes locally with 0 broken links (2022 links validated across 490 files)