### PR TITLE
docs(engineer): document deep and tdd workflows

### DIFF
--- a/src/content/docs/engineer/skills/ck-plan.md
+++ b/src/content/docs/engineer/skills/ck-plan.md
@@ -23,10 +23,13 @@ Planning produces complete project blueprints: `plan.md` overview plus `phase-XX
 | `--auto` | Auto-detect | Follows mode | Follows mode | Follows mode | `--auto` |
 | `--fast` | Fast | Skip | Skip | Skip | `--auto` |
 | `--hard` | Hard | 2 researchers | Yes | Optional | (none) |
+| `--deep` | Deep | 2-3 researchers + per-phase scout | Yes | Yes | (none) |
 | `--parallel` | Parallel | 2 researchers | Yes | Optional | `--parallel` |
 | `--two` | Two approaches | 2+ researchers | After selection | After selection | (none) |
 
-Add `--no-tasks` to any mode to skip task hydration after plan creation.
+Composable flags:
+- `--tdd` — add tests-first structure to each phase for regression-safe refactors
+- `--no-tasks` — skip task hydration after plan creation
 
 ## Usage
 
@@ -37,6 +40,8 @@ Add `--no-tasks` to any mode to skip task hydration after plan creation.
 **Examples:**
 - `/ck:plan "add Stripe subscription billing" --fast`
 - `/ck:plan "migrate from REST to GraphQL" --hard`
+- `/ck:plan "untangle the notification pipeline" --deep`
+- `/ck:plan "refactor auth middleware safely" --tdd`
 - `/ck:plan "implement real-time notifications + presence" --parallel`
 - `/ck:plan "redesign auth system" --two`
 - `/ck:plan "scaffold new microservice" --auto --no-tasks`
@@ -51,10 +56,10 @@ Pre-Creation Check → Mode Detection → Research Phase
 
 1. **Pre-Creation Check** — scan existing plans to avoid duplication
 2. **Mode Detection** — interpret flags or auto-select based on task complexity
-3. **Research Phase** — spawn parallel researchers (hard/parallel/two modes)
+3. **Research Phase** — spawn parallel researchers (hard/deep/parallel/two modes)
 4. **Codebase Analysis** — scout relevant files, patterns, dependencies
 5. **Plan Documentation** — write plan.md + phase files
-6. **Red Team Review** — adversarial critique of the plan (hard/parallel)
+6. **Red Team Review** — adversarial critique of the plan (hard/deep/parallel/two)
 7. **Validation** — confirm plan is implementable
 8. **Hydrate Tasks** — create session-scoped tasks from phase todo items
 9. **Context Reminder** — remind active plan for downstream tools
@@ -71,7 +76,12 @@ plans/
         └── researcher-*.md  # Research findings
 ```
 
-Each phase file contains: overview, requirements, architecture, file ownership, implementation steps, todo checklist, success criteria, risk assessment.
+Each phase file contains: overview, requirements, architecture, file ownership,
+implementation steps, todo checklist, success criteria, risk assessment.
+
+Deep mode adds per-phase file inventories, test scenario matrices, and
+dependency maps. `--tdd` adds "Tests Before", "Refactor", and "Tests After"
+sections so the generated plan protects existing behavior during refactors.
 
 ## Task Hydration
 
@@ -84,6 +94,9 @@ Tasks are ephemeral (session-scoped). Plan files are persistent. Hydration bridg
 5. Next session: re-hydrate remaining `[ ]` items
 
 Use `--no-tasks` when you want the plan only (e.g., for review before execution).
+
+If planning used `--tdd`, keep that flag on the cook handoff command:
+`/ck:cook /absolute/path/to/plan.md --tdd`
 
 ## Active Plan State
 

--- a/src/content/docs/engineer/skills/cook.md
+++ b/src/content/docs/engineer/skills/cook.md
@@ -24,6 +24,8 @@ Think of it as your implementation conductor. Give it a task like "add user auth
 - **Scout Phase**: Discover codebase structure and related files
 - **Planning**: Create detailed implementation plans with phases
 - **Implementation**: Execute with quality gates and review cycles
+- **TDD Refactors**: Add tests-first execution with `--tdd` when you need
+  regression-safe changes
 - **Testing**: Comprehensive test coverage with 100% pass requirement
 - **Code Review**: Automated or human review based on complexity
 
@@ -46,6 +48,9 @@ Think of it as your implementation conductor. Give it a task like "add user auth
 
 Optional flags: `--interactive`, `--fast`, `--parallel`, `--no-test`, `--auto`
 
+Composable flags: `--tdd` adds tests-first execution per phase without changing
+the detected mode.
+
 If no flag provided, uses interactive mode by default.
 
 ## Example Prompts
@@ -53,6 +58,7 @@ If no flag provided, uses interactive mode by default.
 - "/ck:cook add user authentication to the app"
 - "/ck:cook implement real-time notifications --fast"
 - "/ck:cook path/to/plan.md --auto"
+- "/ck:cook refactor auth middleware --tdd"
 - "/ck:cook add search, filters, and pagination --parallel"
 - "/ck:cook prototype new UI design --no-test"
 
@@ -66,6 +72,9 @@ If no flag provided, uses interactive mode by default.
 **Default (non-auto)**: Stops at [Review] gates for human approval before each major step.
 
 **Auto mode**: Skips human review gates, implements all phases continuously.
+
+**TDD mode**: Keeps the selected workflow mode, but splits each implementation
+phase into tests-before, implementation, and verification steps.
 
 ## Quality Gates
 


### PR DESCRIPTION
## Summary
- document `ck:plan --deep` and `ck:plan --tdd` on the engineer skill page
- document `ck:cook --tdd` behavior on the engineer cook page
- align the public docs with the paired engineer-kit workflow update

## Validation
- `bun run build`
- internal link validation during Astro build

## Source PR
- claudekit-engineer: https://github.com/claudekit/claudekit-engineer/pull/644
