### PR TITLE
docs: correct Windows global install path

### DIFF
--- a/src/content/docs-vi/getting-started/installation.md
+++ b/src/content/docs-vi/getting-started/installation.md
@@ -166,7 +166,7 @@ ck init -g --kit engineer --version v1.0.0
 
 **Nơi files được cài đặt:**
 - **macOS/Linux**: `~/.claude/`
-- **Windows**: `%LOCALAPPDATA%\.claude\`
+- **Windows**: `%USERPROFILE%\.claude\`
 
 > ✅ **Mẹo:** Chế độ global lý tưởng cho phát triển cá nhân. Cài đặt một lần, sử dụng mọi nơi.
 

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -164,7 +164,7 @@ ck init -g --kit engineer --version v1.0.0
 
 **Where files are installed:**
 - **macOS/Linux**: `~/.claude/`
-- **Windows**: `%LOCALAPPDATA%\.claude\`
+- **Windows**: `%USERPROFILE%\.claude\`
 
 > ✅ **Tip:** Global mode is ideal for personal development. Install once, use everywhere.
 


### PR DESCRIPTION
## Summary
- Correct English and Vietnamese getting-started installation docs to show `%USERPROFILE%\.claude\` for Windows global installs.
- Align getting-started docs with CLI behavior and the regression guard in mrgoonie/claudekit-cli#809.

Related to mrgoonie/claudekit-cli#809
Related to mrgoonie/claudekit-cli#808

## Validation
- [x] `rg -n "%LOCALAPPDATA%.*\\\\.claude|LOCALAPPDATA.*\\\\.claude|%LOCALAPPDATA%.*\.claude|LOCALAPPDATA.*\.claude" src/content/docs src/content/docs-vi -S` returns no matches
- [x] `bun run build`