### PR TITLE
chore: promote dev to main

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import mdx from '@astrojs/mdx';
 import pagefind from 'astro-pagefind';
@@ -160,6 +161,7 @@ ${docs.length > 5 ? `- [... ${docs.length - 5} more pages](https://docs.claudeki
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://docs.claudekit.cc',
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'vi'],
@@ -171,6 +173,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     react(),
+    sitemap(),
     tailwind({
       applyBaseStyles: false, // We'll use our custom CSS
     }),

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "^0.9.6",
         "@astrojs/mdx": "4.3.13",
         "@astrojs/react": "4.4.2",
+        "@astrojs/sitemap": "^3.7.2",
         "@astrojs/tailwind": "^6.0.2",
         "@radix-ui/react-collapsible": "^1.1.2",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -56,6 +57,8 @@
     "@astrojs/prism": ["@astrojs/prism@3.3.0", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ=="],
 
     "@astrojs/react": ["@astrojs/react@4.4.2", "", { "dependencies": { "@vitejs/plugin-react": "^4.7.0", "ultrahtml": "^1.6.0", "vite": "^6.4.1" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.2", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA=="],
 
     "@astrojs/tailwind": ["@astrojs/tailwind@6.0.2", "", { "dependencies": { "autoprefixer": "^10.4.21", "postcss": "^8.5.3", "postcss-load-config": "^4.0.2" }, "peerDependencies": { "astro": "^3.0.0 || ^4.0.0 || ^5.0.0", "tailwindcss": "^3.0.24" } }, "sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg=="],
 
@@ -422,6 +425,8 @@
     "@types/react": ["@types/react@18.3.27", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w=="],
 
     "@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -1151,6 +1156,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
@@ -1158,6 +1165,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stream-replace-string": ["stream-replace-string@2.0.0", "", {}, "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1331,7 +1340,7 @@
 
     "yoctocolors": ["yoctocolors@2.1.2", "", {}, "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -1347,7 +1356,11 @@
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "@types/sax/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -1367,9 +1380,13 @@
 
     "ofetch/ufo": ["ufo@1.6.1", "", {}, "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA=="],
 
+    "openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "sitemap/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -1389,6 +1406,10 @@
 
     "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
+    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@types/sax/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "boxen/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "boxen/string-width/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
@@ -1396,6 +1417,8 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "tailwindcss/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/docs/project-changelog.md
+++ b/docs/project-changelog.md
@@ -1,10 +1,52 @@
 # Project Changelog
 
-**Last Updated**: 2025-12-30
+**Last Updated**: 2026-04-15
 **Version**: 0.0.4
 **Project**: claudekit-docs
 
 ## Version History
+
+### Unreleased - 2026-04-15
+
+#### 🛡️ Trust Hardening For `docs.claudekit.cc`
+
+**Problem Addressed**:
+- Hardened the docs site after FortiGuard classified `docs.claudekit.cc` as `Spam URLs`
+- Focused on repo-owned trust, crawlability, and metadata signals instead of treating the issue as an application outage
+
+**Site Identity Improvements**:
+- Reworked the root homepage into a neutral documentation-first entrypoint instead of a sales-forward landing page
+- Added explicit trust and support references for sitemap, `llms.txt`, `security.txt`, and support/security contacts
+- Disabled the AI assistant launcher on the root docs homepage to keep the entrypoint clean and uncluttered
+
+**SEO / Discovery Improvements**:
+- Added Astro `site` configuration for canonical absolute URL generation
+- Integrated `@astrojs/sitemap` and verified `sitemap-index.xml` generation during build
+- Added canonical, Open Graph, Twitter, robots, author, and theme-color metadata in the shared base layout
+- Added `robots.txt` and `security.txt` artifacts, including `/.well-known/security.txt`
+
+**Edge Security Improvements**:
+- Added baseline ingress response headers:
+  - `X-Content-Type-Options: nosniff`
+  - `X-Frame-Options: SAMEORIGIN`
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+  - `Permissions-Policy` for camera, geolocation, and microphone
+
+**Validation**:
+- `bun run build` passes successfully
+- Generated artifacts verified in `dist/`:
+  - `sitemap-index.xml`
+  - `robots.txt`
+  - `security.txt`
+  - `.well-known/security.txt`
+- Root page metadata verified in built HTML
+
+**Follow-Up Still Required Outside This Repo**:
+- Promote the docs fix from `dev` to `main`
+- Re-submit / escalate FortiGuard reclassification after production rollout
+- Post a single final status update back to `claudekit-engineer#639` only after rollout is complete
+
+---
 
 ### v0.0.4 - 2025-12-30
 

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -6,6 +6,11 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Content-Type-Options: nosniff";
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Referrer-Policy: strict-origin-when-cross-origin";
+      more_set_headers "Permissions-Policy: camera=(), geolocation=(), microphone=()";
 spec:
   ingressClassName: nginx
   tls:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@astrojs/check": "^0.9.6",
     "@astrojs/mdx": "4.3.13",
     "@astrojs/react": "4.4.2",
+    "@astrojs/sitemap": "^3.7.2",
     "@astrojs/tailwind": "^6.0.2",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.4",

--- a/plans/260415-1558-fortiguard-trust-hardening/phase-01-site-trust-signals.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/phase-01-site-trust-signals.md
@@ -1,0 +1,93 @@
+# Phase 01 - Site Trust Signals
+
+## Context Links
+
+- Issue: `claudekit-docs#147`
+- Intake issue: `claudekit-engineer#639`
+- Files:
+  - `src/pages/index.astro`
+  - `src/layouts/BaseLayout.astro`
+  - `astro.config.mjs`
+  - `k8s/ingress.yaml`
+  - `public/*`
+
+## Overview
+
+Priority: High
+Status: In Progress
+Brief: Strengthen the docs host's public identity so it looks like a documentation property instead of a low-context landing page with weak crawl and trust signals.
+
+## Key Insights
+
+- FortiGuard is blocking `docs.claudekit.cc` as `Spam URLs`.
+- The docs site is healthy, but public trust/discovery signals are incomplete.
+- Repo-owned fixes should focus on crawlability, metadata quality, and a more neutral docs-first entrypoint.
+
+## Requirements
+
+- Add a deployed `site` URL and sitemap generation.
+- Add canonical and social metadata in the base layout.
+- Add `robots.txt` and `security.txt`.
+- Make the root page more obviously documentation-first.
+- Add baseline security headers at ingress level.
+
+## Architecture
+
+- `BaseLayout` owns document metadata.
+- `index.astro` owns the root page posture.
+- `astro.config.mjs` owns site URL and build integrations.
+- `public/` owns static trust files.
+- `k8s/ingress.yaml` owns response header policy at the edge ingress layer.
+
+## Related Code Files
+
+Modify:
+- `src/pages/index.astro`
+- `src/layouts/BaseLayout.astro`
+- `astro.config.mjs`
+- `package.json`
+- `bun.lock`
+- `k8s/ingress.yaml`
+
+Create:
+- `public/robots.txt`
+- `public/security.txt`
+
+## Implementation Steps
+
+1. Add `@astrojs/sitemap` and configure `site`.
+2. Emit canonical, Open Graph, and Twitter metadata from `BaseLayout`.
+3. Add crawl and contact trust files in `public/`.
+4. Rework the root page copy and structure toward documentation-first framing.
+5. Add ingress annotations for baseline security headers.
+
+## Todo List
+
+- [ ] Configure sitemap generation
+- [ ] Add metadata hardening
+- [ ] Add static trust files
+- [ ] Rework root docs page
+- [ ] Add ingress security headers
+
+## Success Criteria
+
+- Build emits sitemap artifacts.
+- Generated HTML contains canonical and social metadata.
+- `robots.txt` and `security.txt` resolve successfully.
+- Root page copy reads as documentation-first.
+- Ingress config is valid YAML and includes header hardening.
+
+## Risk Assessment
+
+- Root page copy changes may affect existing positioning.
+- New headers must not break embedded assets or third-party integrations.
+
+## Security Considerations
+
+- Prefer restrictive but low-risk headers.
+- Avoid CSP changes without full asset audit.
+
+## Next Steps
+
+- Run build validation and inspect generated artifacts.
+- Capture rollout notes for post-merge reclassification follow-up.

--- a/plans/260415-1558-fortiguard-trust-hardening/phase-02-validation-and-rollout.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/phase-02-validation-and-rollout.md
@@ -1,0 +1,43 @@
+# Phase 02 - Validation And Rollout
+
+## Context Links
+
+- Phase 01: `./phase-01-site-trust-signals.md`
+- Validation commands: `bun run build`
+
+## Overview
+
+Priority: High
+Status: Pending
+Brief: Verify the generated site outputs and document what still needs to happen outside the repo.
+
+## Key Insights
+
+- This repo can improve trust posture but cannot directly clear FortiGuard categorization.
+- The original engineer issue should receive exactly one status update only after rollout is complete.
+
+## Requirements
+
+- Build must pass.
+- Generated output must include sitemap and trust files.
+- Final handoff must clearly separate repo work from infra/reputation work.
+
+## Implementation Steps
+
+1. Run build and inspect output files.
+2. Check generated HTML for canonical and social tags.
+3. Summarize any remaining non-repo actions.
+4. Defer engineer-issue comment until `dev` and then `main` rollout are done.
+
+## Todo List
+
+- [ ] Build passes
+- [ ] Output files verified
+- [ ] Remaining external actions listed
+- [ ] Cross-repo status update explicitly deferred
+
+## Success Criteria
+
+- Repo changes are PR-ready.
+- Verification notes are concrete.
+- No premature comment is posted to `claudekit-engineer#639`.

--- a/plans/260415-1558-fortiguard-trust-hardening/plan.md
+++ b/plans/260415-1558-fortiguard-trust-hardening/plan.md
@@ -1,0 +1,34 @@
+# FortiGuard Trust Hardening
+
+Status: In Progress
+Issue: `claudekit-docs#147`
+Intake: `claudekit-engineer#639`
+
+## Goal
+
+Reduce repo-owned false-positive risk for `docs.claudekit.cc` by hardening public trust signals, metadata, crawlability, and security posture in the docs site itself.
+
+## Phases
+
+1. [Phase 01](./phase-01-site-trust-signals.md) - Add site-level trust and discovery signals
+2. [Phase 02](./phase-02-validation-and-rollout.md) - Validate outputs and prepare rollout notes
+
+## Expected Outcomes
+
+- Root docs hostname presents as a neutral documentation site
+- Canonical and social metadata are emitted consistently
+- `robots.txt`, `security.txt`, and sitemap artifacts exist
+- Ingress sends basic security headers
+- Remaining infra-only follow-up is isolated from repo-owned work
+
+## Dependencies
+
+- Astro site config
+- Base layout metadata
+- Public static files
+- Kubernetes ingress config
+
+## Notes
+
+- Do not post back to `claudekit-engineer#639` until the docs fix is merged to `dev`, promoted to `main`, and confirmed live.
+- Repo-side hardening is necessary but may not fully clear FortiGuard without external reclassification.

--- a/plans/reports/maintainer-260415-1609-fortiguard-trust-hardening.md
+++ b/plans/reports/maintainer-260415-1609-fortiguard-trust-hardening.md
@@ -1,0 +1,39 @@
+# Maintainer Report - FortiGuard Trust Hardening
+
+Date: 2026-04-15
+Repo: `claudekit-docs`
+Issue: `#147`
+Intake: `claudekit-engineer#639`
+
+## Diagnosis
+
+- FortiGuard blocks `https://docs.claudekit.cc/` as `Spam URLs`.
+- The site is live and returns valid HTML with a valid TLS certificate.
+- Repo-owned gaps were trust and discovery signals, not application availability.
+
+## Repo-Owned Fix Scope
+
+- Reworked `/` into a documentation-first homepage.
+- Added canonical, Open Graph, Twitter, robots, author, and theme metadata.
+- Added `@astrojs/sitemap` with explicit `site` config.
+- Added `robots.txt`, `security.txt`, and `/.well-known/security.txt`.
+- Added baseline ingress security headers.
+- Disabled the AI assistant launcher on the root homepage to reduce visual clutter.
+
+## Validation
+
+- `bun run build` passed after changes.
+- Verified generated outputs:
+  - `dist/sitemap-index.xml`
+  - `dist/robots.txt`
+  - `dist/security.txt`
+  - `dist/.well-known/security.txt`
+- Verified built root HTML contains canonical and social metadata.
+- Captured local UI sanity screenshot of the cleaned root page.
+
+## Remaining Non-Repo Work
+
+- Deploy the docs repo fix to `dev`.
+- Promote `dev` to `main`.
+- Re-submit or escalate FortiGuard reclassification once production reflects the changes.
+- Post one final status update back to `claudekit-engineer#639` only after the rollout is complete.

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@claudekit.cc
+Contact: mailto:support@claudekit.cc
+Expires: 2026-10-15T00:00:00.000Z
+Preferred-Languages: en, vi
+Canonical: https://docs.claudekit.cc/.well-known/security.txt
+Policy: https://docs.claudekit.cc/docs/support

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.claudekit.cc/sitemap-index.xml

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,6 @@
+Contact: mailto:security@claudekit.cc
+Contact: mailto:support@claudekit.cc
+Expires: 2026-10-15T00:00:00.000Z
+Preferred-Languages: en, vi
+Canonical: https://docs.claudekit.cc/.well-known/security.txt
+Policy: https://docs.claudekit.cc/docs/support

--- a/src/content/docs/engineer/skills/ck-plan.md
+++ b/src/content/docs/engineer/skills/ck-plan.md
@@ -10,7 +10,7 @@ published: true
 
 # Plan
 
-Creates structured, research-backed implementation plans in your `plans/` directory. Formerly split across `/ck:plan --fast`, `/ck:plan --hard`, and other commands—now consolidated into one skill.
+Creates structured, research-backed implementation plans in the active plan root. Project scope defaults to `plans/` in the current project. Global scope is allowed conditionally and resolves through the configured global plans root, defaulting to `~/.claude/plans/` when unset. Formerly split across `/ck:plan --fast`, `/ck:plan --hard`, and other commands—now consolidated into one skill.
 
 ## What This Skill Does
 
@@ -45,6 +45,16 @@ Composable flags:
 - `/ck:plan "implement real-time notifications + presence" --parallel`
 - `/ck:plan "redesign auth system" --two`
 - `/ck:plan "scaffold new microservice" --auto --no-tasks`
+- `/ck:plan "create shared architecture roadmap" --global`
+
+## Scope Rules
+
+- **Project scope** is the default whenever the current working tree has project context.
+- **Global scope** is allowed when:
+  - you explicitly ask for it with `--global`, or
+  - there is no project context to anchor a local plan.
+- **No project context** means no `.git`, `package.json`, or `CLAUDE.md` was found in the ancestor chain.
+- Scan unfinished plans in the active scope before creating a new one.
 
 ## Workflow Process
 
@@ -76,6 +86,8 @@ plans/
         └── researcher-*.md  # Research findings
 ```
 
+Global scope uses the same directory shape under the configured global plans root instead of the current project.
+
 Each phase file contains: overview, requirements, architecture, file ownership,
 implementation steps, todo checklist, success criteria, risk assessment.
 
@@ -97,6 +109,16 @@ Use `--no-tasks` when you want the plan only (e.g., for review before execution)
 
 If planning used `--tdd`, keep that flag on the cook handoff command:
 `/ck:cook /absolute/path/to/plan.md --tdd`
+
+## Cross-Plan Dependencies
+
+Use `ck plan status` as the authoritative dependency/status view.
+
+- Bare references such as `260413-auth-system` stay in the current scope.
+- Cross-scope references use explicit prefixes:
+  - `global:260413-auth-system`
+  - `project:260413-dashboard`
+- Missing refs should warn and render as `not found`, not hard-fail the plan.
 
 ## Active Plan State
 

--- a/src/content/docs/engineer/skills/index.md
+++ b/src/content/docs/engineer/skills/index.md
@@ -84,7 +84,7 @@ As of engineer@2.12.0, all 19 commands have been migrated to skills. The `/` sla
 | [cook](/docs/engineer/skills/cook) | Feature implementation workflow |
 | [fix](/docs/engineer/skills/fix) | Bug fixing with intelligent routing |
 | [git](/docs/engineer/skills/git) | Git operations with conventional commits |
-| [plans-kanban](/docs/engineer/skills/plans-kanban) | Visual plan progress tracking |
+| [plans-kanban](/docs/engineer/skills/plans-kanban) | Open the integrated plans dashboard in the CLI UI |
 | [project-management](/docs/engineer/skills/project-management) | Task tracking, plan status, session bridging |
 | [team](/docs/engineer/skills/team) | Agent Teams for parallel multi-session collaboration |
 | [ask](/docs/engineer/skills/ask) | Answer technical and architectural questions |
@@ -92,7 +92,7 @@ As of engineer@2.12.0, all 19 commands have been migrated to skills. The `/` sla
 | [coding-level](/docs/engineer/skills/coding-level) | Set coding experience level for tailored output |
 | [docs](/docs/engineer/skills/docs) | Manage project documentation (init, update, summarize) |
 | [journal](/docs/engineer/skills/journal) | Write development journal entries |
-| [kanban](/docs/engineer/skills/kanban) | AI agent orchestration board |
+| [kanban](/docs/engineer/skills/kanban) | Alias launcher for the plans dashboard |
 | [preview](/docs/engineer/skills/preview) | View files or generate visual explanations and diagrams |
 | [test](/docs/engineer/skills/test) | Run test suites, coverage analysis, build verification |
 | [use-mcp](/docs/engineer/skills/use-mcp) | Utilize MCP server tools |

--- a/src/content/docs/engineer/skills/kanban.md
+++ b/src/content/docs/engineer/skills/kanban.md
@@ -1,6 +1,6 @@
 ---
 title: "ck:kanban"
-description: "AI agent orchestration board for task visualization and team coordination"
+description: "Alias launcher for the ClaudeKit plans dashboard"
 section: engineer
 kit: engineer
 category: skills
@@ -9,16 +9,31 @@ order: 55
 
 # Kanban
 
-AI agent orchestration board for visualizing tasks and coordinating agent teams. View and manage work in progress across your project.
+`ck:kanban` is now an alias for the plans dashboard launcher.
+
+It no longer refers to a separate AI agent orchestration board in the engineer kit. For engineer users, this command opens the same integrated plans experience as `ck:plans-kanban`.
 
 ## Usage
 
-```
+```bash
 /ck:kanban
 ```
 
-## What It Does
+## Current Behavior
 
-- Visualizes current tasks and their status
-- Tracks agent assignments and progress
-- Provides project overview dashboard
+- opens the plans dashboard inside `ck config ui`
+- starts the dashboard if it is not already running
+- follows CLI auto-fallback ports if `3456` is unavailable
+- accepts old path/server flags with warnings for compatibility
+
+## Use It For
+
+- visual plan progress tracking
+- phase timelines and activity views
+- quick navigation into `plan.md` and phase files
+- lightweight plan-state actions from the dashboard
+
+## Related Skills
+
+- [ck:plans-kanban](/docs/engineer/skills/plans-kanban) - primary plans dashboard launcher
+- [ck:plan](/docs/engineer/skills/ck-plan) - plan creation and updates

--- a/src/content/docs/engineer/skills/plans-kanban.md
+++ b/src/content/docs/engineer/skills/plans-kanban.md
@@ -24,6 +24,12 @@ It opens the ClaudeKit CLI dashboard plans route and gives you:
 - markdown reader navigation for `plan.md` and phase files
 - quick phase actions such as start, complete, reset, validate, and start-next
 
+Scope note:
+
+- Project dashboards should show project-scoped plans only.
+- Global dashboards should show global-scoped plans only.
+- `ck plan status` remains the authoritative dependency/status view for `blockedBy` / `blocks`.
+
 ## How It Works
 
 When invoked, the launcher:
@@ -64,7 +70,7 @@ Old standalone-server flags are still accepted with warnings so existing habits 
 
 | Legacy input | Current behavior |
 | --- | --- |
-| `--dir <path>` / positional path | Warns and ignores. The dashboard now discovers plans through the CLI UI route. |
+| `--dir <path>` / positional path | Warns and ignores. This launcher opens the generic `/plans` route and does not choose a custom plan root. |
 | `--plans <path>` | Warns and ignores. |
 | `--port <n>` | Warns and ignores. The launcher targets the CLI dashboard starting at `3456`. |
 | `--host <addr>` | Warns and ignores. Use `ck config ui --host ...` directly if needed. |
@@ -97,6 +103,8 @@ That means:
 - there is no separate `localhost:3500` dashboard anymore
 - the canonical visual experience lives under the CLI dashboard
 - the skill exists to open the right place quickly, not to run a separate app stack
+- the generic `/plans` route still defaults to `plans` unless a `dir` query param is already present
+- scope-aware plan roots come from project/global dashboard context, not deprecated launcher flags
 
 ## Troubleshooting
 

--- a/src/content/docs/engineer/skills/plans-kanban.md
+++ b/src/content/docs/engineer/skills/plans-kanban.md
@@ -1,6 +1,6 @@
 ---
 title: "ck:plans-kanban"
-description: Visual dashboard server for viewing plan directories with progress tracking, timeline visualization, phase status, and activity heatmap
+description: Open the ClaudeKit plans dashboard inside the CLI config UI for plan tracking, timelines, reader navigation, and quick phase actions
 section: engineer
 kit: engineer
 category: skills
@@ -8,309 +8,122 @@ order: 50
 published: true
 ---
 
-# Plans Kanban Dashboard
+# Plans Dashboard
 
-> Transform plan directories into visual dashboards with progress tracking, Gantt timelines, and phase status indicators.
+> Open the integrated plans dashboard inside `ck config ui`.
 
 ## What This Skill Does
 
-Plans Kanban Dashboard is a background HTTP server that renders interactive visual dashboards for plan directories. It automatically parses `plan.md` files and phase documents to display progress bars, phase breakdowns, timeline visualizations, and activity heatmaps.
+`ck:plans-kanban` is now a thin launcher, not a standalone server.
 
-This skill is essential for monitoring multi-phase implementation plans, tracking progress across parallel development efforts, and visualizing project timelines. The glassmorphism UI with dark mode provides a modern, readable interface accessible from any browser.
+It opens the ClaudeKit CLI dashboard plans route and gives you:
 
-## Prerequisites
+- multi-plan grid and kanban views
+- single-plan detail pages with progress summaries
+- timeline and activity heatmap views
+- markdown reader navigation for `plan.md` and phase files
+- quick phase actions such as start, complete, reset, validate, and start-next
 
-**Installation Required**:
-```bash
-# Option 1: Install via ClaudeKit CLI (recommended)
-ck init  # Runs install.sh which handles all skills
+## How It Works
 
-# Option 2: Manual installation
-cd .claude/skills/plans-kanban
-npm install
+When invoked, the launcher:
+
+1. checks whether the CLI dashboard is already running
+2. starts `ck config ui --port 3456 --no-open` if needed
+3. opens the plans route in your browser
+
+Default URL:
+
+```text
+http://localhost:3456/plans
 ```
 
-**Dependencies**: `gray-matter` (installed via npm)
+If port `3456` is busy, the CLI may auto-fallback to `3457-3460`, and the launcher follows that running port.
 
-**Without installation**: You'll get **Error 500** when viewing plan details.
-
-## Activation
-
-This skill activates automatically when:
-- User mentions viewing plans, kanban dashboard, or progress tracking
-- User references plan directories or phase management
-- User wants visual timeline or Gantt chart
-
-Manual activation:
-```bash
-/ck:kanban [plans-directory]
-```
-
-## Quick Start
+## Usage
 
 ```bash
-# View plans dashboard
-node .claude/skills/plans-kanban/scripts/server.cjs \
-  --dir ./plans \
-  --open
-
-# Remote access (accessible from network)
-node .claude/skills/plans-kanban/scripts/server.cjs \
-  --dir ./plans \
-  --host 0.0.0.0 \
-  --open
-
-# Background mode (keep terminal free)
-node .claude/skills/plans-kanban/scripts/server.cjs \
-  --dir ./plans \
-  --background
-
-# Stop all running servers
-node .claude/skills/plans-kanban/scripts/server.cjs --stop
+/ck:plans-kanban
 ```
 
-## Features
-
-### Dashboard View
-
-Plan cards display:
-- **Progress bars**: Visual percentage of completed phases
-- **Phase breakdown**: Count of completed, in-progress, and pending phases
-- **Last modified**: Timestamp of most recent update
-- **Issue links**: GitHub issue references (if present)
-- **Branch links**: Git branch references (if present)
-- **Priority indicators**: High/medium/low priority badges
-
-### Timeline Visualization
-
-Gantt-style timeline showing:
-- Plan duration from start to estimated completion
-- Overlapping plans for resource planning
-- Activity heatmap highlighting busy periods
-- Phase milestones and deadlines
-
-### Design
-
-- **Glassmorphism UI**: Frosted glass effect with backdrop blur
-- **Dark mode**: Warm accent colors optimized for night viewing
-- **Responsive grid**: Adapts to screen size (desktop, tablet, mobile)
-- **Warm accents**: Amber and orange highlights for visual hierarchy
-
-## CLI Options
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--dir <path>` | Plans directory to scan | Required |
-| `--port <number>` | Server port | 3500 |
-| `--host <addr>` | Host to bind (`0.0.0.0` for remote) | localhost |
-| `--open` | Auto-open browser | false |
-| `--background` | Run in background | false |
-| `--stop` | Stop all servers | - |
-
-## Architecture
-
-```
-scripts/
-├── server.cjs               # Main entry point
-└── lib/
-    ├── port-finder.cjs      # Port allocation (3500-3550)
-    ├── process-mgr.cjs      # PID management (/tmp)
-    ├── http-server.cjs      # HTTP routing
-    ├── plan-parser.cjs      # Plan.md parsing
-    ├── plan-scanner.cjs     # Directory scanning
-    ├── plan-metadata-extractor.cjs  # Rich metadata extraction
-    └── dashboard-renderer.cjs       # HTML generation
-
-assets/
-├── dashboard-template.html  # Dashboard HTML template
-├── dashboard.css           # Glassmorphism styles
-└── dashboard.js            # Client interactivity
-```
-
-## HTTP Routes
-
-| Route | Description |
-|-------|-------------|
-| `/` or `/ck:kanban` | Dashboard view for default directory |
-| `/ck:kanban?dir=<path>` | Dashboard for specific directory |
-| `/api/plans` | JSON API for plans data |
-| `/api/plans?dir=<path>` | JSON API for specific directory |
-| `/assets/*` | Static assets (CSS, JS) |
-| `/file/*` | Local file serving (for images, etc.) |
-
-## Plan Directory Structure
-
-The dashboard scans for directories containing `plan.md` files:
-
-```
-plans/
-├── 251215-feature-a/
-│   ├── plan.md              # Required - parsed for metadata and phases
-│   ├── phase-01-setup.md
-│   ├── phase-02-impl.md
-│   └── phase-03-test.md
-├── 251214-feature-b/
-│   ├── plan.md
-│   └── phase-01-research.md
-└── templates/               # Excluded by default (no plan.md)
-```
-
-**Required**: Each plan directory must contain `plan.md` with frontmatter:
-
-```yaml
----
-title: "ck:plans-kanban"
-status: in-progress
-priority: high
-issue: https://github.com/org/repo/issues/123
-branch: feature/feature-a
-created: 2025-12-15
----
-```
-
-## Remote Access
-
-For network access from other devices:
+Direct launcher:
 
 ```bash
-# Bind to all interfaces
-node .claude/skills/plans-kanban/scripts/server.cjs \
-  --dir ./plans \
-  --host 0.0.0.0 \
-  --port 3500
+node .claude/skills/plans-kanban/scripts/open-dashboard.cjs
 ```
 
-Server output includes both local and network URLs:
-
-```json
-{
-  "success": true,
-  "url": "http://localhost:3500/kanban?dir=...",
-  "networkUrl": "http://192.168.2.75:3500/kanban?dir=...",
-  "port": 3500
-}
-```
-
-**Use networkUrl to access from phones, tablets, or other computers on same network.**
-
-## Capabilities
-
-### Progress Tracking
-
-Dashboard automatically calculates completion percentage:
-
-```markdown
-# plan.md
-
-## Phase 1: Setup [completed]
-## Phase 2: Implementation [in-progress]
-## Phase 3: Testing [pending]
-
-Progress: 33% (1/3 completed)
-```
-
-**When to use**: Track multi-phase projects, monitor parallel teams, visualize sprint progress.
-
-### Timeline Visualization
-
-Gantt chart shows:
-- Plan start and end dates
-- Overlapping plans (resource conflicts)
-- Critical path highlighting
-- Milestone markers
-
-**When to use**: Capacity planning, deadline tracking, resource allocation.
-
-### JSON API Integration
-
-Programmatic access to plan data:
+Run the dashboard manually:
 
 ```bash
-curl http://localhost:3500/api/plans | jq '.plans[] | {title, status, progress}'
+ck config ui
 ```
 
-**When to use**: CI/CD integration, reporting dashboards, automation scripts.
+## Deprecated Compatibility
 
-## Examples
+Old standalone-server flags are still accepted with warnings so existing habits do not break abruptly.
 
-### Example 1: Monitor Development Sprints
+| Legacy input | Current behavior |
+| --- | --- |
+| `--dir <path>` / positional path | Warns and ignores. The dashboard now discovers plans through the CLI UI route. |
+| `--plans <path>` | Warns and ignores. |
+| `--port <n>` | Warns and ignores. The launcher targets the CLI dashboard starting at `3456`. |
+| `--host <addr>` | Warns and ignores. Use `ck config ui --host ...` directly if needed. |
+| `--background` / `--foreground` | Warns and ignores. The standalone server flow no longer exists. |
+| `--stop` | Stops the launcher-managed dashboard process if present; otherwise prints manual shutdown guidance. |
+| `--open` | Accepted. Opening is now the default behavior. |
+
+## Related CLI Commands
 
 ```bash
-# Start dashboard for sprint plans
-/ck:kanban plans/sprints/
-
-# Access from phone to check progress during standup
-# Use networkUrl: http://192.168.1.100:3500/kanban?dir=plans/sprints
+ck config ui
+ck plan status /absolute/path/to/plan.md
+cd /absolute/path/to/plan-dir && ck plan check 1 --start
+cd /absolute/path/to/plan-dir && ck plan check 1
+cd /absolute/path/to/plan-dir && ck plan uncheck 1
 ```
 
-### Example 2: Track Parallel Feature Development
+## What Changed
 
-```
-plans/
-├── feature-auth/
-│   ├── plan.md [in-progress, 60% complete]
-│   ├── phase-01-design.md [completed]
-│   └── phase-02-impl.md [in-progress]
-├── feature-api/
-│   ├── plan.md [in-progress, 80% complete]
-│   └── phase-01-endpoints.md [completed]
-└── feature-ui/
-    └── plan.md [pending, 0% complete]
-```
+Before this migration, `plans-kanban` owned:
 
-Dashboard shows all three features side-by-side with progress bars and timeline overlap.
+- its own localhost server
+- its own renderer and static assets
+- its own background server lifecycle
 
-## Best Practices
+After the migration, those responsibilities moved into `claudekit-cli` and `ck config ui`.
 
-**Use consistent phase naming**: `phase-01-name.md`, `phase-02-name.md` for automatic sorting.
+That means:
 
-**Update plan.md frontmatter**: Keep status, priority, and dates current for accurate dashboards.
-
-**Include issue/branch links**: Dashboard auto-links to GitHub for quick navigation.
-
-**Run in background mode**: Free up terminal while keeping dashboard accessible.
-
-**Use network access for teams**: Share networkUrl for team visibility during standups.
-
-**Check /api/plans for automation**: Integrate with CI/CD or reporting tools.
+- there is no separate `localhost:3500` dashboard anymore
+- the canonical visual experience lives under the CLI dashboard
+- the skill exists to open the right place quickly, not to run a separate app stack
 
 ## Troubleshooting
 
-**Problem**: Port 3500 already in use.
+**`ck` not found**
 
-**Solution**: Server auto-increments to next available port (3500-3550). Check terminal output for actual port.
+Install the ClaudeKit CLI and confirm `ck --version` works.
 
----
+**Dashboard did not open**
 
-**Problem**: No plans found in directory.
+Start it manually with:
 
-**Solution**: Ensure each plan directory contains `plan.md` file. Check directory path is correct.
+```bash
+ck config ui --port 3456
+```
 
----
+Then open `/plans` on the port the CLI reports.
 
-**Problem**: Can't access from other devices.
+**Need a custom host or port**
 
-**Solution**: Use `--host 0.0.0.0` to bind to all network interfaces. Check firewall allows port 3500.
+Run `ck config ui` directly with the flags you need. The skill intentionally stays thin and opinionated.
 
----
+**Need to stop a launcher-started dashboard**
 
-**Problem**: Server won't stop with `--stop`.
-
-**Solution**: Check `/tmp/plans-kanban-*.pid` for stale PID files. Manually kill process or delete PID files.
-
----
-
-**Problem**: Progress shows 0% but phases are marked completed.
-
-**Solution**: Verify phase markdown files have status indicators in headers: `## Phase 1: Name [completed]`
+Run the launcher again with `--stop`. If you started the dashboard manually, stop the terminal running `ck config ui`.
 
 ## Related Skills
 
-- [Markdown Novel Viewer](/docs/engineer/skills/markdown-novel-viewer) - Read individual plan files with rich formatting
-- [Planning](/docs/engineer/skills/ck-plan) - Create and structure plan directories
-- [Research](/docs/engineer/skills/research) - Gather requirements for planning
-
-## Related Commands
-
-- `/ck:kanban` - Quick access to dashboard server
-- `/ck:preview` - View individual plan files (uses Markdown Novel Viewer)
+- [ck:kanban](/docs/engineer/skills/kanban) - alias launcher for the same plans dashboard
+- [ck:plan](/docs/engineer/skills/ck-plan) - plan creation and state management
+- [markdown-novel-viewer](/docs/engineer/skills/markdown-novel-viewer) - long-form markdown reading

--- a/src/content/docs/getting-started/migration-from-commands-to-skills.md
+++ b/src/content/docs/getting-started/migration-from-commands-to-skills.md
@@ -67,7 +67,7 @@ These commands remain as slash commands:
 - `/ck:coding-level` — Set coding detail level
 - `/ck:docs*` — Documentation generation
 - `/ck:journal` — Session journaling
-- `/ck:kanban` — Task board management
+- `/ck:kanban` — Plans dashboard launcher
 - `/ck:plan*` — Planning workflows
 - `/ck:preview` — Preview changes
 - `/ck:code-review` — Codebase review (migrated from `/review:codebase*`)

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,6 +19,17 @@ const {
 
 // Generate alternate URLs for hreflang tags
 const alternates = slug ? getAlternateUrls(slug) : [];
+const siteUrl = Astro.site ?? new URL('https://docs.claudekit.cc');
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl);
+
+canonicalUrl.search = '';
+canonicalUrl.hash = '';
+
+const socialImageUrl = new URL('/og-image.png', siteUrl);
+const ogLocale = locale === 'vi' ? 'vi_VN' : 'en_US';
+const alternateOgLocales = Array.from(
+  new Set(alternates.map(({ lang }) => (lang === 'vi' ? 'vi_VN' : lang === 'en' ? 'en_US' : null)))
+).filter((value): value is 'en_US' | 'vi_VN' => value !== null && value !== ogLocale);
 ---
 
 <!DOCTYPE html>
@@ -27,14 +38,35 @@ const alternates = slug ? getAlternateUrls(slug) : [];
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
+    <meta name="author" content="ClaudeKit" />
+    <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
+    <meta name="theme-color" content="#0d0d0d" />
     <meta name="generator" content={Astro.generator} />
 
     <link rel="icon" type="image/png" href="/logo-512-transparent.png" />
+    <link rel="canonical" href={canonicalUrl.toString()} />
 
     <!-- Hreflang tags for SEO -->
     {alternates.map(({ lang, url }) => (
       <link rel="alternate" hreflang={lang} href={url} />
     ))}
+
+    <meta property="og:site_name" content="ClaudeKit Documentation" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl.toString()} />
+    <meta property="og:image" content={socialImageUrl.toString()} />
+    <meta property="og:image:alt" content="ClaudeKit Documentation" />
+    <meta property="og:locale" content={ogLocale} />
+    {alternateOgLocales.map((value) => (
+      <meta property="og:locale:alternate" content={value} />
+    ))}
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={socialImageUrl.toString()} />
 
     <title>{title}</title>
   </head>

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -23,6 +23,7 @@ export interface Props {
   content?: { body: string; data: Record<string, any> };
   contentWidth?: 'default' | 'wide';
   showTableOfContents?: boolean;
+  showAssistant?: boolean;
 }
 
 const {
@@ -33,6 +34,7 @@ const {
   headings = [],
   contentWidth = 'default',
   showTableOfContents = true,
+  showAssistant = true,
 } = Astro.props;
 const currentPath = Astro.url.pathname;
 const shouldShowTableOfContents = showTableOfContents && headings.length > 0;
@@ -83,8 +85,12 @@ const frontmatter = content?.data || {
         )}
       </div>
 
