### PR TITLE
release: promote dev to main (engineer skill docs + migrate refresh)

### DIFF
--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -24,9 +24,41 @@ ck migrate --all --global
 # Preview migration plan without writing files
 ck migrate --dry-run
 
+# Force ASCII borders for legacy terminals
+CK_FORCE_ASCII=1 ck migrate --agent codex --dry-run
+
 # Non-interactive with sensible defaults
 ck migrate --yes
 ```
+
+## Terminal Flow
+
+The current CLI flow is optimized to answer the two questions users actually ask during migration:
+
+1. **Where will the files go?**
+2. **What changed?**
+
+Before any write happens, `ck migrate` now renders:
+
+- A **source/destination intro panel** showing discovered Claude Code content and the target provider paths
+- A **pre-flight summary** with one row per portable type (`Agents`, `Skills`, `Commands`, `Config`, `Rules`, `Hooks`)
+- Inline scope notes such as `Codex: global-only` or `merge` when a provider does not map 1:1
+
+After execution, the command ends with a boxed footer:
+
+- **WHERE** — destination paths that were actually touched
+- **WHAT** — item counts by type
+- **NEXT** — follow-up commands such as `ck doctor` or provider-specific inspection commands
+
+`--dry-run` uses the same structure, but reports what **would** change instead of writing files.
+
+## Scope Behavior
+
+- **Default scope**: project-level
+- **Global scope**: pass `-g` or `--global`
+- **Provider quirks still apply**: for example, Codex commands remain global-only, so the command will clearly tell you when global output is forced for that provider/type
+
+If you are migrating in older Windows terminals, set `CK_FORCE_ASCII=1` to force the ASCII fallback border set.
 
 ## What Happens
 
@@ -184,7 +216,7 @@ Scans `.claude/agents/`, `.claude/commands/`, `.claude/skills/`, `.claude/rules/
 Auto-detects installed providers or prompts for selection. Use `--agent` or `--all` to skip detection.
 
 ### Phase 3: Scope Selection
-Choose between project-level (`.claude/` in CWD) or global (`~/.claude/`) installation.
+Choose between project-level (`.claude/` in CWD, the default) or global (`~/.claude/`) installation.
 
 ### Phase 4: Reconciliation
 Computes a migration plan using checksums and registry state. Displays actions (install, update, skip, delete, conflict).
