### PR TITLE
fix: ck watch and ck content missing from CLI sidebar

### DIFF
--- a/src/content/docs-vi/cli/content.md
+++ b/src/content/docs-vi/cli/content.md
@@ -1,8 +1,7 @@
 ---
 title: "ck content"
 description: "Daemon tạo content tự động từ hoạt động git và đăng lên mạng xã hội"
-section: docs
-category: docs/cli
+section: cli
 order: 11
 published: true
 ---

--- a/src/content/docs-vi/cli/watch.md
+++ b/src/content/docs-vi/cli/watch.md
@@ -1,8 +1,7 @@
 ---
 title: "ck watch"
 description: "Giám sát GitHub issue tự động, phân tích, lập kế hoạch và triển khai với AI"
-section: docs
-category: docs/cli
+section: cli
 order: 10
 published: true
 ---

--- a/src/content/docs/cli/content.md
+++ b/src/content/docs/cli/content.md
@@ -1,8 +1,7 @@
 ---
 title: "ck content"
 description: "Autonomous content daemon that scans git activity and publishes to social media platforms"
-section: docs
-category: cli
+section: cli
 order: 11
 published: true
 ---

--- a/src/content/docs/cli/watch.md
+++ b/src/content/docs/cli/watch.md
@@ -1,8 +1,7 @@
 ---
 title: "ck watch"
 description: "Autonomous GitHub issue monitor that polls, analyzes, plans, and implements issues with AI"
-section: docs
-category: cli
+section: cli
 order: 10
 published: true
 ---


### PR DESCRIPTION
## Summary
`section: docs` → `section: cli` in frontmatter of `ck watch` and `ck content` (EN + VI).

Without this, the sidebar nav ignores these pages (filtered by section key).

## Test plan
- [x] Build passes locally
- [ ] Verify sidebar shows "ck watch" and "ck content" on live site