### PR TITLE
docs: rewrite for AgentKit architecture and fix stale references

### DIFF
--- a/src/content/docs/engineer/skills/ai-multimodal.md
+++ b/src/content/docs/engineer/skills/ai-multimodal.md
@@ -242,4 +242,4 @@ For detailed guidance on specific capabilities, the skill includes comprehensive
 - `references/video-generation.md` - Veo 3 text-to-video, camera control, timing
 - `references/music-generation.md` - Lyria API for background music generation
 
-These references live in the Engineer Kit at `../claudekit-engineer/.claude/skills/ai-multimodal/references/`.
+These references are installed with the skill at `~/.claude/skills/ai-multimodal/references/` (global install) or `.claude/skills/ai-multimodal/references/` (local install).

--- a/src/content/docs/engineer/skills/cti-expert.md
+++ b/src/content/docs/engineer/skills/cti-expert.md
@@ -5,7 +5,12 @@ section: engineer
 kit: engineer
 category: skills
 order: 25
+published: true
 ---
+
+:::caution[Deprecated]
+`cti-expert` has been archived from AgentKit and is no longer included in new ClaudeKit installations. This page is kept for historical reference. There is no direct replacement — use `/ck:brainstorm` for threat modeling discussions or `/ck:ck-security` for security audits.
+:::
 
 # CTI Expert
 

--- a/src/content/docs/engineer/skills/cti-expert.md
+++ b/src/content/docs/engineer/skills/cti-expert.md
@@ -8,8 +8,12 @@ order: 25
 published: true
 ---
 
-:::caution[Deprecated]
-`cti-expert` has been archived from AgentKit and is no longer included in new ClaudeKit installations. This page is kept for historical reference. There is no direct replacement — use `/ck:brainstorm` for threat modeling discussions or `/ck:ck-security` for security audits.
+:::caution[Deprecated — not installed]
+`cti-expert` has been archived from AgentKit and is **no longer included** in new ClaudeKit installations. Commands on this page will not work in current installations. Use `/ck:brainstorm` for threat modeling discussions or `/ck:security` for security audits.
+:::
+
+:::note[Historical reference only]
+The content below describes the original `cti-expert` skill. None of these commands are available in current installations. This page is preserved for reference only.
 :::
 
 # CTI Expert

--- a/src/content/docs/engineer/skills/index.md
+++ b/src/content/docs/engineer/skills/index.md
@@ -9,10 +9,12 @@ published: true
 ---
 # Skills Overview
 
