### PR TITLE
docs: update engineer plan scope and dashboard docs

### DIFF
--- a/src/content/docs/engineer/skills/ck-plan.md
+++ b/src/content/docs/engineer/skills/ck-plan.md
@@ -10,7 +10,7 @@ published: true
 
 # Plan
 
-Creates structured, research-backed implementation plans in your `plans/` directory. Formerly split across `/ck:plan --fast`, `/ck:plan --hard`, and other commands—now consolidated into one skill.
+Creates structured, research-backed implementation plans in the active plan root. Project scope defaults to `plans/` in the current project. Global scope is allowed conditionally and resolves through the configured global plans root, defaulting to `~/.claude/plans/` when unset. Formerly split across `/ck:plan --fast`, `/ck:plan --hard`, and other commands—now consolidated into one skill.
 
 ## What This Skill Does
 
@@ -45,6 +45,16 @@ Composable flags:
 - `/ck:plan "implement real-time notifications + presence" --parallel`
 - `/ck:plan "redesign auth system" --two`
 - `/ck:plan "scaffold new microservice" --auto --no-tasks`
+- `/ck:plan "create shared architecture roadmap" --global`
+
+## Scope Rules
+
+- **Project scope** is the default whenever the current working tree has project context.
+- **Global scope** is allowed when:
+  - you explicitly ask for it with `--global`, or
+  - there is no project context to anchor a local plan.
+- **No project context** means no `.git`, `package.json`, or `CLAUDE.md` was found in the ancestor chain.
+- Scan unfinished plans in the active scope before creating a new one.
 
 ## Workflow Process
 
@@ -76,6 +86,8 @@ plans/
         └── researcher-*.md  # Research findings
 ```
 
+Global scope uses the same directory shape under the configured global plans root instead of the current project.
+
 Each phase file contains: overview, requirements, architecture, file ownership,
 implementation steps, todo checklist, success criteria, risk assessment.
 
@@ -97,6 +109,16 @@ Use `--no-tasks` when you want the plan only (e.g., for review before execution)
 
 If planning used `--tdd`, keep that flag on the cook handoff command:
 `/ck:cook /absolute/path/to/plan.md --tdd`
+
+## Cross-Plan Dependencies
+
+Use `ck plan status` as the authoritative dependency/status view.
+
+- Bare references such as `260413-auth-system` stay in the current scope.
+- Cross-scope references use explicit prefixes:
+  - `global:260413-auth-system`
+  - `project:260413-dashboard`
+- Missing refs should warn and render as `not found`, not hard-fail the plan.
 
 ## Active Plan State
 

--- a/src/content/docs/engineer/skills/plans-kanban.md
+++ b/src/content/docs/engineer/skills/plans-kanban.md
@@ -24,6 +24,12 @@ It opens the ClaudeKit CLI dashboard plans route and gives you:
 - markdown reader navigation for `plan.md` and phase files
 - quick phase actions such as start, complete, reset, validate, and start-next
 
+Scope note:
+
+- Project dashboards should show project-scoped plans only.
+- Global dashboards should show global-scoped plans only.
+- `ck plan status` remains the authoritative dependency/status view for `blockedBy` / `blocks`.
+
 ## How It Works
 
 When invoked, the launcher:
@@ -64,7 +70,7 @@ Old standalone-server flags are still accepted with warnings so existing habits 
 
 | Legacy input | Current behavior |
 | --- | --- |
-| `--dir <path>` / positional path | Warns and ignores. The dashboard now discovers plans through the CLI UI route. |
+| `--dir <path>` / positional path | Warns and ignores. This launcher opens the generic `/plans` route and does not choose a custom plan root. |
 | `--plans <path>` | Warns and ignores. |
 | `--port <n>` | Warns and ignores. The launcher targets the CLI dashboard starting at `3456`. |
 | `--host <addr>` | Warns and ignores. Use `ck config ui --host ...` directly if needed. |
@@ -97,6 +103,8 @@ That means:
 - there is no separate `localhost:3500` dashboard anymore
 - the canonical visual experience lives under the CLI dashboard
 - the skill exists to open the right place quickly, not to run a separate app stack
+- the generic `/plans` route still defaults to `plans` unless a `dir` query param is already present
+- scope-aware plan roots come from project/global dashboard context, not deprecated launcher flags
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- document conditional global plan roots and explicit cross-scope dependency refs for `ck:plan`
- clarify that `ck:plans-kanban` opens the generic `/plans` route and does not select custom plan roots
- align public engineer docs with the shipped skill/docs updates in the source repos

## Validation
- [x] `npm run build`

## Related PRs
- mrgoonie/claudekit-cli#668
- claudekit/claudekit-engineer#661
