### PR TITLE
docs(graphify): remove unsafe install guidance

### DIFF
--- a/src/content/docs/engineer/skills/graphify.md
+++ b/src/content/docs/engineer/skills/graphify.md
@@ -172,12 +172,13 @@ Use the graphify MCP tool to find how AuthService connects to UserRepository
 
 ## Installation
 
+ClaudeKit already ships `ck:graphify` as a bundled skill. Do not run
+`graphify install` for ClaudeKit setup: upstream uses that command to install
+its standalone Claude skill at `~/.claude/skills/graphify/SKILL.md`.
+
 ```bash
 # Core install (code parsing only)
 pip install graphifyy
-
-# Download language grammars
-graphify install
 
 # With MCP server support
 pip install 'graphifyy[mcp]'


### PR DESCRIPTION
## Summary

- Remove the `graphify install` step from CK Graphify docs.
- Add warning that upstream `graphify install` installs the standalone Claude skill at `~/.claude/skills/graphify/SKILL.md`, which is the collision path fixed by claudekit-engineer PR #746.

## Validation

- `bun run build`

Related: claudekit/claudekit-engineer#746
Closes claudekit/claudekit-engineer#745