-      {/* AI Assistant - Two-stage UX (client:only to avoid SSR hook errors) */}
-      <DocsAssistant client:only="react" />
+      {showAssistant && (
+        <>
+          {/* AI Assistant - Two-stage UX (client:only to avoid SSR hook errors) */}
+          <DocsAssistant client:only="react" />
+        </>
+      )}
     </div>
   </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,144 +1,139 @@
 ---
 import DocsLayout from '../layouts/DocsLayout.astro';
-import HomeHero from '../components/home/HomeHero.astro';
-import HomeValueProps from '../components/home/HomeValueProps.astro';
-import HomeWorkflowProof from '../components/home/HomeWorkflowProof.astro';
-import HomeGetStarted from '../components/home/HomeGetStarted.astro';
 
-const title = 'ClaudeKit - Build Software Like You Have a Team';
-const description = '14 specialized AI agents working together. Write less code, ship faster, maintain quality. Reclaim 50-70% of time on repetitive tasks.';
+const title = 'ClaudeKit Documentation';
+const description =
+  'Official documentation for ClaudeKit CLI, Engineer, and Marketing kits, including installation, workflows, troubleshooting, and support resources.';
 
-const heroCode = `# Install ClaudeKit CLI
-npm install -g claudekit-cli
+const quickLinks = [
+  { title: 'Install ClaudeKit', description: 'Start with setup, access requirements, and first-run guidance.', href: '/docs/getting-started/installation' },
+  { title: 'Read The Introduction', description: 'Understand how the CLI, agents, commands, and skills fit together.', href: '/docs/getting-started/introduction' },
+  { title: 'Get Support', description: 'Find troubleshooting steps, FAQ entries, and support channels.', href: '/docs/support' },
+  { title: 'Review The Changelog', description: 'See what changed across recent ClaudeKit releases.', href: '/docs/changelog' },
+];
 
-# Create new project
-ck new --dir my-app
+const sections = [
+  { title: 'Getting Started', description: 'Installation, concepts, quick start, and migration guidance.', href: '/docs/getting-started' },
+  { title: 'CLI', description: 'Command reference, configuration, backups, and architecture.', href: '/docs/cli' },
+  { title: 'Engineer', description: 'Agents, commands, configuration, and technical skills.', href: '/docs/engineer' },
+  { title: 'Marketing', description: 'Marketing agents, content workflows, and automation skills.', href: '/docs/marketing' },
+  { title: 'Workflows', description: 'End-to-end playbooks for planning, implementation, testing, and delivery.', href: '/docs/workflows' },
+  { title: 'Support', description: 'Troubleshooting, FAQ, community, and escalation paths.', href: '/docs/support' },
+];
 
-# Select "Engineer Kit"
-# Wait for installation to complete
-
-# Start the project
-cd my-app
-
-# Start Claude Code
-claude
-# or \`claude --dangerously-skip-permissions\` (use as your own risk)
-
-# Bootstrap a new project, or plan and implement a feature
-/ck:bootstrap [create a calendar booking app that sync with Apple & Google Calendar]
-/ck:plan [add user authentication]
-/ck:cook [implement user authentication]
-
-# Review, approve, deploy`;
-
-const cliCode = `# Initialize ClaudeKit Engineer in your project
-ck init --kit engineer
-
-# Update ClaudeKit Engineer to latest version
-ck init
-
-# Check available ClaudeKit versions
-ck versions`;
-
-const planningCode = `# Planner agent reads your codebase
-/ck:plan [add real-time notifications with WebSocket]
-
-# Creates detailed implementation plan:
-# - Architecture decisions
-# - File changes needed
-# - Test strategy
-# - Security considerations`;
-
-const implementationCode = `# Implement based on plan
-/ck:cook [implement WebSocket notifications based on the plan]
-
-# Generates:
-# - Server-side WebSocket handler
-# - Client-side connection manager
-# - Event types and validators
-# - Error handling and reconnection logic`;
-
-const testingCode = `# Tester agent creates comprehensive tests
-/ck:test [WebSocket notifications]
-
-# Produces:
-# - Unit tests for handlers
-# - Integration tests for end-to-end flow
-# - Mock WebSocket server
-# - Coverage report`;
-
-const debuggingCode = `# Debug and fix issues
-/ck:debug [users are reporting timeout errors on checkout]
-
-# Agent workflow:
-# 1. Searches logs for timeout patterns
-# 2. Traces code execution paths
-# 3. Identifies bottleneck in payment processing
-# 4. Suggests fixes with performance impact
-# 5. Generates tests to prevent regression`;
-
-const refactoringCode = `# Map codebase structure
-/ck:scout analyze the authentication system
-
-# Planner creates refactoring roadmap
-/ck:plan [migrate from sessions to JWT]
-
-# Implement changes from plan
-/clear
-/ck:cook implement JWT authentication as planned
-
-# Tester ensures nothing breaks
-/ck:test [authentication system]`;
-
-const step1Code = `npm install -g claudekit-cli`;
-const step2Code = `ck new my-first-app
-cd my-first-app`;
-const step3Code = `/ck:plan [add user registration API]
-/clear
-/ck:cook [implement the registration endpoint as planned]`;
-const step4Code = `git diff
-npm test
-# commit via git-manager or manually`;
+const trustLinks = [
+  { label: 'LLMs.txt', href: '/llms.txt', description: 'Machine-readable site index for AI tooling and retrieval.' },
+  { label: 'Sitemap', href: '/sitemap-index.xml', description: 'XML sitemap for search engines and security scanners.' },
+  { label: 'Security.txt', href: '/.well-known/security.txt', description: 'Security contact and disclosure information.' },
+];
 
 const headings = [
-  { depth: 2, text: 'Why ClaudeKit?', slug: 'why-claudekit' },
-  { depth: 3, text: 'Specialized Agents, Real Results', slug: 'specialized-agents-real-results' },
-  { depth: 3, text: 'Eliminate Repetitive Work', slug: 'eliminate-repetitive-work' },
-  { depth: 3, text: 'Stay in Control', slug: 'stay-in-control' },
-  { depth: 2, text: 'How It Works', slug: 'how-it-works' },
-  { depth: 3, text: 'ClaudeKit Engineer: 14 Specialized Agents', slug: 'claudekit-engineer-14-specialized-agents' },
-  { depth: 3, text: 'ClaudeKit CLI: Smart Project Management', slug: 'claudekit-cli-smart-project-management' },
-  { depth: 2, text: 'Real Developer Workflows', slug: 'real-developer-workflows' },
-  { depth: 3, text: 'Building a New Feature', slug: 'building-a-new-feature' },
-  { depth: 3, text: 'Debugging Production Issues', slug: 'debugging-production-issues' },
-  { depth: 3, text: 'Refactoring Legacy Code', slug: 'refactoring-legacy-code' },
-  { depth: 2, text: 'Proven Results', slug: 'proven-results' },
-  { depth: 2, text: 'What Developers Say', slug: 'what-developers-say' },
-  { depth: 2, text: 'Get Started in 5 Minutes', slug: 'get-started-in-5-minutes' },
-  { depth: 2, text: 'Explore Documentation', slug: 'explore-documentation' },
+  { depth: 2, text: 'Overview', slug: 'overview' },
+  { depth: 2, text: 'Start Here', slug: 'start-here' },
+  { depth: 2, text: 'Documentation Sections', slug: 'documentation-sections' },
+  { depth: 2, text: 'Trust And Support', slug: 'trust-and-support' },
 ];
 ---
 