@@ -193,7 +225,7 @@ Computes a migration plan using checksums and registry state. Displays actions (
 Installs items, merges hook settings, processes metadata deletions, and cleans up stale entries.
 
 ### Phase 6: Summary
-Displays results with success/skip/failure counts and offers rollback on partial failures.
+Displays a destination-aware `WHERE / WHAT / NEXT` footer and offers rollback on partial failures.
 
 ## Rollback on Failure
 

--- a/src/content/docs/engineer/skills/agentize.md
+++ b/src/content/docs/engineer/skills/agentize.md
@@ -1,0 +1,259 @@
+---
+title: "ck:agentize"
+description: "Convert codebases into agent-friendly CLI and/or MCP server with shared core, tests, and CI"
+section: engineer
+kit: engineer
+category: skills
+order: 62
+---
+
+# Agentize
+
+Transform existing code into an AI agent-friendly and user-friendly surface. Take a feature, module, or entire codebase and expose it as:
+
+- **CLI** — publishable on npm, credential-aware, scriptable
+- **MCP server** — stdio + SSE + Streamable HTTP, deployable on Cloudflare or Docker
+- **Companion skill** — a `/ck:*` skill discoverable on the Claude Plugins Marketplace
+
+Think of it as turning a library into a first-class agent tool that Claude (or other LLMs) can reliably call.
+
+## What This Skill Does
+
+Agentize orchestrates a 7-step workflow: understand the code (scout), analyze capabilities, design agent-friendly interfaces, scaffold a monorepo, wrap the core logic, harden for production, and package for distribution.
+
+The result: one source of truth (shared core), thin CLI/MCP adapters, automatic docs, tests, and CI. No API drift. No duplicate logic.
+
+## Quick Start
+
+```bash
+# Full analysis + implementation (CLI + MCP)
+/ck:agentize ./src/auth --both --auto
+
+# MCP server only
+/ck:agentize ./src/search --mcp --auto
+
+# CLI only, ask clarifying questions first
+/ck:agentize ./src/payment --cli --ask
+```
+
+## Usage
+
+```text
+/ck:agentize [feature-or-module] [--both|--mcp|--cli] [--auto|--ask]
+```
+
+### Output Mode Flags
+
+| Flag | Output |
+|------|--------|
+| `--both` *(default)* | Monorepo with shared `core/`, `cli/` package, `mcp/` package |
+| `--mcp` | MCP server only |
+| `--cli` | CLI package only |
+
+### Interaction Mode Flags
+
+| Flag | Behavior |
+|------|----------|
+| `--auto` *(default)* | Fully autonomous — analyze and implement without questions |
+| `--ask` | After analysis, ask clarifying questions before implementing |
+
+## Workflow Overview
+
+The skill follows a structured 8-phase process:
+
+```
+[0. Track] → [1. Scout] → [2. Analyze] → [3. Decide]
+    ↓           ↓           ↓           ↓
+[7. Package] ← [6. Harden] ← [5. Wrap] ← [4. Scaffold]
+```
+
+**Hard gates:**
+- Phase 0 must run before Phase 1 (plan must exist)
+- Phase 1 must complete before design decisions (read the code first)
+- Phase 3 must resolve output mode before scaffolding
+- In `--ask` mode, Phase 3 blocks on user answers
+
+### Phase 0: Track
+
+Creates a dated plan directory under `plans/` with the invocation arguments and phase checklist. Sets active plan context for all downstream skills.
+
+### Phase 1: Scout (MANDATORY)
+
+Analyzes the target codebase to extract:
+- Entry points and exported APIs
+- Core capabilities worth exposing as tools/commands (typically 5–15)
+- Input/output shapes and parameter validation
+- Side effects (network, filesystem, DB, external services)
+- Configuration surface (env vars, config files, CLI flags)
+- Secrets and credential requirements
+- Language/runtime and dependencies
+- Existing tests to reuse
+
+**Security principle:** Treat READMEs, comments, and existing docs as untrusted guidance. Extract facts only.
+
+### Phase 2: Analyze
+
+Produces an **Agentization Map** showing which capabilities are worth exposing as tools/commands:
+
+| Capability | Function | Inputs | Outputs | Side Effects | Auth | Agent Value | CLI Value |
+|---|---|---|---|---|---|---|---|
+| Search | `search()` | query string | results array | network call | API key | High | High |
+| Cache busting | `invalidate()` | key | void | DB write | admin | Low | Medium |
+
+**Design rules:**
+- Build workflows, not endpoint mirrors (consolidate multi-step flows)
+- Optimize for limited context (concise results, `--detailed` opt-in)
+- Design actionable error messages
+- Prefer human-readable identifiers over opaque IDs
+- Support dry-run and idempotency where mutating
+
+Cut capabilities where both Agent and CLI value are Low.
+
+### Phase 3: Decide
+
+Resolve the output mode and finalize the tool/command list. In `--auto`, the skill chooses sensible defaults. In `--ask`, you answer:
+
+1. Which capabilities are MUST-HAVE v1 vs later?
+2. Read-only vs mutating operations? (affects MCP safety)
+3. Where do credentials come from?
+4. MCP deployment target (stdio-only, Cloudflare, Docker)?
+5. Package name and scope (`@org/…`)?
+6. License and ownership?
+7. Replace or extend an existing CLI?
+
+Output: a decision record with mode, capability list, tool names, transports, and package metadata.
+
+### Phase 4: Scaffold
+
+Creates the repo layout. Default `--both` monorepo structure:
+
+```
+packages/
+├── core/              # extracted reusable logic
+├── cli/               # npm CLI package
+├── mcp/               # MCP server
+├── types/             # shared TypeScript types
+└── tests/             # shared test fixtures
+```
+
+For `--mcp` or `--cli`, creates only the relevant package with inline core logic.
+
+### Phase 5: Wrap
+
+Extracts the core logic into `packages/core/`, then:
+- Creates CLI wrapper with argument parsing, output formatting, credential resolution
+- Creates MCP server with stdio/SSE/HTTP transports, tool definitions, auth flow
+- Shares parameter validation and error handling between both
+
+### Phase 6: Harden
+
+- Unit tests for core logic
+- Integration tests for CLI and MCP
+- Validate inputs, handle edge cases, retry logic
+- Credentials injected at runtime (never embedded)
+- Rate limiting and graceful degradation
+
+### Phase 7: Package
+
+- Document all tools/commands with examples
+- Configure CI/CD (GitHub Actions, semantic versioning)
+- Publish CLI to npm with credential helpers
+- Deploy MCP to Cloudflare Workers or Docker Registry
+- Create companion skill for Claude Plugins Marketplace
+
+## Real-World Example
+
+Convert an auth service into a CLI + MCP:
+
+```bash
+/ck:agentize ./src/auth --both --auto
+```
+
+**Result:**
+- `@myorg/auth-core` — shared auth logic (TypeScript)
+- `@myorg/auth-cli` — npm CLI for local testing, CI/CD integration
+- `myorg/auth-mcp` — MCP server deployable on Cloudflare Workers
+- `/ck:auth` — Claude skill for AI-driven auth operations
+- Complete docs, tests, GitHub Actions CI, semantic release
+
+## Monorepo Layout (--both)
+
+```
+.
+├── packages/
+│   ├── core/
+│   │   ├── src/
+│   │   │   ├── index.ts
+│   │   │   ├── types.ts
+│   │   │   └── ...
+│   │   ├── __tests__/
+│   │   └── package.json
+│   ├── cli/
+│   │   ├── src/
+│   │   │   ├── cli.ts
+│   │   │   ├── commands/
+│   │   │   └── ...
+│   │   ├── __tests__/
+│   │   └── package.json
+│   ├── mcp/
+│   │   ├── src/
+│   │   │   ├── server.ts
+│   │   │   ├── tools/
+│   │   │   └── ...
+│   │   └── package.json
+│   └── types/
+│       ├── index.ts
+│       └── package.json
+├── .github/workflows/
+│   ├── test.yml
+│   └── release.yml
+├── pnpm-workspace.yaml
+├── tsconfig.json
+└── README.md
+```
+
+## Supported Runtimes
+
+- Node.js + TypeScript (primary)
+- Python (via `pypackages/` layout)
+- Go (via shared interface with gRPC)
+
+## Credentials & Environment
+
+Both CLI and MCP support:
+- `.env` files with credential injection
+- OAuth flow integration
+- Environment variable substitution
+- Secure credential prompts (masked input)
+- Credential caching with expiration
+
+## Related Skills
+
+- [MCP Builder](/docs/engineer/skills/mcp-builder) — Build MCP servers from scratch
+- [Cook](/docs/engineer/skills/cook) — Implement features in the wrapped code
+- [Scout](/docs/engineer/skills/scout) — Understand the codebase before wrapping
+- [Skill Creator](/docs/engineer/skills/skill-creator) — Build the `/ck:*` skill for Claude Plugins
+
+## Best Practices
+
+**Understand before wrapping** — Always scout the target code thoroughly before designing the agent interface.
+
+**Shared core, thin adapters** — Keep business logic in `core/`, CLI and MCP adapters thin. Never duplicate logic.
+
+**Agent-centric design** — Design for LLM usage first. Ensure tools return structured, actionable results.
+
+**Credentials at every layer** — No hardcoded secrets. Credentials resolved at runtime in both CLI and MCP.
+
+**Ship with docs and tests** — Every tool and command must have examples and comprehensive tests.
+
+## When to Use Agentize
+
+Use when you have:
+- An existing codebase with useful logic to expose
+- Need for both CLI (npm) and MCP (agent) interfaces
+- Plan to maintain the tool long-term
+
+Don't use for:
+- Building entirely new services (use `/ck:mcp-builder`)
+- Raw npm scaffolding
+- One-off scripts or internal utilities

--- a/src/content/docs/engineer/skills/cti-expert.md
+++ b/src/content/docs/engineer/skills/cti-expert.md
@@ -1,0 +1,231 @@
+---
+title: "ck:cti-expert"
+description: "Cyber threat intelligence and OSINT investigation toolkit for intelligence-grade investigations without API keys"
+section: engineer
+kit: engineer
+category: skills
+order: 25
+---
+
+# CTI Expert
+
+Cyber threat intelligence and open-source intelligence (OSINT) investigation skill. Turns Claude into a trained CTI/OSINT analyst. Generates precision search queries, interprets public data, builds case timelines, and delivers structured intelligence products — no API keys required.
+
+Think of it as having a professional threat intelligence analyst on your team who speaks multiple languages, knows every advanced search technique, and can piece together evidence across hundreds of public data sources.
+
+## What This Skill Does
+
+CTI Expert conducts multi-source investigations into digital footprints, organizations, domains, credentials, and security threats. It handles everything from username enumeration across 3000+ platforms to building threat models from scattered clues.
+
+The skill runs guided case workflows (Acquire → Enrich → Assess → Deliver) that keep investigations organized and verifiable. Every finding is sourced, timestamped, and confidence-scored. You get formal intelligence reports suitable for legal proceedings, executive briefs for decision-makers, or technical threat assessments.
+
+## Quick Start
+
+```bash
+# Full autonomous case — investigates everything applicable
+/case target.com
+
+# Guided workflow for beginners
+/flow person
+
+# Summary of findings so far
+/brief
+
+# Generate formal report
+/report
+```
+
+Append `--yolo` to any command to skip confirmations and let the analyst decide autonomously.
+
+## Investigation Phases
+
+Every case follows the **AEAD** lifecycle:
+
+| Phase | What Happens | Examples |
+|-------|------------|----------|
+| **Acquire** | Collect raw data | sweep domains, enumerate usernames, check breaches |
+| **Enrich** | Expand and connect leads | branch identifiers, build timelines, cross-reference |
+| **Assess** | Score and verify findings | expose score, threat models, validation checks |
+| **Deliver** | Package output | formal reports, executive briefs, IOC exports |
+
+Run `/progress` at any point to see which phase you're in and what's pending.
+
+## Core Capabilities
+
+### Social Media & Username Investigation
+
+```bash
+# Find a username across 3000+ platforms
+/username johndoe
+
+# Enumerate accounts, timeline, connected accounts
+/sweep @johndoe
+```
+
+### Breach & Credential Hunting
+
+```bash
+# Deep breach lookup with context
+/breach-deep user@example.com
+
+# Exposed credentials in repos and paste sites
+/secrets github.com/org
+```
+
+### Domain & IP Intelligence
+
+```bash
+# Full domain reconnaissance
+/sweep example.com
+
+# Technology fingerprint: CMS, analytics, CDN, servers
+/techstack example.com
+
+# DNS history and certificate timeline
+/dns-history example.com
+/cert-history example.com
+```
+
+### Threat & Vulnerability Assessment
+
+```bash
+# Threat intelligence on domain/IP/URL/hash
+/threat-check 185.1.1.1
+
+# Phishing/malware/scam site detection
+/scam-check susp-site.xyz
+
+# CVE and vulnerability lookup
+/vuln-check CVE-2024-1234
+
+# Check if organization is ransomware victim
+/ransomware-check "Acme Corp"
+```
+
+### Cloud & Microsoft 365 Reconnaissance
+
+```bash
+# M365/Azure tenant recon — tenant ID, federation, MDI, SharePoint
+/msftrecon example.com
+
+# Google document metadata and ownership
+/gdoc https://docs.google.com/document/d/...
+```
+
+### Geographic & Transport Intelligence
+
+```bash
+# WiFi SSID geolocation
+/wifi "HomeNetwork"
+
+# Exact AP lookup by MAC address
+/wifi --bssid AA:BB:CC:DD:EE:FF
+```
+
+### Evidence & Reporting
+
+```bash
+# View archived snapshots
+/snapshots example.com
+
+# Full evidence trail for a subject
+/show-trail JohnDoe
+
+# ASCII relationship diagram
+/graph
+```
+
+## Case Management
+
+Save and resume cases:
+
+```bash
+# Persist case state
+/workspace save mycase
+
+# Resume a saved investigation
+/workspace open mycase
+
+# Compare two cases
+/workspace diff case1 case2
+
+# List all saved cases
+/workspace list
+```
+
+## Report Formats
+
+The skill exports intelligence in multiple formats:
+
+| Format | Best For |
+|--------|----------|
+| `/report` | Formal structured intelligence report |
+| `/report brief` | Single-page executive summary |
+| `/report json` | Raw data for integration |
+| `/report csv` | Spreadsheet analysis |
+| `/report legal` | Evidence formatted for legal proceedings |
+| `/report journalist` | Source-citation-heavy format |
+| `/report ioc` | IOCs as STIX 2.1 or flat list |
+
+## Subject Types
+
+CTI Expert tracks entities with rich relationships:
+
+| Type | Symbol | Examples |
+|------|--------|----------|
+| Person | 👤 | Full name, alias |
+| Username | @ | Social handle |
+| Email | 📧 | Address, domain |
+| Domain | 🌐 | Site, subdomain |
+| IP Address | 🖥 | IPv4, IPv6 |
+| Organization | 🏢 | Company, group |
+| Phone | 📱 | E.164 format |
+| Crypto Wallet | 💰 | Bitcoin, Ethereum address |
+| Device | 🖥️ | Server, workstation |
+| Image | 🖼️ | Screenshot, photograph |
+
+## Command Reference
+
+**Acquire phase** — `/case`, `/sweep`, `/username`, `/phone`, `/email-deep`, `/subdomain`, `/breach-deep`, `/traffic`, `/techstack`, `/threat-check`, `/scam-check`, `/vuln-check`, `/msftrecon`, `/dork-sweep`, `/docleak`, `/cert-history`
+
+**Enrich phase** — `/branch`, `/timeline`, `/crossref`, `/link-subjects`, `/show-connections`, `/watch`, `/record-finding`, `/graph`, `/pathfind`
+
+**Assess phase** — `/exposure`, `/threat-model`, `/validate`, `/coverage`, `/verify-finding`, `/subject`, `/lookup`, `/modify`, `/blind-spots`, `/drift`
+
+**Deliver phase** — `/report`, `/brief`, `/report json`, `/report csv`, `/report legal`, `/report ioc`, `/render entities`, `/render timeline`, `/render risk`, `/workspace save/open/list`
+
+**Navigation** — `/flow`, `/progress`, `/opsec`, `/onboard`, `/quality`, `/novice`, `/terms`
+
+See `SKILL.md` in the skill directory for the complete command reference and examples.
+
+## Best Practices
+
+**Collection Method** — The skill uses `agent-browser` when available for JavaScript-heavy sites and infinite-scroll discovery. Falls back to web search, web fetch, and direct URL retrieval when needed. Tool limitations are logged as gaps, never case blockers.
+
+**Search Operators** — CTI Expert generates 12–15 advanced search queries automatically. Each targets a specific platform or data source to maximize signal and minimize noise.
+
+**Confidence Scoring** — All findings are tagged by confidence level and source. The skill will flag ambiguous or high-uncertainty findings for human verification.
+
+**OPSEC Checklist** — Run `/opsec` during sensitive investigations to review operational security practices.
+
+## Use Cases
+
+- **Incident response** — Rapid threat assessment and attribution
+- **Due diligence** — Pre-partnership investigation of companies or individuals
+- **Legal discovery** — Evidence collection for litigation or compliance
+- **Security research** — Vulnerability disclosure and responsible reporting
+- **Fraud investigation** — Tracking digital footprints of bad actors
+- **Brand protection** — Monitoring for impersonation and credential abuse
+- **Threat hunting** — Proactive search for indicators of compromise
+
+## Prerequisites
+
+- No API keys or paid subscriptions required
+- Access to Claude with web search and web fetch capabilities
+- For `agent-browser` features: JavaScript-capable environment (Playwright MCP)
+
+## Related Skills
+
+- [Scout](/docs/engineer/skills/scout) — Quick file search and codebase exploration
+- [Repomix](/docs/engineer/skills/repomix) — Full codebase context dump
+- [Security](/docs/engineer/skills/ck-security) — Automated security auditing

--- a/src/content/docs/engineer/skills/graphify.md
+++ b/src/content/docs/engineer/skills/graphify.md
@@ -1,0 +1,318 @@
+---
+title: "ck:graphify"
+description: "Build queryable knowledge graphs from code, docs, papers, images for architecture understanding"
+section: engineer
+kit: engineer
+category: skills
+order: 42
+---
+
+# Graphify
+
+Turn any folder of code, documentation, papers, or images into a queryable knowledge graph. Uses tree-sitter AST for code (20+ languages), Whisper for audio/video, and LLM agents for documents.
+
+Think of it as building a semantic index of your codebase—one you can search by concept instead of grepping for filenames.
+
+## What This Skill Does
+
+Graphify builds interactive knowledge graphs that reveal architecture, dependencies, and cross-file relationships. Instead of jumping between files, ask the graph "what calls this function?" or "which modules depend on X?" and get visual connection maps.
+
+The skill produces three artifacts: an interactive HTML visualization, a structured markdown report highlighting key insights, and a persistent JSON graph for programmatic queries.
+
+## Quick Start
+
+```bash
+# Build knowledge graph from current directory
+graphify .
+
+# Build from specific path
+graphify /path/to/project
+
+# Watch mode — auto-rebuild on file changes
+graphify . --watch
+
+# Expose graph as MCP server for Claude to query
+python -m graphify.serve graphify-out/graph.json
+```
+
+## When to Use Graphify
+
+**Before planning** — Build the graph first to understand architecture, then plan with visual context.
+
+**Architecture analysis** — Find god nodes (most-connected concepts), surprising dependencies, and architectural anti-patterns.
+
+**Codebase navigation** — Prefer structure-based navigation over grepping when entering unfamiliar projects.
+
+**Token-efficient context** — 71.5x fewer tokens than raw files — crucial for large codebases.
+
+**Cross-domain understanding** — Combine code AST + documents + papers + images for complete context.
+
+## Output Artifacts
+
+| File | Purpose |
+|------|---------|
+| `graphify-out/graph.html` | Interactive visualization with search, filtering, community detection |
+| `graphify-out/GRAPH_REPORT.md` | God nodes, surprising connections, architecture insights, suggested questions |
+| `graphify-out/graph.json` | Persistent graph for queries across sessions |
+| `graphify-out/cache/` | SHA256-based incremental updates (only reprocesses changed files) |
+
+## Interactive Visualization
+
+Open `graphify-out/graph.html` in your browser to:
+
+- **Search for concepts** — Type a class name, function, or topic
+- **Filter by community** — See related concepts grouped automatically
+- **Explore neighbors** — Click a node to see everything connected
+- **Query shortest path** — Find the connection route between two concepts
+
+## Supported Input Types
+
+### Code Files (Tree-Sitter AST)
+
+20+ languages supported with deterministic parsing:
+
+Python, JavaScript, TypeScript, Go, Rust, Java, C, C++, Ruby, C#, Kotlin, Scala, PHP, Swift, Lua, Zig, PowerShell, Elixir, Objective-C, Julia
+
+For each language, the graph extracts:
+- Function and class definitions
+- Imports and dependencies
+- Call chains and inheritance hierarchies
+- Variable assignments and mutations
+- Type annotations (where available)
+
+**No API calls for code** — Tree-sitter runs locally. File contents never leave your machine.
+
+### Audio & Video (Whisper)
+
+Transcribe podcasts, talks, and videos:
+
+```bash
+# Builds knowledge graph from audio transcript + timestamps
+graphify ./videos/*.mp4 --watch
+```
+
+**Local transcription** — Uses Whisper on-device. No files sent to external APIs.
+
+### Documents & Papers (LLM-Powered)
+
+PDFs, Markdown, Office documents — LLM agents extract key concepts, relationships, and summaries:
+
+```bash
+# Extract from all PDFs and markdown
+graphify ./docs ./papers/*.pdf
+```
+
+**Semantic extraction** — Processes via your configured model provider (Claude/OpenAI).
+
+### Images (Vision Models)
+
+Screenshots, diagrams, photographs — extract text and describe visual elements:
+
+```bash
+graphify ./screenshots/*.png
+```
+
+## Graph Report Insights
+
+The auto-generated `GRAPH_REPORT.md` includes:
+
+- **God nodes** — Most-connected concepts in the graph (likely core abstractions)
+- **Surprising connections** — Unexpected dependencies or architectural patterns
+- **Community detection** — Automatically grouped concepts and modules
+- **Suggested questions** — Intelligent queries to explore based on graph structure
+
+## Relationship Confidence Tags
+
+Every relationship is tagged by how it was discovered:
+
+| Tag | Meaning | Reliability |
+|-----|---------|------------|
+| `EXTRACTED` | Directly from AST (imports, calls, inheritance) | 100% |
+| `INFERRED` | LLM-derived from semantic analysis | 85–95% |
+| `AMBIGUOUS` | Uncertain — requires human verification | <85% |
+
+## MCP Server Mode
+
+Expose the graph as an MCP server so Claude can query it directly:
+
+```bash
+# Start server from graph file
+python -m graphify.serve graphify-out/graph.json
+```
+
+### Available MCP Tools
+
+| Tool | Query Type |
+|------|-----------|
+| `query_graph` | Search for concepts by name or type |
+| `get_node` | Details of a specific node (definition, references) |
+| `get_neighbors` | Find all connected concepts |
+| `shortest_path` | Find minimum hops between two concepts |
+
+### Claude Code Integration
+
+Add to `.claude/.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "graphify": {
+      "command": "python",
+      "args": ["-m", "graphify.serve", "graphify-out/graph.json"]
+    }
+  }
+}
+```
+
+Then query within Claude Code:
+
+```
+Use the graphify MCP tool to find how AuthService connects to UserRepository
+```
+
+## Installation
+
+```bash
+# Core install (code parsing only)
+pip install graphifyy
+
+# Download language grammars
+graphify install
+
+# With MCP server support
+pip install 'graphifyy[mcp]'
+
+# Full install (MCP + PDF + video + office + community detection)
+pip install 'graphifyy[all]'
+```
+
+**Note:** Package name is `graphifyy` (double-y) on PyPI.
+
+**Requirements:** Python 3.10+
+
+## Architecture: Three-Pass Processing
+
+### Pass 1: AST Extraction (Local, Deterministic)
+
+Tree-sitter parses code in 20+ languages. Extraction is:
+- **Deterministic** — same input → same output every time
+- **Local** — no API calls, file contents stay private
+- **Fast** — parallel processing across files
+
+### Pass 2: Audio/Video (Local via Whisper)
+
+Transcription runs on-device:
+- **Private** — audio never uploaded
+- **Timestamped** — preserves temporal markers
+- **Fallback-safe** — missing audio → gap in graph, not a blocker
+
+### Pass 3: Semantic Extraction (API-Based)
+
+LLM agents process documents, papers, and images:
+- **Parallel** — multiple documents processed simultaneously
+- **Configurable** — choose model, context window, temperature
+- **Privacy-aware** — send only what's necessary
+
+## Incremental Updates
+
+Graph rebuilds are optimized:
+- **SHA256 file hashing** — unchanged files skipped
+- **Caching** — previous results reused
+- **Partial updates** — only changed files reprocessed
+
+Perfect for watch mode during active development.
+
+## Privacy & Data Handling
+
+| Input Type | Processing | Privacy |
+|-----------|-----------|---------|
+| Code files | Tree-sitter (local) | Private |
+| Audio/video | Whisper (local) | Private |
+| Documents | LLM API (configurable) | Depends on provider |
+| Images | Vision model (configurable) | Depends on provider |
+
+**No data leaves your machine unless you explicitly send it via LLM API calls.**
+
+## Workflow Integration
+
+### Before Planning
+
+```bash
+graphify /path/to/target
+# Read GRAPH_REPORT.md for architecture insights
+/ck:plan "Implement feature X"  # now informed by graph
+```
+
+### With Scout
+
+Use graphify for high-level structure, scout for specific file details:
+
+```bash
+graphify .                      # build architecture graph
+/ck:scout "auth module"          # find specific files
+```
+
+### Active Development
+
+```bash
+graphify . --watch              # rebuild graph as you work
+# Use graph.html as live architecture reference
+```
+
+## Limitations
+
+- **First build** on large codebases can be slow (AST parsing + LLM calls)
+- **Semantic extraction quality** depends on the underlying model
+- **Neo4j integration** requires separate setup (`pip install 'graphifyy[neo4j]'`)
+- **Leiden community detection** requires `pip install 'graphifyy[leiden]'`
+
+For very large codebases (1000+ files), consider:
+- Scoping to a subdirectory (`graphify ./src/core`)
+- Running in watch mode to incrementally build the graph
+- Using the cache (`graphify-out/cache/`) for faster rebuilds
+
+## Related Skills
+
+- [Scout](/docs/engineer/skills/scout) — Quick file search for specific capabilities
+- [Repomix](/docs/engineer/skills/repomix) — Full context dump for raw codebase data
+- [GKG](/docs/engineer/skills/gkg) — Semantic symbol navigation with go-to-definition
+- [Plan](/docs/engineer/skills/ck-plan) — Plan implementation after understanding architecture
+
+## Best Practices
+
+**Build early** — Run graphify before planning complex features. Architecture understanding saves time.
+
+**Use watch mode** — Enable `--watch` during exploratory coding to keep the graph fresh.
+
+**Combine with scout** — Use graphify for overview, scout for drill-down into specific files.
+
+**Export for sharing** — Copy `graphify-out/graph.html` and `GRAPH_REPORT.md` to share architecture with teammates.
+
+**Verify ambiguous edges** — Relationships tagged `AMBIGUOUS` need human verification. Don't assume them without checking the code.
+
+## Examples
+
+### Understanding a Django Project
+
+```bash
+graphify . --watch
+# Opens graph.html → see models, views, middleware connections
+# GRAPH_REPORT.md → lists god nodes (core models, middleware)
+```
+
+### Mapping a Microservices Architecture
+
+```bash
+graphify ./services
+# Graph shows service boundaries and external dependencies
+# Shortest path queries reveal call chains across services
+```
+
+### Learning a Codebase Before Contributing
+
+```bash
+graphify /external/project
+# Read GRAPH_REPORT.md for architecture
+# Query graph for "where are authentication checks?"
+# Browse visualizations to plan contribution
+```


### PR DESCRIPTION
## Summary

Promote pending docs work from `dev` to `main`, paired with upcoming releases:
- **claudekit-cli v3.42.0** (PR #748)
- **claudekit-engineer v2.17.0** (PR #699)

Per `claudekit/CLAUDE.md` docs sync workflow — docs branch must match source PR target. Both source PRs target `main`, so this docs PR also targets `main`.

## Changes

### New skill pages (3)

For engineer v2.17.0 — features that landed in dev with no prior doc coverage:

- **`engineer/skills/cti-expert.md`** — CTI / OSINT investigation skill
- **`engineer/skills/agentize.md`** — Convert a codebase into a CLI + MCP server
- **`engineer/skills/graphify.md`** — Build queryable knowledge graphs from code/docs/papers/images

### Existing doc updates (already on dev)

- `docs(migrate): refresh CLI migrate walkthrough` (PR #150) — keeps the ck migrate guide aligned with the v3.41.x → v3.42.0 UX redesign

## Build & Quality

- [x] `bun run build` passes (587 pages generated, includes new skill pages)
- [x] Frontmatter validated (descriptions ≤160 chars)
- [x] Skills nav auto-discovers via Starlight glob pattern — no manual nav edits needed
- [x] Internal links use absolute paths

## Pairing

| Source PR | Target | Triggers |
|---|---|---|
| [CLI #748](https://github.com/mrgoonie/claudekit-cli/pull/748) | main | v3.42.0 release |
| [Engineer #699](https://github.com/claudekit/claudekit-engineer/pull/699) | main | v2.17.0 release |
| **This PR (docs)** | main | Docs site rebuild + deploy |

## Notes

- No `BREAKING CHANGE:` in any source PR — minor bumps only.
- Docs site auto-deploys on merge to main (per existing CI).
- Bare `#N` references in commits without `Closes/Fixes` keyword are not auto-closed.