### PR TITLE
docs: Codex Windows support + canonical hook wiring overhaul

### DIFF
--- a/src/components/nav/DocsNav.astro
+++ b/src/components/nav/DocsNav.astro
@@ -7,6 +7,14 @@ interface Props {
   currentPath: string;
 }
 
+interface NavTreeNode {
+  title: string;
+  items: any[];
+  subcategories: Record<string, NavTreeNode>;
+  path: string;
+  collapsed: boolean;
+}
+
 const { docs, currentPath } = Astro.props;
 const currentLocale = getLangFromUrl(Astro.url);
 
@@ -16,16 +24,16 @@ const capitalize = (str: string) => {
 };
 
 // Build nested structure
-const buildHierarchy = (docs: any[]) => {
-  const root = {};
+const buildHierarchy = (docs: any[]): Record<string, NavTreeNode> => {
+  const root: Record<string, NavTreeNode> = {};
 
   docs.forEach(doc => {
     const categoryPath = doc.data.category || 'uncategorized';
     const parts = categoryPath.split('/');
-    
-    let currentLevel = root;
-    
-    parts.forEach((part, index) => {
+
+    let currentLevel: Record<string, NavTreeNode> = root;
+
+    parts.forEach((part: string, index: number) => {
       if (!currentLevel[part]) {
         currentLevel[part] = {
           title: capitalize(part),
@@ -35,7 +43,7 @@ const buildHierarchy = (docs: any[]) => {
           collapsed: true // Default collapsed
         };
       }
-      
+
       if (index === parts.length - 1) {
         currentLevel[part].items.push(doc);
       } else {
@@ -65,7 +73,7 @@ const sortItems = (items: any[]) => {
 ---
 
 <div class="docs-nav">
-  {Object.entries(hierarchy).map(([key, category]: [string, any]) => (
+  {Object.entries(hierarchy).map(([_key, category]: [string, NavTreeNode]) => (
     <div class="nav-section" data-category={category.path} data-collapsible>
       <button class="nav-section-title" aria-expanded="false">
         <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -100,7 +108,7 @@ const sortItems = (items: any[]) => {
         })}
 
         {/* Render subcategories */}
-        {Object.entries(category.subcategories).map(([subKey, subCategory]: [string, any]) => (
+        {Object.entries(category.subcategories).map(([_subKey, subCategory]: [string, NavTreeNode]) => (
           <div class="nav-sub-section" data-category={subCategory.path} data-collapsible>
             <button class="nav-sub-section-title" aria-expanded="false">
               <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/src/content/docs/changelog/index.md
+++ b/src/content/docs/changelog/index.md
@@ -12,6 +12,23 @@ Track all releases and changes for the ClaudeKit Engineer Kit.
 
 ---
 
+## v2.20.0 (Upcoming)
+
+### Highlights
+
+- **Expanded default hook wiring** — 7 additional hooks now wired by default: `session-init`, `dev-rules-reminder`, `cook-after-plan-reminder`, `plan-format-kanban`, `session-state`, `subagent-init`, `usage-quota-cache-refresh`. Total: 15 wired entries across 6 events.
+- **Codex hooks on Windows** — Hook wiring to Codex now works on Windows. The platform gate is removed; `ck init` and `ck migrate` probe for `codex`/`codex.exe`, resolve `%USERPROFILE%` paths, and strip Unix shebangs when targeting Windows.
+- **Direct node invocation** — `node-hook-runner.sh` bash wrapper removed. All hook commands now run via `node` directly. `ck init` auto-repairs legacy bash-runner entries on upgrade.
+- **Zombie hook pruner** — `ck init` automatically removes engineer-tagged hook entries whose referenced file is missing (cleans up stale `node-hook-runner.sh` and `skill-dedup.cjs` references from old installs).
+- **3 opt-in hooks** — `usage-context-awareness`, `team-context-inject`, and `workflow-artifact-gate` are documented as user-side opt-ins with example wiring snippets.
+
+### Removals
+
+- `skill-dedup.cjs` deleted — deprecated since v2.9.1; deduplication now handled by CLI install logic.
+- `node-hook-runner.sh` removed — replaced by direct `node` invocation.
+
+---
+
 ## v2.14.0 (Upcoming)
 
 ### Highlights

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -74,7 +74,7 @@ The `ck migrate` command:
 
 > **Generated hook cleanup (v4.3.0+):** `ck migrate` does not migrate ClaudeKit's generated session/subagent/usage context hooks by default. It also removes stale registrations and hook files for those generated hooks from existing migrated providers, including Codex and Claude Code, while preserving safety hooks such as privacy and scout blocking.
 
-> **Codex hooks on Windows (v4.4.0+):** Hook wiring to Codex now works on all platforms including Windows. The previous Windows short-circuit has been removed. `ck init` and `ck migrate` probe for both `codex` and `codex.exe`, resolve `%USERPROFILE%` path candidates, and strip Unix shebangs from hook files when writing to Windows targets. If you previously ran `ck migrate --agent codex` on Windows and hooks were silently skipped, re-run `ck migrate --agent codex --hooks --force` to wire them now.
+> **Codex hooks on Windows (v4.4.0+):** Hook wiring to Codex now works on all platforms including Windows. The previous Windows short-circuit has been removed. `ck init` and `ck migrate` probe for both `codex` and `codex.exe`, resolve `%USERPROFILE%` path candidates, and generate hook wrappers without a shebang (always invoked via `node`, so they run identically on every platform). If you previously ran `ck migrate --agent codex` on Windows and hooks were silently skipped, re-run `ck migrate --agent codex --hooks --force` to wire them now.
 
 ## Supported Providers
 

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -74,6 +74,8 @@ The `ck migrate` command:
 
 > **Generated hook cleanup (v4.3.0+):** `ck migrate` does not migrate ClaudeKit's generated session/subagent/usage context hooks by default. It also removes stale registrations and hook files for those generated hooks from existing migrated providers, including Codex and Claude Code, while preserving safety hooks such as privacy and scout blocking.
 
+> **Codex hooks on Windows (v4.4.0+):** Hook wiring to Codex now works on all platforms including Windows. The previous Windows short-circuit has been removed. `ck init` and `ck migrate` probe for both `codex` and `codex.exe`, resolve `%USERPROFILE%` path candidates, and strip Unix shebangs from hook files when writing to Windows targets. If you previously ran `ck migrate --agent codex` on Windows and hooks were silently skipped, re-run `ck migrate --agent codex --hooks --force` to wire them now.
+
 ## Supported Providers
 
 Each column indicates how well `ck migrate` can transfer that content type to the target provider:

--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -155,7 +155,7 @@ ClaudeKit Engineer ships with hooks organized by event type. All default hook fi
 | `session-state.cjs` | `SubagentStop` | — | Persist state when any subagent stops |
 | `session-state.cjs` | `Stop` | — | Persist state when session ends |
 
-> `usage-quota-cache-refresh.cjs` and `session-state.cjs` each appear across multiple events — that is intentional. Total: 15 wired entries across 6 events.
+> `usage-quota-cache-refresh.cjs` and `session-state.cjs` each appear across multiple events — that is intentional. Total: 15 wired entries across 7 events.
 
 **Opt-in hooks (not wired by default — add to `settings.json` manually):**
 

--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -10,13 +10,13 @@ published: true
 
 # Hooks
 
-Hooks allow you to extend Claude Code with custom scripts that run at specific points in the workflow. ClaudeKit Engineer includes pre-built hooks for file access control, naming guidance, simplification gates, statusline rendering, optional session context, and notifications.
+Hooks allow you to extend Claude Code with custom scripts that run at specific points in the workflow. ClaudeKit Engineer includes pre-built hooks for file access control, naming guidance, simplification gates, statusline rendering, session context, and notifications.
 
 ## Overview
 
 Hooks are configured in `.claude/settings.json` and execute shell commands in response to Claude Code events.
 
-> **Current default (v2.19.0+):** ClaudeKit installs only lightweight safety and workflow hooks by default. Generated session/subagent/usage context hooks are opt-in and are pruned from existing installs during `ck update` or `ck migrate`.
+> **Current default (v2.20.0+):** ClaudeKit installs a comprehensive set of workflow hooks by default across all supported events. Three additional hooks are available as opt-in for users who want extended context injection. Zombie hook entries (referencing missing files from old installs) are pruned automatically on `ck init`.
 
 ### Available Hook Events
 
@@ -34,23 +34,38 @@ Hooks are configured in `.claude/settings.json` and execute shell commands in re
 
 ## Configuration
 
-Hooks are defined in `.claude/settings.json`:
+Hooks are defined in `.claude/settings.json`. Since v2.20.0, hook commands invoke `node` directly — the `node-hook-runner.sh` bash wrapper has been removed. If you have an older install, `ck init` auto-repairs legacy bash-runner commands to the direct form.
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "bash .claude/hooks/node-hook-runner.sh .claude/statusline.cjs",
+    "command": "node \".claude/statusline.cjs\"",
     "padding": 0
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/session-init.cjs\"" },
+          { "type": "command", "command": "node \".claude/hooks/usage-quota-cache-refresh.cjs\"" }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/node-hook-runner.sh .claude/hooks/simplify-gate.cjs"
-          }
+          { "type": "command", "command": "node \".claude/hooks/simplify-gate.cjs\"" },
+          { "type": "command", "command": "node \".claude/hooks/dev-rules-reminder.cjs\"" },
+          { "type": "command", "command": "node \".claude/hooks/usage-quota-cache-refresh.cjs\"" }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/subagent-init.cjs\"" }
         ]
       }
     ],
@@ -58,23 +73,49 @@ Hooks are defined in `.claude/settings.json`:
       {
         "matcher": "Write",
         "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/node-hook-runner.sh .claude/hooks/descriptive-name.cjs"
-          }
+          { "type": "command", "command": "node \".claude/hooks/descriptive-name.cjs\"" }
         ]
       },
       {
         "matcher": "Bash|Glob|Grep|Read|Edit|Write",
         "hooks": [
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/node-hook-runner.sh .claude/hooks/scout-block.cjs"
-          },
-          {
-            "type": "command",
-            "command": "bash .claude/hooks/node-hook-runner.sh .claude/hooks/privacy-block.cjs"
-          }
+          { "type": "command", "command": "node \".claude/hooks/scout-block.cjs\"" },
+          { "type": "command", "command": "node \".claude/hooks/privacy-block.cjs\"" }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/plan-format-kanban.cjs\"" }
+        ]
+      },
+      {
+        "matcher": "Task|TaskCreate|TaskUpdate|TodoWrite",
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/session-state.cjs\"" },
+          { "type": "command", "command": "node \".claude/hooks/usage-quota-cache-refresh.cjs\"" }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "Plan",
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/cook-after-plan-reminder.cjs\"" }
+        ]
+      },
+      {
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/session-state.cjs\"" }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/session-state.cjs\"" }
         ]
       }
     ]
@@ -94,23 +135,69 @@ ClaudeKit Engineer ships with hooks organized by event type. All default hook fi
 
 ### Summary Table
 
-| Hook File | Default | Event | Purpose |
-|-----------|---------|-------|---------|
-| `simplify-gate.cjs` | Yes | `UserPromptSubmit` | Enforce simplification workflow rules when relevant |
-| `descriptive-name.cjs` | Yes | `PreToolUse` (Write) | Inject file naming guidance: kebab-case, language conventions |
-| `scout-block.cjs` | Yes | `PreToolUse` (Bash/Glob/Grep/Read/Edit/Write) | Block access to `.ckignore`-listed directories |
-| `privacy-block.cjs` | Yes | `PreToolUse` (Bash/Glob/Grep/Read/Edit/Write) | Block sensitive files, require user approval |
-| `session-init.cjs` | No | `SessionStart` | Load config, detect project, persist env vars |
-| `subagent-init.cjs` | No | `SubagentStart` | Inject minimal context to subagents |
-| `team-context-inject.cjs` | No | `SubagentStart` | Inject peer info + task summary for Agent Team members |
-| `cook-after-plan-reminder.cjs` | No | `SubagentStop` (Plan) | Print user-choice guidance after planning |
-| `dev-rules-reminder.cjs` | No | `UserPromptSubmit` | Inject session context, rules, modularization, Plan Context |
-| `usage-context-awareness.cjs` | No | `UserPromptSubmit` + `PostToolUse` | Fetch usage limits, write to cache |
-| `post-edit-simplify-reminder.cjs` | No | `PostToolUse` (Edit/Write/MultiEdit) | Remind about code-simplifier after repeated edits |
-| `task-completed-handler.cjs` | No | `TaskCompleted` | Log completions, inject progress for Agent Team leads |
-| `teammate-idle-handler.cjs` | No | `TeammateIdle` | Inject available task context when team member goes idle |
+**Default hooks (wired automatically by `ck init`):**
 
-The hooks marked `No` are no longer installed by default because they generate context on session, prompt, subagent, or tool events. Existing installations are cleaned up idempotently by the CLI during update and migration.
+| Hook File | Event | Matcher | Purpose |
+|-----------|-------|---------|---------|
+| `session-init.cjs` | `SessionStart` | `startup\|resume\|clear\|compact` | Load config, detect project, persist env vars |
+| `usage-quota-cache-refresh.cjs` | `SessionStart` | `startup\|resume\|clear\|compact` | Refresh API quota cache on session start |
+| `simplify-gate.cjs` | `UserPromptSubmit` | — | Enforce simplification workflow rules when relevant |
+| `dev-rules-reminder.cjs` | `UserPromptSubmit` | — | Inject session context, rules, modularization, Plan Context |
+| `usage-quota-cache-refresh.cjs` | `UserPromptSubmit` | — | Refresh quota cache on each prompt |
+| `subagent-init.cjs` | `SubagentStart` | — | Inject minimal context (~200 tokens) to subagents |
+| `descriptive-name.cjs` | `PreToolUse` | `Write` | Inject file naming guidance: kebab-case, language conventions |
+| `scout-block.cjs` | `PreToolUse` | `Bash\|Glob\|Grep\|Read\|Edit\|Write` | Block access to `.ckignore`-listed directories |
+| `privacy-block.cjs` | `PreToolUse` | `Bash\|Glob\|Grep\|Read\|Edit\|Write` | Block sensitive files, require user approval |
+| `plan-format-kanban.cjs` | `PostToolUse` | `Edit\|Write\|MultiEdit` | Auto-format plan files as Kanban after edits |
+| `session-state.cjs` | `PostToolUse` | `Task\|TaskCreate\|TaskUpdate\|TodoWrite` | Persist session state on task events |
+| `usage-quota-cache-refresh.cjs` | `PostToolUse` | `Task\|TaskCreate\|TaskUpdate\|TodoWrite` | Refresh quota cache on task tool use |
+| `cook-after-plan-reminder.cjs` | `SubagentStop` | `Plan` | Print `/ck:cook` guidance after planning subagent completes |
+| `session-state.cjs` | `SubagentStop` | — | Persist state when any subagent stops |
+| `session-state.cjs` | `Stop` | — | Persist state when session ends |
+
+> `usage-quota-cache-refresh.cjs` and `session-state.cjs` each appear across multiple events — that is intentional. Total: 15 wired entries across 6 events.
+
+**Opt-in hooks (not wired by default — add to `settings.json` manually):**
+
+| Hook File | Event | Purpose |
+|-----------|-------|---------|
+| `usage-context-awareness.cjs` | `UserPromptSubmit` + `PostToolUse` | Fetch usage limits from API, inject token budget into context |
+| `team-context-inject.cjs` | `SubagentStart` | Inject peer info + task summary for Agent Team members (requires `CK_TEAM_MODE=1`) |
+| `workflow-artifact-gate.cjs` | `UserPromptSubmit` | Gate `/ck:fix` and `/ck:cook` approval on review artifact presence |
+
+**Removed hooks:**
+
+| Hook File | Removed in | Notes |
+|-----------|-----------|-------|
+| `skill-dedup.cjs` | v2.20.0 | Deprecated since v2.9.1; deduplication now handled by CLI install logic |
+| `node-hook-runner.sh` | v2.20.0 | Bash wrapper removed; hooks now invoke `node` directly. `ck init` auto-repairs legacy entries |
+
+**Example: enabling opt-in hooks**
+
+Add any of these blocks to your `.claude/settings.json` `hooks` section:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/usage-context-awareness.cjs\"" }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "node \".claude/hooks/team-context-inject.cjs\"" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Zombie hook entries (entries referencing missing files such as old `node-hook-runner.sh` or `skill-dedup.cjs` paths) are automatically pruned by `ck init` on upgrade.
 
 ---
 


### PR DESCRIPTION
## Summary
- Hooks page: refreshed canonical wiring (15 entries), documented the 3 opt-in hooks with example wiring, noted `skill-dedup` removal + direct-`node` invocation (no more `node-hook-runner.sh`).
- Codex/migrate page: callout that Codex hooks now wire on Windows.
- Changelog: v2.20.0 entry covering all 4 shipped changes.

## Companion source PRs
- claudekit-cli #835 — Codex Windows unmask + zombie pruner
- claudekit-engineer #774 — hook wiring overhaul + drop bash runner

## Test plan
- [x] `bun run build` passes (584 pages, 0 errors, 0 broken links)

## Notes
Docs branch pairs with `dev` per docs-sync rule. Merge via GitHub web UI.