### PR TITLE
docs(cli): document global kit paths per platform

### DIFF
--- a/public/docs/cli/index.md
+++ b/public/docs/cli/index.md
@@ -71,7 +71,7 @@ By default, ClaudeKit uses local configuration (`~/.claudekit`).
 
 For platform-specific **user-scoped settings**, use the `--global` flag:
 - **macOS/Linux**: `~/.claude`
-- **Windows**: `%LOCALAPPDATA%\.claude`
+- **Windows**: `%USERPROFILE%\.claude`
 
 Global mode uses user-scoped directories (no sudo required), allowing separate configurations for different projects.
 

--- a/src/content/docs-vi/cli/index.md
+++ b/src/content/docs-vi/cli/index.md
@@ -153,7 +153,14 @@ Khi tạo một dự án mới, hãy chọn từ các kit có sẵn:
 ClaudeKit hỗ trợ hai chế độ cài đặt:
 
 - **Local** (default): Cài đặt vào `.claude/` trong thư mục dự án của bạn
-- **Global**: Cài đặt vào `~/.claude/` để cấu hình cấp người dùng
+- **Global**: Cài đặt vào thư mục Claude cấp người dùng
+
+Vị trí kit global:
+
+| Nền tảng | Đường dẫn |
+|----------|-----------|
+| macOS/Linux | `~/.claude/` |
+| Windows | `%USERPROFILE%\.claude\` |
 
 Sử dụng `ck init --global` để cài đặt toàn cầu, hoặc `ck init` để cài đặt cục bộ (dành riêng cho dự án).
 

--- a/src/content/docs/cli/index.md
+++ b/src/content/docs/cli/index.md
@@ -153,7 +153,14 @@ When creating a new project, choose from available kits:
 ClaudeKit supports two installation modes:
 
 - **Local** (default): Install to `.claude/` in your project directory
-- **Global**: Install to `~/.claude/` for user-level configuration
+- **Global**: Install to the Claude user directory for user-level configuration
+
+Global kit location:
+
+| Platform | Path |
+|----------|------|
+| macOS/Linux | `~/.claude/` |
+| Windows | `%USERPROFILE%\.claude\` |
 
 Use `ck init --global` for global installation, or `ck init` for local (project-specific) installation.
 


### PR DESCRIPTION
## Summary

Add a platform path table to EN + VI `cli/index.md` so users see the canonical global kit location at a glance:

| Platform | Path |
|----------|------|
| macOS/Linux | `~/.claude/` |
| Windows | `%USERPROFILE%\.claude\` |

Also corrects the public docs Windows path to `%USERPROFILE%` (matches CLI behavior; `%LOCALAPPDATA%` was a legacy pre-fix location, now auto-migrated by the CLI).

## Paired with

[mrgoonie/claudekit-cli#820](https://github.com/mrgoonie/claudekit-cli/pull/820) — CLI legacy Windows global kit self-heal.

## Test plan

- [x] `bun run build` passes (580 pages, pagefind index OK)