### PR TITLE
docs: correct scout-block git-root override path

### DIFF
--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -195,7 +195,7 @@ ClaudeKit Engineer ships with hooks organized by event type. All hook files live
 **Purpose:** Blocks file system access to directories listed in `.ckignore`. Allows build commands (e.g., `npm run build`) to pass through.
 
 **What it does:**
-- Reads the shipped `.ckignore` baseline and then layers an optional project-root `.ckignore` override
+- Reads the shipped `.ckignore` baseline and then layers an optional git-root `./.claude/.ckignore` override
 - Blocks Read/Edit/Write/Glob/Grep operations on matched paths
 - Allows Bash commands that are recognized build/test commands
 - Returns a clear error message explaining which path is blocked and which `.ckignore` file to edit


### PR DESCRIPTION
## Summary

- correct the scout-block docs to point at the git-root `./.claude/.ckignore` project-local override path
- keep the public hooks docs aligned with claudekit-engineer PR #624 after the red-team fix

## Context

Source change: claudekit/claudekit-engineer#623
Source PR: claudekit/claudekit-engineer#624
Supersedes the earlier merged wording in claudekit-docs#132.
