### PR TITLE
docs(cli): add ck migrate command documentation

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -30,6 +30,7 @@ Command-line interface documentation:
 - [ck uninstall](https://docs.claudekit.cc/docs/cli/uninstall.md): Remove ClaudeKit
 - [ck doctor](https://docs.claudekit.cc/docs/cli/doctor.md): Diagnose and fix issues
 - [ck versions](https://docs.claudekit.cc/docs/cli/versions.md): Version management
+- [ck migrate](https://docs.claudekit.cc/docs/cli/migrate.md): Migrate portable content to other AI coding providers
 - [Configuration](https://docs.claudekit.cc/docs/cli/configuration.md): CLI configuration options
 
 ## Engineer Kit

--- a/src/content/docs-vi/cli/migrate.md
+++ b/src/content/docs-vi/cli/migrate.md
@@ -1,0 +1,204 @@
+---
+title: "ck migrate"
+description: "Di chuyển agents, commands, skills, config, rules và hooks sang các AI coding provider khác với hệ thống đối soát thông minh"
+section: cli
+order: 9
+lang: vi
+---
+
+# ck migrate
+
+> Di chuyển toàn bộ nội dung portable của ClaudeKit (agents, commands, skills, config, rules, hooks) sang các AI coding provider khác với hệ thống đối soát thông minh và xử lý xung đột.
+
+## Bắt Đầu Nhanh
+
+```bash
+# Chế độ tương tác (tự phát hiện provider đã cài)
+ck migrate
+
+# Di chuyển sang provider cụ thể
+ck migrate --agent cursor --agent codex
+
+# Di chuyển sang tất cả provider, cài global
+ck migrate --all --global
+
+# Xem trước kế hoạch di chuyển mà không ghi file
+ck migrate --dry-run
+
+# Chế độ không tương tác
+ck migrate --yes
+```
+
+## Quy Trình Hoạt Động
+
+Lệnh `ck migrate`:
+
+1. **Phát hiện** tất cả portable items từ thư mục `.claude/` (agents, commands, skills, config, rules, hooks)
+2. **Dò tìm** các AI coding provider đã cài trên hệ thống
+3. **Tính toán** kế hoạch đối soát so sánh source vs target
+4. **Giải quyết** xung đột tương tác (hoặc tự động với `--yes`)
+5. **Cài đặt** nội dung đã chuyển đổi sang định dạng của từng provider
+6. **Gộp** cấu hình hooks vào `settings.json` của provider
+7. **Dọn dẹp** registry cũ và đường dẫn deprecated
+
+## Provider Được Hỗ Trợ
+
+| Provider | Agents | Commands | Skills | Config | Rules | Hooks |
+|----------|--------|----------|--------|--------|-------|-------|
+| Claude Code | Co | Co | Co | Co | Co | Co |
+| OpenCode | Co | Co | Co | Co | Co | Co |
+| GitHub Copilot | Co | Co | Co | Co | Co | - |
+| Codex | Co | Co | Co | Co | Co | - |
+| Droid | Co | Co | Co | Co | Co | - |
+| Cursor | Co | Co | Co | Co | Co | - |
+| Roo Code | Co | Co | Co | Co | Co | - |
+| Kilo Code | Co | Co | Co | Co | Co | - |
+| Windsurf | Co | Co | Co | Co | Co | - |
+| Goose | Co | - | - | Co | Co | - |
+| Gemini CLI | Co | - | - | Co | Co | - |
+| Amp | Co | - | - | Co | Co | - |
+| Antigravity | Co | - | - | Co | Co | - |
+| Cline | Co | - | - | Co | Co | - |
+| OpenHands | Co | - | - | Co | Co | - |
+
+## Tùy Chọn
+
+### Tùy Chọn Target
+
+| Flag | Mô tả |
+|------|-------|
+| `-a, --agent <provider>` | Provider đích, có thể chỉ định nhiều lần |
+| `--all` | Di chuyển sang tất cả provider |
+| `-g, --global` | Cài global thay vì project-level |
+| `-y, --yes` | Bỏ qua xác nhận |
+| `-f, --force` | Buộc cài lại các item đã xóa/chỉnh sửa |
+| `--dry-run` | Xem trước kế hoạch, không ghi file |
+
+### Chọn Nội Dung
+
+| Flag | Mô tả |
+|------|-------|
+| `--config` | Chỉ di chuyển config CLAUDE.md |
+| `--rules` | Chỉ di chuyển `.claude/rules/` |
+| `--hooks` | Chỉ di chuyển `.claude/hooks/` |
+| `--skip-config` | Bỏ qua config |
+| `--skip-rules` | Bỏ qua rules |
+| `--skip-hooks` | Bỏ qua hooks |
+| `--source <path>` | Đường dẫn CLAUDE.md tùy chỉnh |
+
+## Logic Chọn Nội Dung
+
+Các flag chọn nội dung tuân theo bảng logic chính xác:
+
+**Chế độ "Only"** — khi chỉ định `--config`, `--rules`, `--hooks`:
+- `--config` — chỉ config (không agents/commands/skills/rules/hooks)
+- `--rules` — chỉ rules
+- `--hooks` — chỉ hooks
+- `--config --rules` — chỉ config VÀ rules
+- `--config --hooks` — chỉ config VÀ hooks
+- `--config --rules --hooks` — chỉ config, rules VÀ hooks
+
+**Chế độ "Skip"** — khi sử dụng `--skip-*`:
+- `--skip-config` — mọi thứ trừ config
+- `--skip-rules` — mọi thứ trừ rules
+- `--skip-hooks` — mọi thứ trừ hooks
+
+**Mặc định** (không flag) — di chuyển tất cả.
+
+## Hệ Thống Đối Soát (Reconciliation)
+
+Lệnh migrate sử dụng engine đối soát phức tạp:
+
+1. **Tính checksum** cho cả source items và target files
+2. **So sánh trạng thái** với portable registry để phát hiện:
+   - Items mới cần cài
+   - Items đã cập nhật cần refresh
+   - Items không đổi, bỏ qua
+   - Items đã xóa cần dọn
+   - Xung đột cần giải quyết
+3. **Tạo kế hoạch** hiển thị mọi action trước khi thực thi
+
+### Giải Quyết Xung Đột
+
+Khi target file bị chỉnh sửa bên ngoài, lệnh đưa ra các lựa chọn:
+- **Overwrite** — ghi đè bằng nội dung source
+- **Smart merge** — thử gộp thay đổi
+- **Skip** — giữ nguyên nội dung hiện tại
+- **View diff** — xem khác biệt trước khi quyết định
+
+## Ví Dụ
+
+### Di chuyển tất cả sang Cursor
+
+```bash
+ck migrate --agent cursor
+```
+
+### Di chuyển config và rules sang tất cả provider
+
+```bash
+ck migrate --all --config --rules
+```
+
+### Buộc di chuyển lại hooks globally
+
+```bash
+ck migrate --all --global --hooks --force
+```
+
+### Xem trước thay đổi
+
+```bash
+ck migrate --dry-run
+```
+
+### Di chuyển sang nhiều provider cụ thể
+
+```bash
+ck migrate --agent droid --agent codex --agent cursor
+```
+
+### Bỏ qua hooks khi di chuyển
+
+```bash
+ck migrate --all --skip-hooks
+```
+
+### Dùng CLAUDE.md tùy chỉnh
+
+```bash
+ck migrate --agent cursor --source ./custom/CLAUDE.md
+```
+
+## Các Giai Đoạn Di Chuyển
+
+### Giai đoạn 1: Phát Hiện
+Quét `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.claude/rules/`, `.claude/hooks/`, và `CLAUDE.md` tìm nội dung portable.
+
+### Giai đoạn 2: Chọn Provider
+Tự phát hiện provider đã cài hoặc hiển thị prompt chọn. Dùng `--agent` hoặc `--all` để bỏ qua.
+
+### Giai đoạn 3: Chọn Phạm Vi
+Chọn project-level (`.claude/` trong CWD) hoặc global (`~/.claude/`).
+
+### Giai đoạn 4: Đối Soát
+Tính toán kế hoạch di chuyển dùng checksums và trạng thái registry. Hiển thị các action (install, update, skip, delete, conflict).
+
+### Giai đoạn 5: Thực Thi
+Cài items, gộp hook settings, xử lý metadata deletions, dọn entries cũ.
+
+### Giai đoạn 6: Tổng Kết
+Hiển thị kết quả với số lượng thành công/bỏ qua/thất bại và đề xuất rollback khi lỗi một phần.
+
+## Rollback Khi Lỗi
+
+Nếu một số items lỗi trong khi số khác thành công, lệnh đề xuất rollback:
+- **File mới** được xóa
+- **File đã ghi đè** được giữ (không thể rollback)
+- Registry entries được dọn dẹp
+
+## Lệnh Liên Quan
+
+- [ck init](/vi/docs/cli/init) — Khởi tạo hoặc cập nhật ClaudeKit
+- [ck uninstall](/vi/docs/cli/uninstall) — Gỡ cài đặt ClaudeKit
+- [ck doctor](/vi/docs/cli/doctor) — Chẩn đoán vấn đề cài đặt

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -1,0 +1,203 @@
+---
+title: "ck migrate"
+description: "Migrate agents, commands, skills, config, rules, and hooks to other AI coding providers with smart reconciliation"
+section: cli
+order: 9
+---
+
+# ck migrate
+
+> One-shot migration of all ClaudeKit portable content (agents, commands, skills, config, rules, hooks) to other AI coding providers with intelligent reconciliation and conflict resolution.
+
+## Quick Start
+
+```bash
+# Interactive mode (auto-detects installed providers)
+ck migrate
+
+# Migrate to specific providers
+ck migrate --agent cursor --agent codex
+
+# Migrate to all supported providers globally
+ck migrate --all --global
+
+# Preview migration plan without writing files
+ck migrate --dry-run
+
+# Non-interactive with sensible defaults
+ck migrate --yes
+```
+
+## What Happens
+
+The `ck migrate` command:
+
+1. **Discovers** all portable items from your `.claude/` directory (agents, commands, skills, config, rules, hooks)
+2. **Detects** installed AI coding providers on your system
+3. **Computes** a reconciliation plan comparing source vs target states
+4. **Resolves** conflicts interactively (or auto-resolves with `--yes`)
+5. **Installs** converted content to each target provider's format
+6. **Merges** hook settings into provider-specific `settings.json`
+7. **Cleans up** stale registry entries and deprecated paths
+
+## Supported Providers
+
+| Provider | Agents | Commands | Skills | Config | Rules | Hooks |
+|----------|--------|----------|--------|--------|-------|-------|
+| Claude Code | Yes | Yes | Yes | Yes | Yes | Yes |
+| OpenCode | Yes | Yes | Yes | Yes | Yes | Yes |
+| GitHub Copilot | Yes | Yes | Yes | Yes | Yes | - |
+| Codex | Yes | Yes | Yes | Yes | Yes | - |
+| Droid | Yes | Yes | Yes | Yes | Yes | - |
+| Cursor | Yes | Yes | Yes | Yes | Yes | - |
+| Roo Code | Yes | Yes | Yes | Yes | Yes | - |
+| Kilo Code | Yes | Yes | Yes | Yes | Yes | - |
+| Windsurf | Yes | Yes | Yes | Yes | Yes | - |
+| Goose | Yes | - | - | Yes | Yes | - |
+| Gemini CLI | Yes | - | - | Yes | Yes | - |
+| Amp | Yes | - | - | Yes | Yes | - |
+| Antigravity | Yes | - | - | Yes | Yes | - |
+| Cline | Yes | - | - | Yes | Yes | - |
+| OpenHands | Yes | - | - | Yes | Yes | - |
+
+## Options
+
+### Target Options
+
+| Flag | Description |
+|------|-------------|
+| `-a, --agent <provider>` | Target provider(s), can be specified multiple times |
+| `--all` | Migrate to all supported providers |
+| `-g, --global` | Install globally instead of project-level |
+| `-y, --yes` | Skip confirmation prompts |
+| `-f, --force` | Force reinstall deleted/edited items |
+| `--dry-run` | Preview migration plan without writing files |
+
+### Content Selection
+
+| Flag | Description |
+|------|-------------|
+| `--config` | Migrate CLAUDE.md config only |
+| `--rules` | Migrate `.claude/rules/` only |
+| `--hooks` | Migrate `.claude/hooks/` only |
+| `--skip-config` | Skip config migration |
+| `--skip-rules` | Skip rules migration |
+| `--skip-hooks` | Skip hooks migration |
+| `--source <path>` | Custom CLAUDE.md source path |
+
+## Content Selection Logic
+
+The content selection flags follow a precise truth table:
+
+**"Only" mode** — when any of `--config`, `--rules`, `--hooks` are specified:
+- `--config` — only config (no agents/commands/skills/rules/hooks)
+- `--rules` — only rules
+- `--hooks` — only hooks
+- `--config --rules` — only config AND rules
+- `--config --hooks` — only config AND hooks
+- `--config --rules --hooks` — only config, rules, AND hooks
+
+**"Skip" mode** — when any of `--skip-*` flags are used:
+- `--skip-config` — everything except config
+- `--skip-rules` — everything except rules
+- `--skip-hooks` — everything except hooks
+
+**Default** (no flags) — migrates everything.
+
+## Reconciliation Engine
+
+The migrate command uses a sophisticated reconciliation engine that:
+
+1. **Computes checksums** for both source items and target files
+2. **Compares states** against the portable registry to detect:
+   - New items to install
+   - Updated items needing refresh
+   - Unchanged items to skip
+   - Deleted items to clean up
+   - Conflicts requiring resolution
+3. **Generates a plan** showing all actions before execution
+
+### Conflict Resolution
+
+When a target file has been modified externally, the command offers:
+- **Overwrite** — replace with source content
+- **Smart merge** — attempt to merge changes
+- **Skip** — keep existing content
+- **View diff** — see the differences before deciding
+
+## Examples
+
+### Migrate everything to Cursor
+
+```bash
+ck migrate --agent cursor
+```
+
+### Migrate config and rules to all providers
+
+```bash
+ck migrate --all --config --rules
+```
+
+### Force re-migrate hooks globally
+
+```bash
+ck migrate --all --global --hooks --force
+```
+
+### Preview what would change
+
+```bash
+ck migrate --dry-run
+```
+
+### Migrate to multiple specific providers
+
+```bash
+ck migrate --agent droid --agent codex --agent cursor
+```
+
+### Skip hooks during migration
+
+```bash
+ck migrate --all --skip-hooks
+```
+
+### Use custom CLAUDE.md source
+
+```bash
+ck migrate --agent cursor --source ./custom/CLAUDE.md
+```
+
+## Migration Phases
+
+### Phase 1: Discovery
+Scans `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.claude/rules/`, `.claude/hooks/`, and `CLAUDE.md` for portable content.
+
+### Phase 2: Provider Selection
+Auto-detects installed providers or prompts for selection. Use `--agent` or `--all` to skip detection.
+
+### Phase 3: Scope Selection
+Choose between project-level (`.claude/` in CWD) or global (`~/.claude/`) installation.
+
+### Phase 4: Reconciliation
+Computes a migration plan using checksums and registry state. Displays actions (install, update, skip, delete, conflict).
+
+### Phase 5: Execution
+Installs items, merges hook settings, processes metadata deletions, and cleans up stale entries.
+
+### Phase 6: Summary
+Displays results with success/skip/failure counts and offers rollback on partial failures.
+
+## Rollback on Failure
+
+If some items fail while others succeed, the command offers a rollback option:
+- **New writes** are removed
+- **Overwritten files** are preserved (cannot be rolled back)
+- Registry entries are cleaned up
+
+## Related Commands
+
+- [ck init](/docs/cli/init) — Initialize or update ClaudeKit
+- [ck uninstall](/docs/cli/uninstall) — Remove ClaudeKit installations
+- [ck doctor](/docs/cli/doctor) — Diagnose installation issues


### PR DESCRIPTION
## Summary
- Add comprehensive EN + VI documentation for `ck migrate` command
- Cover 15 supported providers, content selection logic, reconciliation engine, conflict resolution, rollback
- Update `llms.txt` with migrate link

## Test plan
- [x] `bun run build` passes
- [x] EN page renders at `/docs/cli/migrate`
- [x] VI page renders at `/vi/docs/cli/migrate`
- [x] llms.txt updated with new link