### PR TITLE
docs: clarify scout-block project .ckignore overrides

### DIFF
--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -195,10 +195,10 @@ ClaudeKit Engineer ships with hooks organized by event type. All hook files live
 **Purpose:** Blocks file system access to directories listed in `.ckignore`. Allows build commands (e.g., `npm run build`) to pass through.
 
 **What it does:**
-- Reads `.ckignore` to get blocked directory patterns
+- Reads the shipped `.ckignore` baseline and then layers an optional project-root `.ckignore` override
 - Blocks Read/Edit/Write/Glob/Grep operations on matched paths
 - Allows Bash commands that are recognized build/test commands
-- Returns a clear error message explaining which path is blocked and why
+- Returns a clear error message explaining which path is blocked and which `.ckignore` file to edit
 
 ---
 


### PR DESCRIPTION
## Summary

- document that scout-block uses the git-root `./.claude/.ckignore` as the project-local Claude override path
- clarify that blocked output points users to the exact tool-local `.ckignore` file to edit

## Context

Source change: claudekit/claudekit-engineer#623
Source PR: claudekit/claudekit-engineer#624