### PR TITLE
hotfix: increase assistant user bubble typography

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1318,6 +1318,9 @@ pre.astro-code:not([data-language]) span {
 .assistant-message--user .assistant-message-content {
   background-color: var(--color-msg-user-bg);
   color: var(--color-msg-user-text);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  line-height: 1.45;
   margin-left: auto;
   max-width: 85%;
   border-bottom-right-radius: 4px;


### PR DESCRIPTION
## Problem
The docs assistant user bubble text reads smaller than the assistant reply text, especially in light theme, so sent messages feel visually weaker than the response.

## What changed
- increase user-bubble font size to `var(--text-sm)`
- add slightly stronger weight for sent messages
- tighten user-bubble line height for clearer balance against assistant replies

## Validation
- `npm run build`
- manual browser smoke test of the assistant sidebar in light theme

Closes #142
