### PR TITLE
fix: skills nav groups ck-* skills under correct letter

### DIFF
--- a/src/lib/section-nav.ts
+++ b/src/lib/section-nav.ts
@@ -140,5 +140,5 @@ function normalizeSortLabel(value: string) {
 }
 
 function trimSkillPrefix(value: string) {
-  return value.replace(/^ckm?:/i, '').trim();
+  return value.replace(/^ckm?[:-]/i, '').trim();
 }


### PR DESCRIPTION
## Problem

In the engineer/marketing skills sidebar, skills with `ck-` prefix (e.g. `ck-plan`, `ck-debug`, `ck-autoresearch`, `ck-loop`) were grouped under section **C** instead of their actual letter (P, D, A, L). User had to scroll up to "C" to find `plan` — confusing.

Closes #159

## Root Cause

`trimSkillPrefix()` in `src/lib/section-nav.ts` only matched the colon form: `/^ckm?:/i`.

The skills category in `sidebar-nav-section-config.ts` uses `sortKey: 'slug'`, so hyphenated leaf slugs like `ck-plan` are passed to the alpha grouper. The regex didn't strip the hyphen prefix, leaving `ck-plan` → first char `c` → grouped under "C".

Display labels worked because frontmatter `title` uses colon (`ck:plan`) and got stripped correctly. Only the slug-based sort path was broken.

## What changed

| File | Change |
|------|--------|
| `src/lib/section-nav.ts` | Extend regex from `/^ckm?:/i` to `/^ckm?[:-]/i` to handle both `ck:` and `ck-` (and `ckm:`/`ckm-`) prefix forms |

## Validation

Verified prefix stripping for all relevant cases:

| Input | Before fix | After fix |
|---|---|---|
| `ck-plan` | `c` | `p` |
| `ck:plan` | `p` | `p` |
| `ckm-design` | `c` | `d` |
| `ck-autoresearch` | `c` | `a` |
| `code-review` | `c` | `c` (unchanged) |
| `cook` | `c` | `c` (unchanged) |

- [x] `bun run build` passes (580 pages)
- [x] Non-prefixed skills still group correctly under C