### PR TITLE
fix: harden docs site trust signals

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
 import pagefind from 'astro-pagefind';
@@ -160,6 +161,7 @@ ${docs.length > 5 ? `- [... ${docs.length - 5} more pages](https://docs.claudeki
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://docs.claudekit.cc',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'vi'],
@@ -171,6 +173,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     react(),
+    sitemap(),
     tailwind({
       applyBaseStyles: false, // We'll use our custom CSS
     }),

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "^0.9.6",
         "@astrojs/mdx": "4.3.13",
         "@astrojs/react": "4.4.2",
+        "@astrojs/sitemap": "^3.7.2",
         "@astrojs/tailwind": "^6.0.2",
         "@radix-ui/react-collapsible": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -56,6 +57,8 @@
     "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
 
     "@astrojs/react": ["@astrojs/react@4.4.2", "", { "dependencies": { "@vitejs/plugin-react": "^4.7.0", "ultrahtml": "^1.6.0", "vite": "^6.4.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
     "@astrojs/tailwind": ["@astrojs/tailwind@6.0.2", "", { "dependencies": { "autoprefixer": "^10.4.21", "postcss": "^8.5.3", "postcss-load-config": "^4.0.2" }, "peerDependencies": { "astro": "^3.0.0 || ^4.0.0 || ^5.0.0", "tailwindcss": "^3.0.24" } }, "sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg=="],
 
@@ -422,6 +425,8 @@
     "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1151,6 +1156,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -1158,6 +1165,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1331,7 +1340,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -1347,7 +1356,11 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@types/sax/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1367,9 +1380,13 @@
 
     "ofetch/ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
+    "openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -1389,6 +1406,10 @@
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
+    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@types/sax/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "boxen/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
@@ -1396,6 +1417,8 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -1,10 +1,52 @@
 # Project Changelog
 
-**Last Updated**: 2025-12-30
+**Last Updated**: 2026-04-15
 **Version**: 0.0.4
 **Project**: claudekit-docs
 
 ## Version History
+
+### Unreleased - 2026-04-15
+
+#### 🛡️ Trust Hardening For `docs.claudekit.cc`
+
+**Problem Addressed**:
+- Hardened the docs site after FortiGuard classified `docs.claudekit.cc` as `Spam URLs`
+- Focused on repo-owned trust, crawlability, and metadata signals instead of treating the issue as an application outage
+
+**Site Identity Improvements**:
+- Reworked the root homepage into a neutral documentation-first entrypoint instead of a sales-forward landing page
+- Added explicit trust and support references for sitemap, `llms.txt`, `security.txt`, and support/security contacts
+- Disabled the AI assistant launcher on the root docs homepage to keep the entrypoint clean and uncluttered
+
+**SEO / Discovery Improvements**:
+- Added Astro `site` configuration for canonical absolute URL generation
+- Integrated `@astrojs/sitemap` and verified `sitemap-index.xml` generation during build
+- Added canonical, Open Graph, Twitter, robots, author, and theme-color metadata in the shared base layout
+- Added `robots.txt` and `security.txt` artifacts, including `/.well-known/security.txt`
+
+**Edge Security Improvements**:
+- Added baseline ingress response headers:
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: SAMEORIGIN`
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` for camera, geolocation, and microphone
+
+**Validation**:
+- `bun run build` passes successfully
+- Generated artifacts verified in `dist/`:
+  - `sitemap-index.xml`
+  - `robots.txt`
+  - `security.txt`
+  - `.well-known/security.txt`
+- Root page metadata verified in built HTML
+
+**Follow-Up Still Required Outside This Repo**:
+- Promote the docs fix from `dev` to `main`
+- Re-submit / escalate FortiGuard reclassification after production rollout
+- Post a single final status update back to `claudekit-engineer#639` only after rollout is complete
+
+---
 
 ### v0.0.4 - 2025-12-30
 

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+      more_set_headers "Permissions-Policy: camera=(), geolocation=(), microphone=()";
 spec:
   ingressClassName: nginx
   tls:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/mdx": "4.3.13",
     "@astrojs/react": "4.4.2",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/tailwind": "^6.0.2",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",

--- a/plans/260415-1558-fortiguard-trust-hardening/phase-01-site-trust-signals.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/phase-01-site-trust-signals.md
@@ -1,0 +1,93 @@
+# Phase 01 - Site Trust Signals
+
+## Context Links
+
+- Issue: `claudekit-docs#147`
+- Intake issue: `claudekit-engineer#639`
+- Files:
+  - `src/pages/index.astro`
+  - `src/layouts/BaseLayout.astro`
+  - `astro.config.mjs`
+  - `k8s/ingress.yaml`
+  - `public/*`
+
+## Overview
+
+Priority: High
+Status: In Progress
+Brief: Strengthen the docs host's public identity so it looks like a documentation property instead of a low-context landing page with weak crawl and trust signals.
+
+## Key Insights
+
+- FortiGuard is blocking `docs.claudekit.cc` as `Spam URLs`.
+- The docs site is healthy, but public trust/discovery signals are incomplete.
+- Repo-owned fixes should focus on crawlability, metadata quality, and a more neutral docs-first entrypoint.
+
+## Requirements
+
+- Add a deployed `site` URL and sitemap generation.
+- Add canonical and social metadata in the base layout.
+- Add `robots.txt` and `security.txt`.
+- Make the root page more obviously documentation-first.
+- Add baseline security headers at ingress level.
+
+## Architecture
+
+- `BaseLayout` owns document metadata.
+- `index.astro` owns the root page posture.
+- `astro.config.mjs` owns site URL and build integrations.
+- `public/` owns static trust files.
+- `k8s/ingress.yaml` owns response header policy at the edge ingress layer.
+
+## Related Code Files
+
+Modify:
+- `src/pages/index.astro`
+- `src/layouts/BaseLayout.astro`
+- `astro.config.mjs`
+- `package.json`
+- `bun.lock`
+- `k8s/ingress.yaml`
+
+Create:
+- `public/robots.txt`
+- `public/security.txt`
+
+## Implementation Steps
+
+1. Add `@astrojs/sitemap` and configure `site`.
+2. Emit canonical, Open Graph, and Twitter metadata from `BaseLayout`.
+3. Add crawl and contact trust files in `public/`.
+4. Rework the root page copy and structure toward documentation-first framing.
+5. Add ingress annotations for baseline security headers.
+
+## Todo List
+
+- [ ] Configure sitemap generation
+- [ ] Add metadata hardening
+- [ ] Add static trust files
+- [ ] Rework root docs page
+- [ ] Add ingress security headers
+
+## Success Criteria
+
+- Build emits sitemap artifacts.
+- Generated HTML contains canonical and social metadata.
+- `robots.txt` and `security.txt` resolve successfully.
+- Root page copy reads as documentation-first.
+- Ingress config is valid YAML and includes header hardening.
+
+## Risk Assessment
+
+- Root page copy changes may affect existing positioning.
+- New headers must not break embedded assets or third-party integrations.
+
+## Security Considerations
+
+- Prefer restrictive but low-risk headers.
+- Avoid CSP changes without full asset audit.
+
+## Next Steps
+
+- Run build validation and inspect generated artifacts.
+- Capture rollout notes for post-merge reclassification follow-up.

--- a/plans/260415-1558-fortiguard-trust-hardening/phase-02-validation-and-rollout.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/phase-02-validation-and-rollout.md
@@ -1,0 +1,43 @@
+# Phase 02 - Validation And Rollout
+
+## Context Links
+
+- Phase 01: `./phase-01-site-trust-signals.md`
+- Validation commands: `bun run build`
+
+## Overview
+
+Priority: High
+Status: Pending
+Brief: Verify the generated site outputs and document what still needs to happen outside the repo.
+
+## Key Insights
+
+- This repo can improve trust posture but cannot directly clear FortiGuard categorization.
+- The original engineer issue should receive exactly one status update only after rollout is complete.
+
+## Requirements
+
+- Build must pass.
+- Generated output must include sitemap and trust files.
+- Final handoff must clearly separate repo work from infra/reputation work.
+
+## Implementation Steps
+
+1. Run build and inspect output files.
+2. Check generated HTML for canonical and social tags.
+3. Summarize any remaining non-repo actions.
+4. Defer engineer-issue comment until `dev` and then `main` rollout are done.
+
+## Todo List
+
+- [ ] Build passes
+- [ ] Output files verified
+- [ ] Remaining external actions listed
+- [ ] Cross-repo status update explicitly deferred
+
+## Success Criteria
+
+- Repo changes are PR-ready.
+- Verification notes are concrete.
+- No premature comment is posted to `claudekit-engineer#639`.

--- a/plans/260415-1558-fortiguard-trust-hardening/plan.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/plan.md
@@ -1,0 +1,34 @@
+# FortiGuard Trust Hardening
+
+Status: In Progress
+Issue: `claudekit-docs#147`
+Intake: `claudekit-engineer#639`
+
+## Goal
+
+Reduce repo-owned false-positive risk for `docs.claudekit.cc` by hardening public trust signals, metadata, crawlability, and security posture in the docs site itself.
+
+## Phases
+
+1. [Phase 01](./phase-01-site-trust-signals.md) - Add site-level trust and discovery signals
+2. [Phase 02](./phase-02-validation-and-rollout.md) - Validate outputs and prepare rollout notes
+
+## Expected Outcomes
+
+- Root docs hostname presents as a neutral documentation site
+- Canonical and social metadata are emitted consistently
+- `robots.txt`, `security.txt`, and sitemap artifacts exist
+- Ingress sends basic security headers
+- Remaining infra-only follow-up is isolated from repo-owned work
+
+## Dependencies
+
+- Astro site config
+- Base layout metadata
+- Public static files
+- Kubernetes ingress config
+
+## Notes
+
+- Do not post back to `claudekit-engineer#639` until the docs fix is merged to `dev`, promoted to `main`, and confirmed live.
+- Repo-side hardening is necessary but may not fully clear FortiGuard without external reclassification.

--- a/plans/reports/maintainer-260415-1609-fortiguard-trust-hardening.md
+++ b/plans/reports/maintainer-260415-1609-fortiguard-trust-hardening.md
@@ -1,0 +1,39 @@
+# Maintainer Report - FortiGuard Trust Hardening
+
+Date: 2026-04-15
+Repo: `claudekit-docs`
+Issue: `#147`
+Intake: `claudekit-engineer#639`
+
+## Diagnosis
+
+- FortiGuard blocks `https://docs.claudekit.cc/` as `Spam URLs`.
+- The site is live and returns valid HTML with a valid TLS certificate.
+- Repo-owned gaps were trust and discovery signals, not application availability.
+
+## Repo-Owned Fix Scope
+
+- Reworked `/` into a documentation-first homepage.
+- Added canonical, Open Graph, Twitter, robots, author, and theme metadata.
+- Added `@astrojs/sitemap` with explicit `site` config.
+- Added `robots.txt`, `security.txt`, and `/.well-known/security.txt`.
+- Added baseline ingress security headers.
+- Disabled the AI assistant launcher on the root homepage to reduce visual clutter.
+
+## Validation
+
+- `bun run build` passed after changes.
+- Verified generated outputs:
+  - `dist/sitemap-index.xml`
+  - `dist/robots.txt`
+  - `dist/security.txt`
+  - `dist/.well-known/security.txt`
+- Verified built root HTML contains canonical and social metadata.
+- Captured local UI sanity screenshot of the cleaned root page.
+
+## Remaining Non-Repo Work
+
+- Deploy the docs repo fix to `dev`.
+- Promote `dev` to `main`.
+- Re-submit or escalate FortiGuard reclassification once production reflects the changes.
+- Post one final status update back to `claudekit-engineer#639` only after the rollout is complete.

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@claudekit.cc
+Contact: mailto:support@claudekit.cc
+Expires: 2026-10-15T00:00:00.000Z
+Preferred-Languages: en, vi
+Canonical: https://docs.claudekit.cc/.well-known/security.txt
+Policy: https://docs.claudekit.cc/docs/support

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.claudekit.cc/sitemap-index.xml

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@claudekit.cc
+Contact: mailto:support@claudekit.cc
+Expires: 2026-10-15T00:00:00.000Z
+Preferred-Languages: en, vi
+Canonical: https://docs.claudekit.cc/.well-known/security.txt
+Policy: https://docs.claudekit.cc/docs/support

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,6 +19,17 @@ const {
 
 // Generate alternate URLs for hreflang tags
 const alternates = slug ? getAlternateUrls(slug) : [];
+const siteUrl = Astro.site ?? new URL('https://docs.claudekit.cc');
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
+
+canonicalUrl.search = '';
+canonicalUrl.hash = '';
+
+const socialImageUrl = new URL('/og-image.png', siteUrl);
+const ogLocale = locale === 'vi' ? 'vi_VN' : 'en_US';
+const alternateOgLocales = Array.from(
+  new Set(alternates.map(({ lang }) => (lang === 'vi' ? 'vi_VN' : lang === 'en' ? 'en_US' : null)))
+).filter((value): value is 'en_US' | 'vi_VN' => value !== null && value !== ogLocale);
 ---
 
 <!DOCTYPE html>
@@ -27,14 +38,35 @@ const alternates = slug ? getAlternateUrls(slug) : [];
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="author" content="ClaudeKit" />
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+    <meta name="theme-color" content="#0d0d0d" />
     <meta name="generator" content={Astro.generator} />
 
     <link rel="icon" type="image/png" href="/logo-512-transparent.png" />
+    <link rel="canonical" href={canonicalUrl.toString()} />
 
     <!-- Hreflang tags for SEO -->
     {alternates.map(({ lang, url }) => (
       <link rel="alternate" hreflang={lang} href={url} />
     ))}
+
+    <meta property="og:site_name" content="ClaudeKit Documentation" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl.toString()} />
+    <meta property="og:image" content={socialImageUrl.toString()} />
+    <meta property="og:image:alt" content="ClaudeKit Documentation" />
+    <meta property="og:locale" content={ogLocale} />
+    {alternateOgLocales.map((value) => (
+      <meta property="og:locale:alternate" content={value} />
+    ))}
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={socialImageUrl.toString()} />
 
     <title>{title}</title>
   </head>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -23,6 +23,7 @@ export interface Props {
   content?: { body: string; data: Record<string, any> };
   contentWidth?: 'default' | 'wide';
   showTableOfContents?: boolean;
+  showAssistant?: boolean;
 }
 
 const {
@@ -33,6 +34,7 @@ const {
   headings = [],
   contentWidth = 'default',
   showTableOfContents = true,
+  showAssistant = true,
 } = Astro.props;
 const currentPath = Astro.url.pathname;
 const shouldShowTableOfContents = showTableOfContents && headings.length > 0;
@@ -83,8 +85,12 @@ const frontmatter = content?.data || {
         )}
       </div>
 
-      {/* AI Assistant - Two-stage UX (client:only to avoid SSR hook errors) */}
-      <DocsAssistant client:only="react" />
+      {showAssistant && (
+        <>
+          {/* AI Assistant - Two-stage UX (client:only to avoid SSR hook errors) */}
+          <DocsAssistant client:only="react" />
+        </>
+      )}
     </div>
   </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,144 +1,139 @@
 ---
 import DocsLayout from '../layouts/DocsLayout.astro';
-import HomeHero from '../components/home/HomeHero.astro';
-import HomeValueProps from '../components/home/HomeValueProps.astro';
-import HomeWorkflowProof from '../components/home/HomeWorkflowProof.astro';
-import HomeGetStarted from '../components/home/HomeGetStarted.astro';
 
-const title = 'ClaudeKit - Build Software Like You Have a Team';
-const description = '14 specialized AI agents working together. Write less code, ship faster, maintain quality. Reclaim 50-70% of time on repetitive tasks.';
+const title = 'ClaudeKit Documentation';
+const description =
+  'Official documentation for ClaudeKit CLI, Engineer, and Marketing kits, including installation, workflows, troubleshooting, and support resources.';
 
-const heroCode = `# Install ClaudeKit CLI
-npm install -g claudekit-cli
+const quickLinks = [
+  { title: 'Install ClaudeKit', description: 'Start with setup, access requirements, and first-run guidance.', href: '/docs/getting-started/installation' },
+  { title: 'Read The Introduction', description: 'Understand how the CLI, agents, commands, and skills fit together.', href: '/docs/getting-started/introduction' },
+  { title: 'Get Support', description: 'Find troubleshooting steps, FAQ entries, and support channels.', href: '/docs/support' },
+  { title: 'Review The Changelog', description: 'See what changed across recent ClaudeKit releases.', href: '/docs/changelog' },
+];
 
-# Create new project
-ck new --dir my-app
+const sections = [
+  { title: 'Getting Started', description: 'Installation, concepts, quick start, and migration guidance.', href: '/docs/getting-started' },
+  { title: 'CLI', description: 'Command reference, configuration, backups, and architecture.', href: '/docs/cli' },
+  { title: 'Engineer', description: 'Agents, commands, configuration, and technical skills.', href: '/docs/engineer' },
+  { title: 'Marketing', description: 'Marketing agents, content workflows, and automation skills.', href: '/docs/marketing' },
+  { title: 'Workflows', description: 'End-to-end playbooks for planning, implementation, testing, and delivery.', href: '/docs/workflows' },
+  { title: 'Support', description: 'Troubleshooting, FAQ, community, and escalation paths.', href: '/docs/support' },
+];
 
-# Select "Engineer Kit"
-# Wait for installation to complete
-
-# Start the project
-cd my-app
-
-# Start Claude Code
-claude
-# or \`claude --dangerously-skip-permissions\` (use as your own risk)
-
-# Bootstrap a new project, or plan and implement a feature
-/ck:bootstrap [create a calendar booking app that sync with Apple & Google Calendar]
-/ck:plan [add user authentication]
-/ck:cook [implement user authentication]
-
-# Review, approve, deploy`;
-
-const cliCode = `# Initialize ClaudeKit Engineer in your project
-ck init --kit engineer
-
-# Update ClaudeKit Engineer to latest version
-ck init
-
-# Check available ClaudeKit versions
-ck versions`;
-
-const planningCode = `# Planner agent reads your codebase
-/ck:plan [add real-time notifications with WebSocket]
-
-# Creates detailed implementation plan:
-# - Architecture decisions
-# - File changes needed
-# - Test strategy
-# - Security considerations`;
-
-const implementationCode = `# Implement based on plan
-/ck:cook [implement WebSocket notifications based on the plan]
-
-# Generates:
-# - Server-side WebSocket handler
-# - Client-side connection manager
-# - Event types and validators
-# - Error handling and reconnection logic`;
-
-const testingCode = `# Tester agent creates comprehensive tests
-/ck:test [WebSocket notifications]
-
-# Produces:
-# - Unit tests for handlers
-# - Integration tests for end-to-end flow
-# - Mock WebSocket server
-# - Coverage report`;
-
-const debuggingCode = `# Debug and fix issues
-/ck:debug [users are reporting timeout errors on checkout]
-
-# Agent workflow:
-# 1. Searches logs for timeout patterns
-# 2. Traces code execution paths
-# 3. Identifies bottleneck in payment processing
-# 4. Suggests fixes with performance impact
-# 5. Generates tests to prevent regression`;
-
-const refactoringCode = `# Map codebase structure
-/ck:scout analyze the authentication system
-
-# Planner creates refactoring roadmap
-/ck:plan [migrate from sessions to JWT]
-
-# Implement changes from plan
-/clear
-/ck:cook implement JWT authentication as planned
-
-# Tester ensures nothing breaks
-/ck:test [authentication system]`;
-
-const step1Code = `npm install -g claudekit-cli`;
-const step2Code = `ck new my-first-app
-cd my-first-app`;
-const step3Code = `/ck:plan [add user registration API]
-/clear
-/ck:cook [implement the registration endpoint as planned]`;
-const step4Code = `git diff
-npm test
-# commit via git-manager or manually`;
+const trustLinks = [
+  { label: 'LLMs.txt', href: '/llms.txt', description: 'Machine-readable site index for AI tooling and retrieval.' },
+  { label: 'Sitemap', href: '/sitemap-index.xml', description: 'XML sitemap for search engines and security scanners.' },
+  { label: 'Security.txt', href: '/.well-known/security.txt', description: 'Security contact and disclosure information.' },
+];
 
 const headings = [
-  { depth: 2, text: 'Why ClaudeKit?', slug: 'why-claudekit' },
-  { depth: 3, text: 'Specialized Agents, Real Results', slug: 'specialized-agents-real-results' },
-  { depth: 3, text: 'Eliminate Repetitive Work', slug: 'eliminate-repetitive-work' },
-  { depth: 3, text: 'Stay in Control', slug: 'stay-in-control' },
-  { depth: 2, text: 'How It Works', slug: 'how-it-works' },
-  { depth: 3, text: 'ClaudeKit Engineer: 14 Specialized Agents', slug: 'claudekit-engineer-14-specialized-agents' },
-  { depth: 3, text: 'ClaudeKit CLI: Smart Project Management', slug: 'claudekit-cli-smart-project-management' },
-  { depth: 2, text: 'Real Developer Workflows', slug: 'real-developer-workflows' },
-  { depth: 3, text: 'Building a New Feature', slug: 'building-a-new-feature' },
-  { depth: 3, text: 'Debugging Production Issues', slug: 'debugging-production-issues' },
-  { depth: 3, text: 'Refactoring Legacy Code', slug: 'refactoring-legacy-code' },
-  { depth: 2, text: 'Proven Results', slug: 'proven-results' },
-  { depth: 2, text: 'What Developers Say', slug: 'what-developers-say' },
-  { depth: 2, text: 'Get Started in 5 Minutes', slug: 'get-started-in-5-minutes' },
-  { depth: 2, text: 'Explore Documentation', slug: 'explore-documentation' },
+  { depth: 2, text: 'Overview', slug: 'overview' },
+  { depth: 2, text: 'Start Here', slug: 'start-here' },
+  { depth: 2, text: 'Documentation Sections', slug: 'documentation-sections' },
+  { depth: 2, text: 'Trust And Support', slug: 'trust-and-support' },
 ];
 ---
 
-<DocsLayout
-  title={title}
-  description={description}
-  headings={headings}
-  contentWidth="wide"
->
-  <HomeHero heroCode={heroCode} />
-  <HomeValueProps />
-  <HomeWorkflowProof
-    cliCode={cliCode}
-    planningCode={planningCode}
-    implementationCode={implementationCode}
-    testingCode={testingCode}
-    debuggingCode={debuggingCode}
-    refactoringCode={refactoringCode}
-  />
-  <HomeGetStarted
-    step1Code={step1Code}
-    step2Code={step2Code}
-    step3Code={step3Code}
-    step4Code={step4Code}
-  />
+<DocsLayout title={title} description={description} headings={headings} contentWidth="wide" showAssistant={false}>
+  <section class="space-y-6 pb-10 pt-2">
+    <p class="text-sm font-medium uppercase tracking-[0.16em] text-[var(--color-text-muted)]">Official Documentation</p>
+    <h1 class="text-4xl font-bold tracking-tight text-[var(--color-text-primary)] sm:text-5xl">ClaudeKit Documentation</h1>
+    <p class="max-w-4xl text-lg leading-8 text-[var(--color-text-secondary)]">Official documentation for ClaudeKit installation, CLI usage, Engineer and Marketing kits, workflow guides, troubleshooting, and support resources.</p>
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {quickLinks.map((item) => (
+        <a
+          href={item.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h2 class="text-lg font-semibold text-[var(--color-text-primary)]">{item.title}</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{item.description}</p>
+        </a>
+      ))}
+    </div>
+  </section>
+
+  <section id="overview" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Overview</h2>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">ClaudeKit extends Claude Code with kits, agents, commands, and reusable skills. This site is the primary reference for setup, usage, and maintenance across the ClaudeKit stack.</p>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">If you are new here, start with installation and concepts. If you are troubleshooting or validating an existing setup, use the support and workflow sections.</p>
+  </section>
+
+  <section id="start-here" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Start Here</h2>
+    <ol class="grid gap-4 md:grid-cols-3">
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 1</p>
+        <a href="/docs/getting-started/installation" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Install The CLI
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Follow the setup guide, validate repository access, and complete first-run configuration.
+        </p>
+      </li>
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 2</p>
+        <a href="/docs/getting-started/concepts" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Learn The Model
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Understand how kits, agents, slash commands, and skills work together in daily use.
+        </p>
+      </li>
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 3</p>
+        <a href="/docs/workflows" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Run A Workflow
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Pick a workflow for planning, implementation, debugging, review, or delivery.
+        </p>
+      </li>
+    </ol>
+  </section>
+
+  <section id="documentation-sections" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Documentation Sections</h2>
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {sections.map((section) => (
+        <a
+          href={section.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">{section.title}</h3>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{section.description}</p>
+        </a>
+      ))}
+    </div>
+  </section>
+
+  <section id="trust-and-support" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Trust And Support</h2>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">
+      The official documentation host is <code>docs.claudekit.cc</code>. Search engine and security tooling can use the
+      references below to verify site ownership, discover pages, and contact the ClaudeKit team when needed.
+    </p>
+
+    <div class="grid gap-4 md:grid-cols-3">
+      {trustLinks.map((item) => (
+        <a
+          href={item.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">{item.label}</h3>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{item.description}</p>
+        </a>
+      ))}
+    </div>
+
+    <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-6">
+      <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">Contacts</h3>
+      <ul class="mt-3 space-y-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+        <li>Support: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="mailto:support@claudekit.cc">support@claudekit.cc</a></li>
+        <li>Security: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="mailto:security@claudekit.cc">security@claudekit.cc</a></li>
+        <li>Community: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="https://claudekit.cc/discord">claudekit.cc/discord</a></li>
+      </ul>
+    </div>
+  </section>
 </DocsLayout>


### PR DESCRIPTION
## Summary

- rework the docs root page into a documentation-first homepage
- add canonical, Open Graph, Twitter, robots, author, and theme metadata
- generate sitemap artifacts and add public trust files (`robots.txt`, `security.txt`)
- add baseline ingress security headers for the docs host
- document the investigation and rollout caveats in `plans/` and `docs/project-changelog.md`

Closes #147

## Root Cause

FortiGuard is classifying `docs.claudekit.cc` as `Spam URLs`. The site itself is live, but the repo-owned public trust and discovery signals were weak: no sitemap integration, no `robots.txt`, no `security.txt`, minimal shared metadata, and a root page that read more like a marketing landing page than a neutral documentation entrypoint.

## Validation

- [x] `bun run build`
- [x] verified generated `dist/sitemap-index.xml`
- [x] verified generated `dist/robots.txt`
- [x] verified generated `dist/security.txt`
- [x] verified generated `dist/.well-known/security.txt`
- [x] verified canonical and social metadata in built root HTML

## Rollout Note

Do not comment back on `claudekit-engineer#639` yet. That status update should happen once this fix is merged to `dev`, promoted to `main`, and confirmed live in production.