-70+ specialized skills that extend Claude's capabilities—invoked with `/skill-name` or loaded dynamically when you mention them.
+80+ specialized skills that extend Claude's capabilities — invoked with `/ck:skill-name` or loaded dynamically when you mention them.
+
+Skills are sourced from [AgentKit](https://github.com/bestagentkits/agentkit) (`kits/engineer/` and `kits/core/`) and installed to `~/.claude/skills/` via `ck init -g --kit engineer`.
 
 :::tip[Commands → Skills Complete]
-As of engineer@2.12.0, all 19 commands have been migrated to skills. The `/` slash syntax is unchanged. See [Migration Guide](/docs/getting-started/migration-from-commands-to-skills).
+As of engineer@2.12.0, all commands have been migrated to skills. The `/ck:` slash syntax is unchanged. See [Migration Guide](/docs/getting-started/migration-from-commands-to-skills).
 :::
 
 ## Quick Reference
@@ -83,6 +85,7 @@ As of engineer@2.12.0, all 19 commands have been migrated to skills. The `/` sla
 | [fix](/docs/engineer/skills/fix) | Bug fixing with intelligent routing |
 | [git](/docs/engineer/skills/git) | Git operations with conventional commits |
 | [plans-kanban](/docs/engineer/skills/plans-kanban) | Open the integrated plans dashboard in the CLI UI |
+| [kanban](/docs/engineer/skills/kanban) | Alias for plans-kanban — visual plan board shortcut |
 | [project-management](/docs/engineer/skills/project-management) | Task tracking, plan status, session bridging |
 | [team](/docs/engineer/skills/team) | Agent Teams for parallel multi-session collaboration |
 | [ask](/docs/engineer/skills/ask) | Answer technical and architectural questions |
@@ -93,6 +96,7 @@ As of engineer@2.12.0, all 19 commands have been migrated to skills. The `/` sla
 | [preview](/docs/engineer/skills/preview) | View files or generate visual explanations and diagrams |
 | [test](/docs/engineer/skills/test) | Run test suites, coverage analysis, build verification |
 | [use-mcp](/docs/engineer/skills/use-mcp) | Utilize MCP server tools |
+| [mcp-management](/docs/engineer/skills/mcp-management) | Discover, select, and execute MCP server capabilities |
 | [watzup](/docs/engineer/skills/watzup) | Review recent changes and wrap up sessions |
 | [worktree](/docs/engineer/skills/worktree) | Create isolated git worktrees |
 
@@ -146,10 +150,15 @@ Skills activate through **semantic matching** on your prompt:
 
 Every skill contains:
 ```
-.claude/skills/[skill-name]/
-├── SKILL.md          # Core instructions (<100 lines)
+# Source (AgentKit repo):
+agentkit/kits/<kit>/skills/[skill-name]/
+├── SKILL.md          # Core instructions
 ├── references/       # Detailed documentation
 └── scripts/          # Automation scripts (optional)
+
+# Installed location on your machine:
+~/.claude/skills/[skill-name]/   # global (ck init -g)
+.claude/skills/[skill-name]/     # local  (ck init)
 ```
 
 **Progressive disclosure**: SKILL.md provides essentials, references/ has depth.
@@ -178,7 +187,7 @@ skill-creator will:
 2. Design skill structure
 3. Create SKILL.md with proper frontmatter
 4. Add references if needed
-5. Save to `.claude/skills/`
+5. Save to `.claude/skills/` (local) or `~/.claude/skills/` (global)
 
 ### Troubleshooting
 

--- a/src/content/docs/engineer/skills/index.md
+++ b/src/content/docs/engineer/skills/index.md
@@ -9,7 +9,7 @@ published: true
 ---
 # Skills Overview
 
-80+ specialized skills that extend Claude's capabilities — invoked with `/ck:skill-name` or loaded dynamically when you mention them.
+80+ specialized skills that extend Claude's capabilities — invoked with `/ck:skill-name` or loaded dynamically when you mention them. The engineer kit release archive bundles both engineer and core skills (83 total).
 
 Skills are sourced from [AgentKit](https://github.com/bestagentkits/agentkit) (`kits/engineer/` and `kits/core/`) and installed to `~/.claude/skills/` via `ck init -g --kit engineer`.
 

--- a/src/content/docs/engineer/skills/kanban.md
+++ b/src/content/docs/engineer/skills/kanban.md
@@ -1,0 +1,64 @@
+---
+title: "ck:kanban"
+description: "Visual plans dashboard — track plan progress, open plan files, and manage phases from the CLI UI"
+section: engineer
+kit: engineer
+category: skills
+order: 99
+published: true
+---
+
+# kanban
+
+Open the ClaudeKit plans dashboard to visually track plan progress, navigate phases, and manage implementation status.
+
+## What This Skill Does
+
+`/ck:kanban` is an alias for `/ck:plans-kanban`. It opens the ClaudeKit CLI dashboard at the plans route, giving you a visual board of your current implementation plans with phase statuses, checkboxes, and quick navigation into plan files.
+
+## Usage
+
+```
+/ck:kanban
+```
+
+Or use the underlying CLI directly:
+
+```bash
+ck config ui
+```
+
+## Dashboard Features
+
+- Visual plan board showing all plans in `plans/` directory
+- Phase status tracking (not started / in progress / complete)
+- Check/uncheck individual phase tasks
+- Click-through to open plan files
+- Auto-starts the CLI dashboard server if not running
+
+## CLI Commands
+
+For scripted plan management, use the CLI directly:
+
+```bash
+# Open dashboard UI
+ck config ui
+
+# Check plan status
+ck plan status /path/to/plan.md
+
+# Mark a phase started
+cd /path/to/plan-dir && ck plan check <phase-id> --start
+
+# Mark a phase complete
+cd /path/to/plan-dir && ck plan check <phase-id>
+
+# Uncheck a phase
+cd /path/to/plan-dir && ck plan uncheck <phase-id>
+```
+
+## Related Skills
+
+- [plans-kanban](/docs/engineer/skills/plans-kanban) — The underlying skill this aliases
+- [project-management](/docs/engineer/skills/project-management) — Task tracking and session bridging
+- [cook](/docs/engineer/skills/cook) — Feature implementation that generates plans

--- a/src/content/docs/engineer/skills/mcp-management.md
+++ b/src/content/docs/engineer/skills/mcp-management.md
@@ -1,0 +1,88 @@
+---
+title: "ck:mcp-management"
+description: "Discover, analyze, and execute MCP server tools, prompts, and resources with context-efficient subagent delegation"
+section: engineer
+kit: engineer
+category: skills
+order: 99
+published: true
+---
+
+# mcp-management
+
+Manage Model Context Protocol (MCP) servers — discover capabilities, select tools by task, execute calls, and avoid polluting the main context window.
+
+## What This Skill Does
+
+MCP is an open protocol that lets AI agents connect to external tools and data sources. This skill provides structured workflows for:
+
+- **Discovery**: List all tools, prompts, and resources from configured MCP servers
+- **Selection**: Intelligently pick the right MCP tools for a given task
+- **Execution**: Call MCP tools with proper parameter handling
+- **Context management**: Delegate MCP operations to subagents to keep the main context clean
+
+## Usage
+
+```
+/ck:mcp-management [task or server-name]
+```
+
+**Examples:**
+- `/ck:mcp-management list all available tools`
+- `/ck:mcp-management find tools for database operations`
+- `/ck:mcp-management execute github create-issue with title "Bug report"`
+
+## Configuration
+
+MCP servers are configured in `.claude/.mcp.json` in your project root.
+
+**Gemini CLI integration** (recommended) — create a symlink so both Claude Code and Gemini CLI share one config:
+
+```bash
+mkdir -p .gemini && ln -sf .claude/.mcp.json .gemini/settings.json
+```
+
+## Core Capabilities
+
+### Discover MCP Capabilities
+
+```
+/ck:mcp-management discover tools from my configured servers
+```
+
+The skill uses subagents to enumerate tools from each server, saves a persistent tool catalog to JSON for fast re-use, and returns a filtered list relevant to your task.
+
+### Task-Based Tool Selection
+
+```
+/ck:mcp-management I need to create a GitHub issue and post to Slack
+```
+
+The skill analyzes your task, matches it against the tool catalog, and recommends the minimal set of MCP tools needed — avoiding context bloat from loading every tool description.
+
+### Execute MCP Tools
+
+```
+/ck:mcp-management call github:create-issue with title "Login fails on Safari" body "Steps to reproduce..."
+```
+
+Handles parameter mapping, error recovery, and response formatting.
+
+### Multi-Server Management
+
+When multiple MCP servers are configured, the skill tracks which server owns which tool and routes calls to the correct server automatically.
+
+## When to Use vs `use-mcp`
+
+| Use | Skill |
+|-----|-------|
+| Execute a specific known MCP tool | [use-mcp](/docs/engineer/skills/use-mcp) |
+| Discover what MCP tools exist | **mcp-management** |
+| Select the right tool for a task | **mcp-management** |
+| Build or debug an MCP server | [mcp-builder](/docs/engineer/skills/mcp-builder) |
+
+## Related Skills
+
+- [use-mcp](/docs/engineer/skills/use-mcp) — Execute MCP tools directly
+- [mcp-builder](/docs/engineer/skills/mcp-builder) — Build new MCP servers
+- [agentize](/docs/engineer/skills/agentize) — Convert existing tools into MCP servers

--- a/src/content/docs/getting-started/agentkit-migration.md
+++ b/src/content/docs/getting-started/agentkit-migration.md
@@ -1,0 +1,141 @@
+---
+title: "Migrating to AgentKit"
+description: "Upgrade from the old claudekit-engineer manual install to the AgentKit CLI-based workflow"
+section: getting-started
+category: getting-started
+order: 8
+published: true
+---
+
+# Migrating to AgentKit
+
+If you set up ClaudeKit before early 2026 by manually cloning `claudekit-engineer` and copying `.claude/` files, this guide explains how to upgrade to the current AgentKit-based installation.
+
+## What Changed
+
+| Before (pre-AgentKit) | After (AgentKit) |
+|----------------------|------------------|
+| Clone `claudekit-engineer` repo | `ck init -g --kit engineer` |
+| Copy `.claude/` manually | CLI installs skills automatically |
+| Skills in `claudekit-engineer/.claude/skills/` | Skills sourced from `agentkit/kits/*/skills/` |
+| Update by re-cloning | Update by re-running `ck init -g` |
+| Single repo for all skills | Three kits: `engineer`, `marketing`, `core` |
+
+The invocation syntax — `/ck:skill-name` — **did not change**. Your muscle memory is intact.
+
+## Before You Start
+
+Check what you currently have:
+
+```bash
+# Where are your skills installed?
+ls ~/.claude/skills/       # global
+ls .claude/skills/         # local (project-specific)
+
+# What version is installed?
+cat ~/.claude/.ck.json 2>/dev/null || echo "No .ck.json found"
+```
+
+## Migration Steps
+
+### Step 1: Install the CLI
+
+```bash
+npm install -g claudekit-cli
+ck --version
+```
+
+### Step 2: Back Up Any Customized Skills
+
+If you have modified any skill files locally, back them up before upgrading:
+
+```bash
+# Back up only customized skills (ones you edited)
+cp -r ~/.claude/skills/my-custom-skill ~/claude-skills-backup/
+```
+
+Standard ClaudeKit skill files (`SKILL.md`, `references/`) will be overwritten by `ck init`. **Custom skills you created** with `skill-creator` should also be backed up.
+
+### Step 3: Run `ck init -g`
+
+```bash
+ck init -g --kit engineer
+```
+
+This will:
+1. Detect your existing `~/.claude/` installation
+2. Download the latest AgentKit engineer kit release
+3. Install/update skills using smart merge (preserving customizations where possible)
+4. Update agents and configuration files
+
+If you also use the marketing kit:
+
+```bash
+ck init -g --kit marketing
+```
+
+### Step 4: Restore Custom Skills
+
+If you backed up custom skills in Step 2, restore them:
+
+```bash
+cp -r ~/claude-skills-backup/my-custom-skill ~/.claude/skills/
+```
+
+### Step 5: Verify
+
+```bash
+# Skills present
+ls ~/.claude/skills/ | head -20
+
+# Launch Claude Code and test a skill
+claude
+# Then type: /ck:brainstorm test that skills are working
+```
+
+---
+
+## Changed Skill Locations
+
+Skills that moved or were renamed between old CK and AgentKit:
+
+| Old name / location | New name | Kit |
+|--------------------|----------|-----|
+| `/ck:code` | `/ck:cook` | core |
+| `/ck:plan --two` | `/ck:plan --two` (unchanged) | engineer |
+| `/ck:plan --hard` | `/ck:plan --hard` (unchanged) | engineer |
+| `cti-expert` | Archived — no replacement | — |
+| `.claude/commands/core/cook.md` | `~/.claude/skills/cook/SKILL.md` | core |
+| `.claude/commands/fix/fast.md` | `~/.claude/skills/fix/SKILL.md` (use `--quick`) | core |
+
+## Deprecated Skills
+
+These skills existed in the old `claudekit-engineer` but were not carried forward to AgentKit kits. Their capabilities were merged into other skills or dropped:
+
+| Deprecated skill | Alternative |
+|-----------------|-------------|
+| `cti-expert` | No direct replacement; use `/ck:brainstorm` for threat modeling |
+| `/integrate:polar` | Use `payment-integration` skill |
+| `/integrate:sepay` | Use `payment-integration` skill |
+
+## FAQ
+
+**Q: Do I need to delete my old `.claude/` files first?**  
+No. `ck init -g` merges into your existing installation. Only delete manually if you want a completely clean slate.
+
+**Q: Will my custom CLAUDE.md be overwritten?**  
+No. `ck init` does not touch `CLAUDE.md`. It only updates files inside `.claude/`.
+
+**Q: What about local (project-level) installations?**  
+Run `ck init --kit engineer` (without `-g`) from your project root to update that project's `.claude/` directory.
+
+**Q: The skills I use aren't in AgentKit — what happened?**  
+A small number of skills from the old kit were archived or merged. See the "Deprecated Skills" table above. If a skill you relied on is missing, open a request on [Discord](https://claudekit.cc/discord).
+
+---
+
+## Related
+
+- [Installation](/docs/getting-started/installation) — Full installation guide
+- [AgentKit Architecture](/docs/getting-started/agentkit-overview) — How the kit system works
+- [Skills Overview](/docs/engineer/skills) — Current skill catalog

--- a/src/content/docs/getting-started/agentkit-migration.md
+++ b/src/content/docs/getting-started/agentkit-migration.md
@@ -104,7 +104,6 @@ Skills that moved or were renamed between old CK and AgentKit:
 | `/ck:code` | `/ck:cook` | core |
 | `/ck:plan --two` | `/ck:plan --two` (unchanged) | engineer |
 | `/ck:plan --hard` | `/ck:plan --hard` (unchanged) | engineer |
-| `cti-expert` | Archived — no replacement | — |
 | `.claude/commands/core/cook.md` | `~/.claude/skills/cook/SKILL.md` | core |
 | `.claude/commands/fix/fast.md` | `~/.claude/skills/fix/SKILL.md` (use `--quick`) | core |
 

--- a/src/content/docs/getting-started/agentkit-overview.md
+++ b/src/content/docs/getting-started/agentkit-overview.md
@@ -127,7 +127,7 @@ To pull the latest skill updates from AgentKit:
 ck init -g --kit engineer
 
 # Update to a specific version
-ck init -g --kit engineer --version v3.1.0
+ck init -g --kit engineer --release v3.1.0
 ```
 
 The `ck init` command is idempotent — safe to run multiple times. It preserves any customizations you've made to skills using smart merge.

--- a/src/content/docs/getting-started/agentkit-overview.md
+++ b/src/content/docs/getting-started/agentkit-overview.md
@@ -1,0 +1,149 @@
+---
+title: "AgentKit Architecture"
+description: "How AgentKit organizes ClaudeKit into engineer, marketing, and core kits — and how skills install to your machine"
+section: getting-started
+category: getting-started
+order: 3
+published: true
+---
+
+# AgentKit Architecture
+
+ClaudeKit is powered by **AgentKit** — a multi-kit system that organizes skills, agents, and workflows into composable toolkits.
+
+## What Is AgentKit?
+
+AgentKit is the underlying framework that ships, versions, and installs ClaudeKit skills. It replaced the older `claudekit-engineer` monorepo structure in early 2026.
+
+**Key change:** Skills no longer live in a single `claudekit-engineer/.claude/` directory. They are organized into three kits in the `agentkit` repository, each with its own release cycle.
+
+## The Three Kits
+
+```
+agentkit/
+└── kits/
+    ├── engineer/    # Development & automation skills
+    ├── marketing/   # Content, campaigns, brand skills
+    └── core/        # Shared skills used by both kits
+```
+
+### Engineer Kit (`kits/engineer/`)
+
+Skills for software development workflows:
+- Feature implementation (`cook`, `fix`, `brainstorm`)
+- Code quality (`test`, `code-review`, `security-scan`)
+- Developer tooling (`worktree`, `ship`, `journal`, `retro`)
+- AI & automation (`agent-browser`, `agentize`, `gkg`, `graphify`)
+
+### Marketing Kit (`kits/marketing/`)
+
+Skills for content and campaign management:
+- Content creation (`social`, `email`, `video`, `slides`)
+- Brand & design (`brand`, `logo-design`, `banner-design`)
+- Analytics & strategy (`analytics`, `seo`, `competitor`, `pricing-strategy`)
+- Campaign management (`campaign`, `launch-strategy`, `paid-ads`)
+
+### Core Kit (`kits/core/`)
+
+Shared skills available to both engineer and marketing kits:
+- Implementation (`cook`, `fix`, `scout`)
+- Language & frameworks (`frontend-design`, `backend-development`, `databases`)
+- Utilities (`ai-multimodal`, `ai-artist`, `media-processing`, `document-skills`)
+- Auth & payments (`better-auth`, `payment-integration`)
+
+## How Skills Install to Your Machine
+
+When you run `ck init -g --kit engineer`, the CLI:
+
+1. Downloads the selected kit release from GitHub
+2. Installs skills to `~/.claude/skills/` (global) or `./.claude/skills/` (local)
+3. Installs agents to `~/.claude/agents/`
+4. Copies configuration files (`.ck.json`, `.ckignore`, `settings.json`)
+
+**After installation, your file layout:**
+
+```
+~/.claude/
+├── skills/
+│   ├── cook/            # From kits/core/skills/cook/
+│   │   └── SKILL.md
+│   ├── brainstorm/      # From kits/engineer/skills/brainstorm/
+│   │   └── SKILL.md
+│   ├── frontend-design/ # From kits/core/skills/frontend-design/
+│   │   └── SKILL.md
+│   └── ...              # All skills from your selected kit
+├── agents/
+│   ├── planner.md
+│   ├── tester.md
+│   └── ...
+├── .ck.json             # ClaudeKit configuration
+├── .ckignore            # Paths excluded from LLM context
+└── settings.json        # Claude Code hook settings
+```
+
+The installed `~/.claude/skills/` directory is what Claude Code reads at runtime. The `agentkit/kits/` paths are the **source** — not what your machine uses directly.
+
+## Skill Invocation
+
+Skills are invoked with `/ck:skill-name` syntax in Claude Code:
+
+```
+/ck:cook implement user authentication
+/ck:fix --auto
+/ck:brainstorm should we use REST or GraphQL?
+```
+
+The prefix `ck:` routes to ClaudeKit skills. Skills in the marketing kit use `ckm:` prefix:
+
+```
+/ckm:social write a LinkedIn post about our launch
+/ckm:brand update our color palette
+```
+
+## Selecting a Kit
+
+When running `ck init`, you choose which kit to install:
+
+```bash
+# Engineer kit (development workflows)
+ck init -g --kit engineer
+
+# Marketing kit (content & campaigns)
+ck init -g --kit marketing
+
+# Both kits (full installation)
+ck init -g --kit engineer
+ck init -g --kit marketing
+```
+
+Kits can coexist — each installs skills to the same `~/.claude/skills/` directory without conflict.
+
+## Updating Skills
+
+To pull the latest skill updates from AgentKit:
+
+```bash
+# Update engineer kit to latest release
+ck init -g --kit engineer
+
+# Update to a specific version
+ck init -g --kit engineer --version v3.1.0
+```
+
+The `ck init` command is idempotent — safe to run multiple times. It preserves any customizations you've made to skills using smart merge.
+
+## Source Repository
+
+The AgentKit source is at [github.com/bestagentkits/agentkit](https://github.com/bestagentkits/agentkit).
+
+Individual skill source files (SKILL.md) live at:
+```
+agentkit/kits/<kit>/skills/<skill-name>/SKILL.md
+```
+
+## Related
+
+- [Installation](/docs/getting-started/installation) — Install ClaudeKit with the CLI
+- [Quick Start](/docs/getting-started/quick-start) — First feature in 5 minutes
+- [Skills Overview](/docs/engineer/skills) — All available engineer skills
+- [Migration Guide](/docs/getting-started/agentkit-migration) — Upgrading from pre-AgentKit

--- a/src/content/docs/getting-started/concepts.md
+++ b/src/content/docs/getting-started/concepts.md
@@ -74,8 +74,8 @@ Reusable knowledge modules injected into agent context.
 - **Tools**: FFmpeg, ImageMagick, MCP Builder
 
 **How Skills Work**:
-1. Skill files stored in `.claude/skills/`
-2. Auto-activated based on codebase detection (e.g., detects `next.config.js` → activates Next.js skill)
+1. Skill files installed to `~/.claude/skills/` (global) or `.claude/skills/` (local project)
+2. Sourced from [AgentKit kits](https://github.com/bestagentkits/agentkit) — install via `ck init -g --kit engineer`
 3. Skill provides agent with best practices, examples, gotchas
 4. Agent makes better decisions (uses right patterns, avoids common mistakes)
 

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -58,7 +58,7 @@ ck init --kit engineer
 ```
 
 **What gets installed:**
-- 80+ skills (cook, fix, brainstorm, test, scout, and more)
+- 80+ skills (engineer kit includes core skills; 83 total installed)
 - Agents (planner, tester, code-reviewer, debugger)
 - Configuration files (`.ck.json`, `.ckignore`, `settings.json`)
 
@@ -148,7 +148,7 @@ Re-run `ck init` to pull the latest release:
 ck init -g --kit engineer
 
 # Update to a specific version
-ck init -g --kit engineer --version v3.1.0
+ck init -g --kit engineer --release v3.1.0
 
 # Update CLI itself
 ck update
@@ -166,12 +166,12 @@ If you cannot use the CLI (no internet on target machine, air-gapped environment
 
 1. Download the kit release archive from the GitHub Releases page
 2. Extract to a local directory
-3. Run `ck init --local-path /path/to/extracted-kit`
+3. Run `ck init --kit-path /path/to/extracted-kit`
 
 Or install from a local directory:
 
 ```bash
-ck init -g --kit engineer --local-path ./my-downloaded-kit
+ck init -g --kit engineer --kit-path ./my-downloaded-kit
 ```
 
 ---

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: "Documentation for Installation"
+description: "Install ClaudeKit via the CLI — global or project-local, engineer or marketing kit"
 section: getting-started
 category: getting-started
 order: 2
@@ -8,304 +8,221 @@ published: true
 ---
 # Installation
 
-This guide will help you install ClaudeKit and set up your development environment. You can choose between manual installation or using the ClaudeKit CLI.
+ClaudeKit is installed via the **ClaudeKit CLI** (`ck`). The CLI downloads the kit you select from AgentKit releases and copies skills, agents, and configuration into your Claude Code environment.
 
 ## Requirements
 
-Before installing ClaudeKit, ensure you have:
-
 - **Node.js** v18 or higher
 - **npm** v10 or higher (or bun, pnpm, yarn)
-- **Git** for version control
-- **Claude Code CLI** installed (`claude`)
-- **Google Gemini API Key** from [Google AI Studio](https://aistudio.google.com)
+- **Claude Code CLI** installed and authenticated (`claude`)
+- **GitHub Personal Access Token** with `repo` scope (for private repository access)
 
-## Method 1: Manual Installation
+> **Note:** A Google Gemini API key is optional. It is only needed if you use the `ai-multimodal` skill for vision/document analysis.
 
-This method gives you complete control over the installation process.
-
-### Step 1: Clone or Download ClaudeKit Engineer
+## Step 1: Install the CLI
 
 ```bash
-# Option A: Clone repo (requires GitHub access)
-git clone https://github.com/claudekit/claudekit-engineer.git
-
-# Option B: Download from GitHub Releases
-# Visit: https://github.com/claudekit/claudekit-engineer/releases
-```
-
-### Step 2: Copy ClaudeKit Files
-
-Copy the following directories and files from `claudekit-engineer` to your project root:
-
-| Path | Description |
-|-----------|-------|
-| `.claude/` | Main configuration - hooks, skills, commands, workflows |
-| `docs/` | Documentation templates |
-| `plans/` | Planning templates |
-| `CLAUDE.md` | Project instructions for Claude |
-
-**Important hidden files in `.claude/`:**
-- `.ck.json` - ClaudeKit configuration (plan naming, paths, language)
-- `.ckignore` - Directories excluded from context (like `.gitignore` for LLM)
-
-**Linux/macOS:**
-```bash
-cp -r claudekit-engineer/.claude your-project/
-cp -r claudekit-engineer/docs your-project/
-cp -r claudekit-engineer/plans your-project/
-cp claudekit-engineer/CLAUDE.md your-project/
-
-# Verify hidden files were copied
-ls -la your-project/.claude/
-# Should see: .ck.json, .ckignore, settings.json, etc.
-```
-
-**Windows (PowerShell):**
-```powershell
-Copy-Item -Recurse claudekit-engineer\.claude your-project\
-Copy-Item -Recurse claudekit-engineer\docs your-project\
-Copy-Item -Recurse claudekit-engineer\plans your-project\
-Copy-Item claudekit-engineer\CLAUDE.md your-project\
-
-# Verify hidden files were copied
-Get-ChildItem -Force your-project\.claude\
-# Should see: .ck.json, .ckignore, settings.json, etc.
-```
-
-> ⚠️ **Note:** File managers may hide dotfiles (`.ck.json`, `.ckignore`). Use terminal/PowerShell or enable "show hidden files".
-
-### Step 3: Configure Gemini API Key (Optional)
-
-**WHY?**
-ClaudeKit previously used [Human MCP](https://www.npmjs.com/package/@goonnguyen/human-mcp) for image and video analysis because Gemini has better vision capabilities. However, Anthropic launched [**Agent Skills**](https://docs.claude.com/en/docs/engineer/agents-and-tools/agent-skills/overview) with better context engineering support, so all Human MCP tools have been converted to Agent Skills.
-
-**Note:** Gemini API currently offers a generous free tier.
-
-1. Go to [Google AI Studio](https://aistudio.google.com) and get your API Key
-2. Copy `.claude/skills/.env.example` to `.claude/skills/.env` and paste your key into the `GEMINI_API_KEY` environment variable
-
-You're ready to use it.
-
-### Step 4: Start Claude Code
-
-Launch Claude Code in your working project:
-
-```bash
-# Standard mode
-claude
-
-# Skip permissions (use cautiously)
-claude --dangerously-skip-permissions
-```
-
-### Step 5: Initialize Documentation
-
-Run the `/ck:docs init` command to scan and generate specs for your project:
-
-```bash
-/ck:docs init
-```
-
-This command creates markdown files in the `docs` directory:
-- `codebase-summary.md`
-- `code-standards.md`
-- `system-architecture.md`
-- And more...
-
-Your project is now ready for development!
-
-## Method 2: ClaudeKit CLI
-
-The CLI provides an automated way to set up ClaudeKit projects.
-
-### Installation
-
-Install ClaudeKit CLI globally:
-
-```bash
-# npm
+# npm (recommended)
 npm install -g claudekit-cli
 
 # bun
 bun add -g claudekit-cli
 
-# Verify installation
+# pnpm
+pnpm add -g claudekit-cli
+
+# Verify
 ck --version
 ```
 
-### Which Installation Mode Should I Choose?
+## Step 2: Choose Installation Scope
 
-| Use Case | Mode | Command |
-|------------|--------|------|
-| **First-time installation** | Global ⭐ | `ck init -g --kit engineer` |
-| **Want to use ClaudeKit for ALL projects** | Global ⭐ | `ck init -g --kit engineer` |
-| **Only for a specific project** | Local | `ck init --kit engineer` |
-| **CI/CD environment** | Local | `ck init --kit engineer` |
+| Mode | Command | Skills installed to | Use when |
+|------|---------|-------------------|----------|
+| **Global** ⭐ | `ck init -g` | `~/.claude/skills/` | Available in every project |
+| **Local** | `ck init` | `./.claude/skills/` | Only this project |
 
----
+**Global is recommended for most users.** Run once, use ClaudeKit in any project.
 
-### Option A: Global Installation ⭐ Recommended for Most Users
+## Step 3: Install Your Kit
 
-> **Use when:** You want ClaudeKit available for ALL projects without copying files to each project.
->
-> **Run from:** Any directory (e.g., home folder, desktop, anywhere)
+### Engineer Kit (development workflows)
 
 ```bash
-# Interactive mode
-ck init -g
-
-# With kit selection
+# Global — available in all projects
 ck init -g --kit engineer
 
-# Specific version
-ck init -g --kit engineer --version v1.0.0
-```
-
-**Where files are installed:**
-- **macOS/Linux**: `~/.claude/`
-- **Windows**: `%USERPROFILE%\.claude\`
-
-> ✅ **Tip:** Global mode is ideal for personal development. Install once, use everywhere.
-
----
-
-### Option B: Local Installation (Project-Specific)
-
-> **Use when:** You want ClaudeKit files ONLY in a specific project.
->
-> **Run from:** Your project's root directory (e.g., `/projects/my-app/`)
-
-```bash
-# Move to project first!
+# Local — current project only
 cd /path/to/your/project
-
-# Interactive mode
-ck init
-
-# With kit selection
 ck init --kit engineer
-
-# With exclude patterns
-ck init --exclude "local-config/**" --exclude "*.local"
 ```
 
-**Where files are installed:** In the current project directory (`./.claude/`)
+**What gets installed:**
+- 80+ skills (cook, fix, brainstorm, test, scout, and more)
+- Agents (planner, tester, code-reviewer, debugger)
+- Configuration files (`.ck.json`, `.ckignore`, `settings.json`)
 
-> ⚠️ **Warning:** Running `ck init` (without `-g`) from **home directory** or **user directory** will install ClaudeKit there, which may cause hook path errors. If you want ClaudeKit available everywhere, use `ck init -g`.
-
----
-
-### Updating CLI
-
-To update the `ck` command-line tool to the latest version:
+### Marketing Kit (content & campaigns)
 
 ```bash
-ck update
+ck init -g --kit marketing
 ```
 
-**Note:** This command only updates the CLI, not ClaudeKit Engineer files. Use `ck init` (local) or `ck init -g` (global) to update ClaudeKit Engineer files.
+**What gets installed:**
+- 60+ skills (social, email, brand, seo, video, campaign, and more)
+- Marketing agents (copywriter, designer, campaign-manager)
 
-### Authentication
+### Both Kits
 
-The CLI requires a **GitHub Personal Access Token (PAT)** to download releases from private repositories (`claudekit-engineer` and `claudekit-marketing`).
+Run `ck init -g` once per kit. They install to the same `~/.claude/` directory without conflict:
 
-**Authentication Fallback Chain:**
+```bash
+ck init -g --kit engineer
+ck init -g --kit marketing
+```
 
-1. **GitHub CLI**: Uses `gh auth token` if GitHub CLI is installed and authenticated
-2. **Environment Variables**: Checks `GITHUB_TOKEN` or `GH_TOKEN`
-3. **OS Keychain**: Retrieves saved token from system keychain
-4. **User Prompt**: Prompts for token input and offers to save securely
+## Step 4: Authenticate
 
-**Creating a Personal Access Token:**
+The CLI needs a GitHub Personal Access Token to download kit releases.
 
-1. Go to GitHub Settings → Developer settings → Personal access tokens → Tokens (classic)
-2. Create new token with `repo` scope (for private repositories)
-3. Copy the token
+**Automatic (recommended):** If you have the GitHub CLI installed and authenticated, the CLI picks up your token automatically:
 
-**Setting Token via Environment Variable:**
+```bash
+gh auth login  # if not already done
+ck init -g --kit engineer  # token detected automatically
+```
+
+**Manual:** Create a token at GitHub Settings → Developer settings → Personal access tokens → Tokens (classic). Select the `repo` scope. Then:
 
 ```bash
 export GITHUB_TOKEN=ghp_your_token_here
+ck init -g --kit engineer
 ```
+
+The CLI also checks `GH_TOKEN` and your OS keychain — you only need to enter a token once.
+
+## Step 5: Start Using ClaudeKit
+
+Launch Claude Code in any project:
+
+```bash
+claude
+```
+
+Then invoke skills with `/ck:` prefix:
+
+```bash
+/ck:cook add user authentication
+/ck:fix --auto
+/ck:brainstorm should I use REST or GraphQL?
+/ck:test
+```
+
+Initialize project documentation (optional but recommended):
+
+```bash
+/ck:docs init
+```
+
+This scans your project and generates `docs/codebase-summary.md`, `docs/code-standards.md`, and `docs/system-architecture.md`.
+
+---
 
 ## Verify Installation
 
-After installation (either method), verify everything is set up correctly:
-
 ```bash
-# Check Claude Code is available
+# Check skills are installed
+ls ~/.claude/skills/    # Global
+ls .claude/skills/      # Local
+
+# Check Claude Code sees the config
 claude --version
-
-# Check .claude directory exists
-ls -la .claude/
 ```
 
-## Updating ClaudeKit
+## Update ClaudeKit
 
-Keep ClaudeKit Engineer up to date:
-
-```bash
-# Update ClaudeKit Engineer to latest version
-ck init
-
-# Update to specific version
-ck init --version v1.2.0
-```
-
-**Exclude specific files when updating:**
+Re-run `ck init` to pull the latest release:
 
 ```bash
-# Don't overwrite CLAUDE.md
-ck init --exclude CLAUDE.md
-```
+# Update engineer kit globally
+ck init -g --kit engineer
 
-**Update CLI:**
+# Update to a specific version
+ck init -g --kit engineer --version v3.1.0
 
-```bash
-# Update ck command-line tool
+# Update CLI itself
 ck update
 ```
 
-## Troubleshooting
+`ck init` is safe to re-run — it merges updates and preserves your customizations.
 
-### Permission Errors
+---
 
-On macOS/Linux, you may need sudo:
+## Advanced: Manual Installation
+
+> This method is not recommended for most users. Use `ck init` above.
+
+If you cannot use the CLI (no internet on target machine, air-gapped environment):
+
+1. Download the kit release archive from the GitHub Releases page
+2. Extract to a local directory
+3. Run `ck init --local-path /path/to/extracted-kit`
+
+Or install from a local directory:
 
 ```bash
-sudo npm install -g claudekit-cli
+ck init -g --kit engineer --local-path ./my-downloaded-kit
 ```
 
-Or configure npm to use a different directory:
+---
+
+## Troubleshooting
+
+### Permission Errors (npm global install)
 
 ```bash
+# Option A: Use npx (no global install needed)
+npx claudekit-cli init -g --kit engineer
+
+# Option B: Configure npm prefix
 mkdir ~/.npm-global
 npm config set prefix '~/.npm-global'
 export PATH=~/.npm-global/bin:$PATH
+npm install -g claudekit-cli
+```
+
+### GitHub Authentication Failed
+
+```bash
+# Install GitHub CLI
+brew install gh        # macOS
+# or: https://cli.github.com
+
+# Authenticate
+gh auth login
+
+# Verify
+gh auth status
 ```
 
 ### Claude Code Not Found
 
-If the `claude` command is not found:
+Install Claude Code CLI from [claude.ai/code](https://claude.ai/code), then restart your terminal and verify with `claude --version`.
 
-1. Install Claude Code CLI from [claude.ai/code](https://claude.ai/code)
-2. Restart terminal
-3. Verify with `claude --version`
+### Skills Not Activating
 
-### GitHub Authentication Failed
+After global install, verify skills are present:
+```bash
+ls ~/.claude/skills/cook
+# Should show: SKILL.md (and possibly references/ scripts/)
+```
 
-If CLI cannot authenticate:
+If empty, re-run `ck init -g --kit engineer`.
 
-1. Install GitHub CLI: `brew install gh` (macOS) or see [cli.github.com](https://cli.github.com)
-2. Authenticate: `gh auth login`
-3. Verify: `gh auth status`
-4. Or set environment variable: `export GITHUB_TOKEN=your_token`
+---
 
 ## Next Steps
 
-Now that ClaudeKit is installed, continue with:
-
-- [Quick Start Guide](/docs/getting-started/quick-start) - Build your first project
-- [CLAUDE.md Explained](/docs/engineer/configuration/claude-md) - Understand the configuration file
-- [Workflows](/docs/engineer/configuration/workflows) - Learn about development workflows
+- [AgentKit Architecture](/docs/getting-started/agentkit-overview) — Understand how kits, skills, and agents fit together
+- [Quick Start](/docs/getting-started/quick-start) — Build your first feature
+- [Skills Overview](/docs/engineer/skills) — Browse all available skills

--- a/src/content/docs/getting-started/introduction.md
+++ b/src/content/docs/getting-started/introduction.md
@@ -31,50 +31,51 @@ New to ClaudeKit? Watch this step-by-step tutorial covering CLI installation, se
 
 ClaudeKit extends Claude Code with specialized toolkits for engineering and marketing. Instead of writing prompts from scratch, you call workflows optimized for speed and quality.
 
-### Two Powerful Toolkits
+ClaudeKit is powered by **AgentKit** — a multi-kit framework that ships skills, agents, and workflows as versioned releases. Skills install to `~/.claude/skills/` via the `ck` CLI and are invoked with `/ck:skill-name` inside Claude Code.
 
-**Engineer Kit** - Development & automation toolkit:
-- **Agents**: Specialized AI assistants (planner, researcher, tester, debugger, backend-developer)
-- **Commands**: Development workflows (`/ck:cook`, `/ck:fix`, `/ck:plan`, `/ck:test`)
-- **Skills**: Technical knowledge modules (Next.js, PostgreSQL, Docker, DevOps)
+### Two Powerful Kits
 
-**Marketing Kit** - Marketing & content automation toolkit:
-- **Agents**: Content creators (copywriter, ui-ux-designer, campaign-manager, seo-specialist)
-- **Commands**: Marketing workflows (`/write:blog`, `/video:create`, `/slide:create`, `/campaign:*`)
+**Engineer Kit** — Development & automation toolkit:
+- **Agents**: Specialized AI assistants (planner, researcher, tester, debugger, code-reviewer)
+- **Skills**: `/ck:cook`, `/ck:fix`, `/ck:plan`, `/ck:test`, `/ck:brainstorm` and 75+ more
+- **Knowledge modules**: Next.js, PostgreSQL, Docker, DevOps, better-auth, and more
+
+**Marketing Kit** — Marketing & content automation toolkit:
+- **Agents**: Content creators (copywriter, designer, campaign-manager, seo-specialist)
+- **Skills**: `/ckm:social`, `/ckm:email`, `/ckm:brand`, `/ckm:seo`, `/ckm:campaign` and 55+ more
 - **Asset Management**: Centralized hub for copy, storyboards, slides, brand guidelines
-- **Skills**: Marketing expertise (copywriting, SEO, analytics, video production)
 
 ## How It Works
 
 **Engineer Kit Example:**
 1. Type `/ck:cook "add user authentication"`
-2. System launches planner → researcher → developer → tester
+2. System launches planner → researcher → developer → tester agents
 3. Agents collaborate, write code, run tests, commit changes
 4. You review results, provide feedback, iterate
 
 **Marketing Kit Example:**
-1. Type `/write:blog "introducing our new API"`
-2. System extracts your writing style from `/assets/writing-styles/`
-3. Copywriter agent drafts blog matching your tone
-4. Content saved to Asset Management hub for reuse
+1. Type `/ckm:social "launch announcement for our new API"`
+2. System applies your brand voice and platform guidelines
+3. Content variants generated for LinkedIn, X, and newsletter
+4. Assets saved to content hub for reuse
 
 ## Why Use ClaudeKit?
 
 **For Engineers:**
-- **Speed**: 10x faster than manual prompting for feature development
-- **Quality**: Battle-tested workflows reduce bugs and technical debt
-- **Consistency**: Same development patterns across entire team
+- **Speed**: Structured workflows replace repetitive prompting for feature development
+- **Quality**: Battle-tested skill prompts reduce bugs and technical debt
+- **Consistency**: Same development patterns across your entire team
 
 **For Marketers:**
 - **Brand Consistency**: Centralized asset management ensures unified messaging
-- **Context Awareness**: Content based on actual product/codebase
-- **Production Ready**: Video storyboards with Gemini Veo 3.1, slides in .pptx format
+- **Context Awareness**: Content based on actual product and codebase
+- **Production Ready**: Video storyboards, `.pptx` slides, multi-channel copy
 
-## Choose Your Toolkit
+## Choose Your Kit
 
 Use the kit switcher in the header to explore:
 
-**Engineer Kit** → Start at [Engineer Docs](/docs/engineer/agents)
+**Engineer Kit** → Start at [Engineer Skills](/docs/engineer/skills)
 - Feature development workflows
 - Testing and debugging agents
 - Infrastructure automation
@@ -86,9 +87,9 @@ Use the kit switcher in the header to explore:
 
 ## Next Steps
 
-1. **[Understand the Concepts](/docs/getting-started/concepts)** - How agents, commands, and skills work
-2. **[Install ClaudeKit](/docs/getting-started/installation)** - Set up the CLI
-3. **[Quick Start](/docs/getting-started/quick-start)** - Build your first feature or campaign
+1. **[Install ClaudeKit](/docs/getting-started/installation)** — Set up the `ck` CLI in 5 minutes
+2. **[AgentKit Architecture](/docs/getting-started/agentkit-overview)** — Understand kits, skills, and agents
+3. **[Quick Start](/docs/getting-started/quick-start)** — Build your first feature or campaign
 
 ## Explore Workflows
 

--- a/src/content/docs/getting-started/quick-start.md
+++ b/src/content/docs/getting-started/quick-start.md
@@ -293,7 +293,7 @@ A: `code-reviewer` catches issues before commit. Plus, you review PRs as normal.
 A: For basic features, no. For advanced skills (Gemini, Search), yes. See [API Key Setup](/docs/support/troubleshooting/api-key-setup).
 
 **Q: Can I customize agents?**
-A: Yes. Edit `.claude/agents/*.md` to tune behavior. See [Custom Agents](/docs/engineer/configuration/hooks).
+A: Yes. Edit `~/.claude/agents/*.md` (global) or `.claude/agents/*.md` (local) to tune behavior. See [Custom Agents](/docs/engineer/configuration/hooks).
 
 ## Explore More
 

--- a/src/content/docs/marketing/skills/index.md
+++ b/src/content/docs/marketing/skills/index.md
@@ -98,10 +98,11 @@ Skills automatically activate based on task context - no explicit command needed
 
 ## Configuration
 
-Skills store configuration in user's project directory:
+Skills are installed to `~/.claude/skills/` (global) or `.claude/skills/` (local project):
 
 ```
-.claude/skills/{skill-name}/
+~/.claude/skills/{skill-name}/     # global install (recommended)
+.claude/skills/{skill-name}/       # local project install
 ├── SKILL.md              # Skill definition
 ├── references/           # Knowledge base
 ├── scripts/              # Automation scripts
@@ -152,7 +153,7 @@ Use natural language to explicitly activate: "Activate {skill-name} skill for th
 Check skill doc's "Prerequisites" section for required keys.
 
 **Script not found?**
-Verify skill installed: `ls .claude/skills/{skill-name}/scripts/`
+Verify skill installed: `ls ~/.claude/skills/{skill-name}/scripts/` (global) or `ls .claude/skills/{skill-name}/scripts/` (local)
 
 **Reference not loading?**
-Skills use progressive disclosure. Load references manually when needed: `Read .claude/skills/{skill-name}/references/{file}.md`
+Skills use progressive disclosure. Load references manually when needed: `Read ~/.claude/skills/{skill-name}/references/{file}.md`

--- a/src/content/docs/support/troubleshooting/api-key-setup.md
+++ b/src/content/docs/support/troubleshooting/api-key-setup.md
@@ -275,8 +275,8 @@ echo $OPENROUTER_API_KEY
 Edit agent files to use OpenRouter models:
 
 ```bash
-# Example: Use Claude Opus for planning
-cat > .claude/agents/planner.md << 'EOF'
+# Example: Use Claude Opus for planning (global install)
+cat > ~/.claude/agents/planner.md << 'EOF'
 ---
 name: planner
 description: Creates implementation plans

--- a/src/content/docs/support/troubleshooting/command-errors.md
+++ b/src/content/docs/support/troubleshooting/command-errors.md
@@ -18,16 +18,17 @@ Commands not working? Get them running in minutes with these step-by-step fixes.
 
 ```bash
 # 1. Verify .claude directory exists
-ls -la .claude/
+ls -la ~/.claude/    # global install
+ls -la .claude/      # local project install
 
-# 2. Check commands directory
-ls .claude/commands/
+# 2. Check skills directory
+ls ~/.claude/skills/
 
-# 3. Verify specific command file
-cat .claude/commands/core/cook.md
+# 3. Verify a specific skill file exists
+ls ~/.claude/skills/cook/
 
 # If files missing, reinitialize ClaudeKit
-ck init --kit engineer
+ck init -g --kit engineer
 ```
 
 ---
@@ -52,56 +53,57 @@ claude --version
 **Step 2: Check .claude directory structure**
 
 ```bash
+# Global install (recommended)
 # Should show:
-# .claude/
+# ~/.claude/
 # ├── agents/
-# ├── commands/
 # ├── skills/
-# └── workflows/
+# └── .ck.json
 
-tree .claude -L 2
+tree ~/.claude -L 2
 
 # Or without tree command
-ls -R .claude/
+ls ~/.claude/
+ls ~/.claude/skills/
 ```
 
-**Step 3: Verify command files exist**
+**Step 3: Verify skill files exist**
 
 ```bash
-# List all commands
-find .claude/commands -name "*.md"
+# List all installed skills
+ls ~/.claude/skills/
 
-# Should show files like:
-# .claude/commands/core/cook.md
-# .claude/commands/core/plan.md
-# .claude/commands/fix/fast.md
-# etc.
+# Should show directories like:
+# cook/  fix/  brainstorm/  test/  scout/ ...
+
+# Verify a specific skill
+ls ~/.claude/skills/cook/
+# Should show: SKILL.md
 ```
 
-**Step 4: Check command file format**
+**Step 4: Check skill file format**
 
 ```bash
-# View command file
-cat .claude/commands/core/cook.md
+# View skill file
+cat ~/.claude/skills/cook/SKILL.md
 
 # Must have frontmatter:
 # ---
-# name: cook
-# description: Implement a feature step by step
+# name: ck:cook
+# description: Implement features...
 # ---
 ```
 
 **Expected structure**:
 ```markdown
 ---
-name: cook
-description: Implement a feature step by step
-model: gemini-2.5-flash-agent
+name: ck:cook
+description: Implement features, plans, and fixes with structured workflow
+category: utilities
 ---
 
-# Cook Command
-
-Detailed implementation instructions...
+# Cook - Smart Feature Implementation
+...
 ```
 
 ---
@@ -175,14 +177,16 @@ See [API Key Setup](/docs/support/troubleshooting/api-key-setup) for complete co
 **Solution**:
 
 ```bash
-# Check command syntax in file
-cat .claude/commands/core/cook.md
-
-# Use correct format:
+# Use correct format — natural language after skill name:
 /ck:cook implement feature name
 
-# NOT:
-/ck:cook --implement feature
+# Flags use -- prefix:
+/ck:fix --auto
+/ck:cook "add auth" --fast
+
+# NOT colon-separated flags (old syntax):
+# /ck:fix:auto  ❌  (wrong)
+# /ck:fix --auto  ✓  (correct)
 ```
 
 #### Agent Not Available
@@ -193,7 +197,8 @@ cat .claude/commands/core/cook.md
 
 ```bash
 # Check agents directory
-ls .claude/agents/
+ls ~/.claude/agents/    # global
+ls .claude/agents/      # local
 
 # Should show:
 # planner.md
@@ -202,10 +207,10 @@ ls .claude/agents/
 # etc.
 
 # Verify agent file
-cat .claude/agents/planner.md
+cat ~/.claude/agents/planner.md
 
 # Reinitialize if missing
-ck init --kit engineer
+ck init -g --kit engineer
 ```
 
 See [Agent Issues](/docs/support/troubleshooting/agent-issues) for agent-specific problems.
@@ -216,13 +221,13 @@ See [Agent Issues](/docs/support/troubleshooting/agent-issues) for agent-specifi
 
 ### Invalid Frontmatter
 
-**Symptom**: Command file exists but command doesn't load
+**Symptom**: Skill file exists but skill doesn't load
 
 **Problem**: Frontmatter syntax errors
 
 ```bash
 # Check frontmatter format
-head -n 10 .claude/commands/core/cook.md
+head -n 10 ~/.claude/skills/cook/SKILL.md
 ```
 
 ✅ **Correct format**:
@@ -260,26 +265,23 @@ description: Implement a feature
 3. Use correct YAML syntax
 4. Include closing `---`
 
-### Command Name Conflicts
+### Skill Name Conflicts
 
-**Symptom**: Custom command doesn't work, core command runs instead
+**Symptom**: Custom skill doesn't work, core skill runs instead
 
-**Problem**: Duplicate command names
+**Problem**: Duplicate skill names
 
 **Solution**:
 
 ```bash
 # Find duplicates
-find .claude/commands -name "*.md" -exec grep -l "^name: cook$" {} \;
+find ~/.claude/skills -name "SKILL.md" -exec grep -l "^name: ck:cook$" {} \;
 
 # Should show only one file
 
-# If duplicates exist, rename custom command
-# Change name in frontmatter
----
-name: cook-custom
-description: My custom cook implementation
----
+# If duplicates exist, rename your custom skill
+# Change name in frontmatter to a unique value:
+# name: ck:cook-custom
 ```
 
 ---
@@ -303,23 +305,23 @@ ck init --kit engineer
 tree .claude -L 2
 ```
 
-### Corrupted Command Files
+### Corrupted Skill Files
 
-**Symptom**: Commands worked before, now fail with parse errors
+**Symptom**: Skills worked before, now fail with parse errors
 
 **Solution**:
 
-ClaudeKit now creates an automatic recovery backup under `~/.claudekit/backups/` before destructive refresh or uninstall flows. Keep the manual copy below if you want your own explicit backup as well.
+ClaudeKit creates an automatic recovery backup under `~/.claudekit/backups/` before destructive refresh or uninstall flows. Keep the manual copy below for your own explicit backup as well.
 
 ```bash
-# Backup current .claude
-cp -r .claude .claude.backup
+# Backup current .claude (global)
+cp -r ~/.claude ~/.claude.backup
 
-# Update to fresh version
-ck init --kit engineer
+# Re-install to fresh version
+ck init -g --kit engineer
 
-# Restore custom files if needed
-cp .claude.backup/commands/my-custom.md .claude/commands/
+# Restore custom skills if needed
+cp -r ~/.claude.backup/skills/my-custom-skill ~/.claude/skills/
 
 # Verify
 /ck:cook test command
@@ -348,48 +350,49 @@ icacls .claude /grant Everyone:F /T
 
 ### Required Files
 
-ClaudeKit requires this structure:
+ClaudeKit (global install) requires this structure:
 
 ```
-.claude/
+~/.claude/
 ├── agents/          # AI agent definitions
 │   ├── planner.md
 │   ├── researcher.md
 │   ├── code-reviewer.md
 │   └── ...
-├── commands/        # Slash commands
-│   ├── core/
-│   │   ├── cook.md
-│   │   ├── plan.md
-│   │   └── ...
+├── skills/          # Installed skills (from AgentKit kits)
+│   ├── cook/
+│   │   └── SKILL.md
 │   ├── fix/
-│   ├── git/
+│   │   └── SKILL.md
+│   ├── brainstorm/
+│   │   └── SKILL.md
 │   └── ...
-├── skills/          # Specialized skills
-├── workflows/       # Workflow definitions
-CLAUDE.md           # Configuration
-.mcp.json           # MCP server config [DEPRECATED]
+├── .ck.json         # ClaudeKit configuration
+├── .ckignore        # Paths excluded from LLM context
+└── settings.json    # Claude Code hook settings
 ```
+
+> **Note:** There is no `commands/` directory in current AgentKit installations. Skills replaced commands as of engineer@2.12.0.
 
 ### Validate Structure
 
 ```bash
-# Check all required directories
-for dir in agents commands skills workflows; do
-  if [ -d ".claude/$dir" ]; then
-    echo "✅ .claude/$dir exists"
+# Check all required directories (global)
+for dir in agents skills; do
+  if [ -d "$HOME/.claude/$dir" ]; then
+    echo "✅ ~/.claude/$dir exists"
   else
-    echo "❌ .claude/$dir missing"
+    echo "❌ ~/.claude/$dir missing — run: ck init -g --kit engineer"
   fi
 done
 
-# Count command files
-find .claude/commands -name "*.md" | wc -l
-# Should show 30+
+# Count skill directories
+ls ~/.claude/skills/ | wc -l
+# Should show 50+
 
 # Count agent files
-find .claude/agents -name "*.md" | wc -l
-# Should show 12+
+find ~/.claude/agents -name "*.md" | wc -l
+# Should show 5+
 ```
 
 ---
@@ -414,10 +417,10 @@ cat ~/.claudekit/logs/latest.log
 
 ```bash
 # Test agent directly
-cat .claude/agents/planner.md
+cat ~/.claude/agents/planner.md
 
-# Test command parsing
-head -n 20 .claude/commands/core/cook.md
+# Test skill file
+head -n 20 ~/.claude/skills/cook/SKILL.md
 
 # Test Claude Code
 claude --version
@@ -445,14 +448,14 @@ echo ".claude exists: $([ -d .claude ] && echo yes || echo no)"
 ### Reset ClaudeKit
 
 ```bash
-# Backup custom files
-cp -r .claude .claude.backup
+# Backup custom files (global install)
+cp -r ~/.claude ~/.claude.backup
 
 # Update to latest
-ck init --kit engineer
+ck init -g --kit engineer
 
-# Restore custom commands
-cp .claude.backup/commands/my-custom.md .claude/commands/
+# Restore custom skills
+cp -r ~/.claude.backup/skills/my-custom-skill ~/.claude/skills/
 
 # Test
 /ck:cook hello world

--- a/src/content/docs/support/troubleshooting/command-errors.md
+++ b/src/content/docs/support/troubleshooting/command-errors.md
@@ -233,9 +233,8 @@ head -n 10 ~/.claude/skills/cook/SKILL.md
 ✅ **Correct format**:
 ```yaml
 ---
-name: cook
+name: ck:cook
 description: Implement a feature step by step
-model: gemini-2.5-flash-agent
 ---
 ```
 
@@ -544,7 +543,7 @@ claude --dangerously-skip-permissions
 
 ### Get Help
 
-1. **GitHub Issues**: [Report command problems](https://github.com/claudekit/claudekit-engineer/issues)
+1. **GitHub Issues**: [Report command problems](https://github.com/bestagentkits/agentkit/issues)
 2. **Discord**: [Ask community](https://claudekit.cc/discord)
 3. **Include**: Debug report, error message, steps to reproduce
 

--- a/src/content/docs/support/troubleshooting/performance-issues.md
+++ b/src/content/docs/support/troubleshooting/performance-issues.md
@@ -102,8 +102,8 @@ export CLAUDEKIT_VERBOSE=1
 **Solution**:
 
 ```bash
-# Check agent model
-cat .claude/agents/tester.md | grep model:
+# Check agent model (global install)
+cat ~/.claude/agents/tester.md | grep model:
 
 # Fast models (use for simple tasks):
 model: gemini-2.5-flash-agent
@@ -114,7 +114,7 @@ model: claude-sonnet-4
 model: claude-opus-4
 
 # Fix: Edit agent file
-nano .claude/agents/tester.md
+nano ~/.claude/agents/tester.md
 # Change to: model: gemini-2.5-flash-agent
 ```
 


### PR DESCRIPTION
## Summary

Track 1 of epic #164 — content rewrite to reflect AgentKit migration.

## Changes

- Rewrite `installation.md` + `getting-started/` for AgentKit (kits at `agentkit/kits/*/`)
- Add `agentkit-overview.md` and `agentkit-migration.md`
- Correct `.claude/skills/` and `.claude/agents/` path references throughout
- Add 2 missing skill pages (`kanban`, `mcp-management`); mark `cti-expert` deprecated
- Major overhaul of `troubleshooting/command-errors.md`

## Validation

- [x] `bun run build` passes — 0 errors, 2139/2139 internal links valid
- [x] No `src/content/**` colon-syntax (root cause was live render / non-MDX path; flagged to Track 2)

## Notes

- Source MDX never had colon-style `/cmd:flag` patterns — the audit's finding was a live-site render artifact. Track 2 (#166) diagnoses the render path.
- Vietnamese mirror `src/content/docs-vi/` not updated — out of Track 1 scope; flagged for i18n follow-up.

Closes #165
Part of #164