-<DocsLayout
-  title={title}
-  description={description}
-  headings={headings}
-  contentWidth="wide"
->
-  <HomeHero heroCode={heroCode} />
-  <HomeValueProps />
-  <HomeWorkflowProof
-    cliCode={cliCode}
-    planningCode={planningCode}
-    implementationCode={implementationCode}
-    testingCode={testingCode}
-    debuggingCode={debuggingCode}
-    refactoringCode={refactoringCode}
-  />
-  <HomeGetStarted
-    step1Code={step1Code}
-    step2Code={step2Code}
-    step3Code={step3Code}
-    step4Code={step4Code}
-  />
+<DocsLayout title={title} description={description} headings={headings} contentWidth="wide" showAssistant={false}>
+  <section class="space-y-6 pb-10 pt-2">
+    <p class="text-sm font-medium uppercase tracking-[0.16em] text-[var(--color-text-muted)]">Official Documentation</p>
+    <h1 class="text-4xl font-bold tracking-tight text-[var(--color-text-primary)] sm:text-5xl">ClaudeKit Documentation</h1>
+    <p class="max-w-4xl text-lg leading-8 text-[var(--color-text-secondary)]">Official documentation for ClaudeKit installation, CLI usage, Engineer and Marketing kits, workflow guides, troubleshooting, and support resources.</p>
+
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {quickLinks.map((item) => (
+        <a
+          href={item.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h2 class="text-lg font-semibold text-[var(--color-text-primary)]">{item.title}</h2>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{item.description}</p>
+        </a>
+      ))}
+    </div>
+  </section>
+
+  <section id="overview" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Overview</h2>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">ClaudeKit extends Claude Code with kits, agents, commands, and reusable skills. This site is the primary reference for setup, usage, and maintenance across the ClaudeKit stack.</p>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">If you are new here, start with installation and concepts. If you are troubleshooting or validating an existing setup, use the support and workflow sections.</p>
+  </section>
+
+  <section id="start-here" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Start Here</h2>
+    <ol class="grid gap-4 md:grid-cols-3">
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 1</p>
+        <a href="/docs/getting-started/installation" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Install The CLI
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Follow the setup guide, validate repository access, and complete first-run configuration.
+        </p>
+      </li>
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 2</p>
+        <a href="/docs/getting-started/concepts" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Learn The Model
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Understand how kits, agents, slash commands, and skills work together in daily use.
+        </p>
+      </li>
+      <li class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5">
+        <p class="text-sm font-medium uppercase tracking-[0.12em] text-[var(--color-text-muted)]">Step 3</p>
+        <a href="/docs/workflows" class="mt-2 block text-lg font-semibold text-[var(--color-text-primary)]">
+          Run A Workflow
+        </a>
+        <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+          Pick a workflow for planning, implementation, debugging, review, or delivery.
+        </p>
+      </li>
+    </ol>
+  </section>
+
+  <section id="documentation-sections" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Documentation Sections</h2>
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {sections.map((section) => (
+        <a
+          href={section.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">{section.title}</h3>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{section.description}</p>
+        </a>
+      ))}
+    </div>
+  </section>
+
+  <section id="trust-and-support" class="space-y-4 border-t border-[var(--color-border)] pt-10">
+    <h2 class="text-2xl font-semibold text-[var(--color-text-primary)]">Trust And Support</h2>
+    <p class="max-w-4xl leading-7 text-[var(--color-text-secondary)]">
+      The official documentation host is <code>docs.claudekit.cc</code>. Search engine and security tooling can use the
+      references below to verify site ownership, discover pages, and contact the ClaudeKit team when needed.
+    </p>
+
+    <div class="grid gap-4 md:grid-cols-3">
+      {trustLinks.map((item) => (
+        <a
+          href={item.href}
+          class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-5 transition-colors hover:border-[var(--color-border-hover)] hover:bg-[var(--color-bg-tertiary)]"
+        >
+          <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">{item.label}</h3>
+          <p class="mt-2 text-sm leading-6 text-[var(--color-text-secondary)]">{item.description}</p>
+        </a>
+      ))}
+    </div>
+
+    <div class="rounded-2xl border border-[var(--color-border)] bg-[var(--color-bg-secondary)] p-6">
+      <h3 class="text-lg font-semibold text-[var(--color-text-primary)]">Contacts</h3>
+      <ul class="mt-3 space-y-2 text-sm leading-6 text-[var(--color-text-secondary)]">
+        <li>Support: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="mailto:support@claudekit.cc">support@claudekit.cc</a></li>
+        <li>Security: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="mailto:security@claudekit.cc">security@claudekit.cc</a></li>
+        <li>Community: <a class="font-medium text-[var(--color-accent-blue)] hover:underline" href="https://claudekit.cc/discord">claudekit.cc/discord</a></li>
+      </ul>
+    </div>
+  </section>
 </DocsLayout>


### PR DESCRIPTION
## Summary

Promote the current `dev` branch to `main` for `claudekit-docs`.

This promotion includes the docs changes currently merged into `dev`:
- `#146` - plan system / dashboard docs updates
- `#148` - docs site trust hardening for the FortiGuard false-positive

## Validation

- `#148` was merged into `dev` on 2026-04-15
- `origin/dev` is ahead of `origin/main`
- no existing open `dev -> main` PR was present at creation time

## Post-Merge Note

After this promotion is merged and the production docs site is confirmed live on `main`, post one final status update back to `claudekit-engineer#639`.
