### PR TITLE
docs: sync agent teams monitoring guidance

### DIFF
--- a/src/components/FloatingChat.astro
+++ b/src/components/FloatingChat.astro
@@ -46,28 +46,31 @@ import { AIChat } from './AIChat';
     const closeBtn = document.getElementById('chat-close');
 
     if (!fab || !modal || !backdrop) return;
+    const chatFab = fab;
+    const chatModal = modal;
+    const chatBackdrop = backdrop;
 
     function openChat() {
-      modal.classList.add('open');
-      backdrop.classList.add('open');
-      fab.classList.add('open');
+      chatModal.classList.add('open');
+      chatBackdrop.classList.add('open');
+      chatFab.classList.add('open');
       document.body.style.overflow = 'hidden';
       // Focus input
       setTimeout(() => {
-        const input = modal.querySelector('.ai-input') as HTMLInputElement;
+        const input = chatModal.querySelector('.ai-input') as HTMLInputElement;
         input?.focus();
       }, 100);
     }
 
     function closeChat() {
-      modal.classList.remove('open');
-      backdrop.classList.remove('open');
-      fab.classList.remove('open');
+      chatModal.classList.remove('open');
+      chatBackdrop.classList.remove('open');
+      chatFab.classList.remove('open');
       document.body.style.overflow = '';
     }
 
-    fab.addEventListener('click', () => {
-      if (modal.classList.contains('open')) {
+    chatFab.addEventListener('click', () => {
+      if (chatModal.classList.contains('open')) {
         closeChat();
       } else {
         openChat();
@@ -75,7 +78,7 @@ import { AIChat } from './AIChat';
     });
 
     closeBtn?.addEventListener('click', closeChat);
-    backdrop.addEventListener('click', closeChat);
+    chatBackdrop.addEventListener('click', closeChat);
 
     // Keyboard: Cmd+? to open, Escape to close
     document.addEventListener('keydown', (e) => {
@@ -83,7 +86,7 @@ import { AIChat } from './AIChat';
         e.preventDefault();
         openChat();
       }
-      if (e.key === 'Escape' && modal.classList.contains('open')) {
+      if (e.key === 'Escape' && chatModal.classList.contains('open')) {
         closeChat();
       }
     });

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,6 @@
 import LanguageSwitcher from './LanguageSwitcher';
 import { KitSwitcher } from './KitSwitcher';
 import { getLangFromUrl, getLocalizedPath, useTranslations } from '../i18n/utils';
-import type { Locale } from '../i18n/locales';
 
 const currentLocale = getLangFromUrl(Astro.url);
 const currentPath = Astro.url.pathname;
@@ -126,24 +125,27 @@ const navIcons = {
     const backdrop = document.getElementById('sidebar-backdrop');
 
     if (!menuToggle || !sidebar || !backdrop) return;
+    const menuToggleButton = menuToggle;
+    const sidebarElement = sidebar;
+    const backdropElement = backdrop;
 
     // Helper function to close sidebar
     function closeSidebar() {
-      sidebar.classList.remove('open');
-      backdrop.classList.remove('visible');
+      sidebarElement.classList.remove('open');
+      backdropElement.classList.remove('visible');
       document.body.style.overflow = '';
     }
 
     // Helper function to open sidebar
     function openSidebar() {
-      sidebar.classList.add('open');
-      backdrop.classList.add('visible');
+      sidebarElement.classList.add('open');
+      backdropElement.classList.add('visible');
       document.body.style.overflow = 'hidden';
     }
 
     // Toggle sidebar on button click
     function handleToggle() {
-      const isOpen = sidebar.classList.contains('open');
+      const isOpen = sidebarElement.classList.contains('open');
       if (isOpen) {
         closeSidebar();
       } else {
@@ -158,7 +160,7 @@ const navIcons = {
 
     // Close sidebar on Escape key
     function handleEscape(e: KeyboardEvent) {
-      if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+      if (e.key === 'Escape' && sidebarElement.classList.contains('open')) {
         closeSidebar();
       }
     }
@@ -172,8 +174,8 @@ const navIcons = {
     }
 
     // Attach event listeners
-    menuToggle.addEventListener('click', handleToggle);
-    backdrop.addEventListener('click', handleBackdropClick);
+    menuToggleButton.addEventListener('click', handleToggle);
+    backdropElement.addEventListener('click', handleBackdropClick);
     document.addEventListener('keydown', handleEscape);
     mediaQuery.addEventListener('change', handleMediaChange);
 
@@ -182,8 +184,8 @@ const navIcons = {
 
     // Cleanup function for event listeners
     function cleanup() {
-      menuToggle.removeEventListener('click', handleToggle);
-      backdrop.removeEventListener('click', handleBackdropClick);
+      menuToggleButton.removeEventListener('click', handleToggle);
+      backdropElement.removeEventListener('click', handleBackdropClick);
       document.removeEventListener('keydown', handleEscape);
       mediaQuery.removeEventListener('change', handleMediaChange);
     }
@@ -203,16 +205,17 @@ const navIcons = {
     const docsLink = document.querySelector('.docs-link');
 
     if (!docsLink) return;
+    const docsAnchor = docsLink;
 
     function updateDocsLink() {
       const selectedKit = localStorage.getItem(STORAGE_KEY);
-      const engineerPath = docsLink.getAttribute('data-engineer-path');
-      const marketingPath = docsLink.getAttribute('data-marketing-path');
+      const engineerPath = docsAnchor.getAttribute('data-engineer-path');
+      const marketingPath = docsAnchor.getAttribute('data-marketing-path');
 
       if (selectedKit === 'marketing' && marketingPath) {
-        docsLink.setAttribute('href', marketingPath);
+        docsAnchor.setAttribute('href', marketingPath);
       } else if (engineerPath) {
-        docsLink.setAttribute('href', engineerPath);
+        docsAnchor.setAttribute('href', engineerPath);
       }
     }
 

--- a/src/content/docs-vi/engineer/skills/team.md
+++ b/src/content/docs-vi/engineer/skills/team.md
@@ -11,13 +11,13 @@ lang: vi
 
 # Team
 
-Engine điều phối CK-native (v2.1.0) tạo ra các phiên Claude Code độc lập làm teammates, mỗi phiên có cửa sổ context riêng, quyền sở hữu task và bộ nhớ xuyên phiên.
+Engine điều phối CK-native (v3.0) tạo ra các phiên Claude Code độc lập làm teammates, mỗi phiên có cửa sổ context riêng, quyền sở hữu task và bộ nhớ xuyên phiên. v3.0 dùng giám sát tường minh qua TaskList/message và giữ rules của teammate trong skill.
 
 ## Skill Này Làm Gì
 
-Agent Teams cho phép bạn chạy nhiều instance Claude Code song song—mỗi instance giải quyết một workstream khác nhau đồng thời. Teammates chia sẻ danh sách task và giao tiếp qua messaging. Không giống subagents (fire-and-forget), teammates là liên tục, hướng sự kiện và có khả năng thảo luận.
+Agent Teams cho phép bạn chạy nhiều instance Claude Code song song—mỗi instance giải quyết một workstream khác nhau đồng thời. Teammates chia sẻ danh sách task và giao tiếp qua messaging. Không giống subagents (fire-and-forget), teammates là liên tục và có khả năng thảo luận.
 
-Templates tự động thực thi khi spawn (thay đổi từ v2.1.0—là thủ công trong v1.x).
+Templates tự động thực thi khi spawn (thay đổi từ v2.1.0—là thủ công trong v1.x). v3.0 cập nhật Agent API và mặc định yêu cầu teammates cập nhật TaskList, rồi gửi message ngắn gọn cho lead.
 
 ## Templates
 
@@ -59,14 +59,16 @@ CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude
 # Claude Code >= 2.1.33 (được bật mặc định)
 ```
 
-## Giám Sát Hướng Sự Kiện
+## Giám Sát Tường Minh
 
-Teams kích hoạt hooks bạn có thể quan sát:
+ClaudeKit không ship custom handlers `TaskCompleted` hoặc `TeammateIdle` mặc định. Team workflow dùng trạng thái task và message tường minh:
 
-| Sự Kiện | Khi Nào | Dùng Cho |
-|-------|------|---------|
-| `TaskCompleted` | Teammate hoàn thành task | Theo dõi tiến trình, kích hoạt dependents |
-| `TeammateIdle` | Teammate không có task đang chờ | Phân công lại công việc, kết thúc |
+1. Teammates gọi `TaskUpdate` khi bắt đầu, bị block, hoặc hoàn thành việc
+2. Teammates gửi message ngắn gọn khi hoàn thành hoặc bị block cho lead
+3. Lead kiểm tra `TaskList` trước khi tổng hợp, phân công lại, spawn tester, hoặc shutdown
+4. Idle nghĩa là teammate đang chờ; không phải tín hiệu hoàn thành
+
+Claude Code có platform events như `TaskCompleted` và `TeammateIdle`, nhưng ClaudeKit không bật handler automation mặc định cho đến khi project tự thêm và validate handler riêng.
 
 ## Bộ Nhớ Agent
 

--- a/src/content/docs/engineer/configuration/hooks.md
+++ b/src/content/docs/engineer/configuration/hooks.md
@@ -32,6 +32,8 @@ Hooks are configured in `.claude/settings.json` and execute shell commands in re
 | `Stop` | When Claude session ends |
 | `SubagentStop` | When a subagent completes |
 
+ClaudeKit does not register default handlers for `TaskCompleted` or `TeammateIdle`. `/ck:team` monitors `TaskList` and teammate messages explicitly.
+
 ## Configuration
 
 Hooks are defined in `.claude/settings.json`. Since v2.20.0, hook commands invoke `node` directly — the `node-hook-runner.sh` bash wrapper has been removed. If you have an older install, `ck init` auto-repairs legacy bash-runner commands to the direct form.
@@ -171,6 +173,8 @@ ClaudeKit Engineer ships with hooks organized by event type. All default hook fi
 |-----------|-----------|-------|
 | `skill-dedup.cjs` | v2.20.0 | Deprecated since v2.9.1; deduplication now handled by CLI install logic |
 | `node-hook-runner.sh` | v2.20.0 | Bash wrapper removed; hooks now invoke `node` directly. `ck init` auto-repairs legacy entries |
+| `task-completed-handler.cjs` | Agent Teams v3.0 cleanup | Removed from ClaudeKit defaults; use explicit TaskList/message monitoring |
+| `teammate-idle-handler.cjs` | Agent Teams v3.0 cleanup | Removed from ClaudeKit defaults; idle is not a completion signal |
 
 **Example: enabling opt-in hooks**
 
@@ -340,28 +344,11 @@ Zombie hook entries (entries referencing missing files such as old `node-hook-ru
 
 ---
 
-### task-completed-handler.cjs
+### Retired Agent Teams handlers
 
-**Event:** `TaskCompleted`
+ClaudeKit no longer ships `task-completed-handler.cjs` or `teammate-idle-handler.cjs`. If an older install still references those files, `ck init` removes the stale entries during upgrade cleanup.
 
-**Purpose:** Logs task completions to `.claude/logs/tasks.log`. In Agent Team mode, injects progress summary for the lead agent.
-
-**What it does:**
-- Appends task ID, subject, completion time, and owner to the task log
-- If `CK_TEAM_MODE=1`: formats a progress summary showing completed vs total tasks and injects it into lead's context
-
----
-
-### teammate-idle-handler.cjs
-
-**Event:** `TeammateIdle`
-
-**Purpose:** When an Agent Team member goes idle (waiting for input), injects available unblocked task context so they can claim the next task without waiting for a message.
-
-**What it does:**
-- Reads `TaskList` for unblocked pending tasks
-- Formats task summary and injects it as context
-- Prevents teammates from staying idle when work is available
+For `/ck:team`, teammates mark progress with `TaskUpdate`, send concise completion or blocked messages, and the lead checks `TaskList` before synthesis, reassignment, tester spawn, or shutdown.
 
 ---
 

--- a/src/content/docs/engineer/skills/team.md
+++ b/src/content/docs/engineer/skills/team.md
@@ -10,13 +10,13 @@ published: true
 
 # Team
 
-CK-native orchestration engine (v3.0) that spawns independent Claude Code sessions as teammates, each with their own context window, task ownership, and cross-session memory. Updated to current Claude Code Agent API with improved event-driven hooks and teammate coordination.
+CK-native orchestration engine (v3.0) that spawns independent Claude Code sessions as teammates, each with their own context window, task ownership, and cross-session memory. Updated to current Claude Code Agent API with explicit TaskList/message monitoring and skill-local teammate rules.
 
 ## What This Skill Does
 
-Agent Teams lets you run multiple Claude Code instances in parallel—each tackling a different workstream simultaneously. Teammates share a task list and communicate via messaging. Unlike subagents (fire-and-forget), teammates are persistent, event-driven, and capable of discussion.
+Agent Teams lets you run multiple Claude Code instances in parallel—each tackling a different workstream simultaneously. Teammates share a task list and communicate via messaging. Unlike subagents (fire-and-forget), teammates are persistent and capable of discussion.
 
-Templates auto-execute on spawn (v2.1.0+). v3.0 updates the underlying Agent API integration and adds improved cross-teammate event coordination.
+Templates auto-execute on spawn (v2.1.0+). v3.0 updates the underlying Agent API integration and keeps monitoring explicit by default: teammates update TaskList and send concise messages to the lead.
 
 ## Templates
 
@@ -58,14 +58,16 @@ CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude
 # Claude Code >= 2.1.33 (enabled by default)
 ```
 
-## Event-Driven Monitoring
+## Explicit Monitoring
 
-Teams fire hooks you can observe:
+ClaudeKit does not ship custom `TaskCompleted` or `TeammateIdle` handlers by default. Team workflows use explicit task state and messages:
 
-| Event | When | Use For |
-|-------|------|---------|
-| `TaskCompleted` | Teammate finishes a task | Progress tracking, triggering dependents |
-| `TeammateIdle` | Teammate has no pending tasks | Reassign work, wind down |
+1. Teammates call `TaskUpdate` when they start, block, or complete work
+2. Teammates send concise completion or blocked messages to the lead
+3. The lead checks `TaskList` before synthesis, reassignment, tester spawn, or shutdown
+4. Idle means a teammate is waiting; it is not a completion signal
+
+Claude Code exposes platform events such as `TaskCompleted` and `TeammateIdle`, but ClaudeKit keeps handler automation out of the default install until a project deliberately adds and validates its own handlers.
 
 ## Agent Memory
 


### PR DESCRIPTION
## Summary
- Update public `/ck:team` docs in English and Vietnamese to describe explicit TaskList/message monitoring instead of default event-driven hook automation.
- Move the retired Agent Teams handler filenames into the removed-hooks guidance.
- Clarify that `TaskCompleted` and `TeammateIdle` remain Claude Code platform events, but ClaudeKit does not register default handlers for them.
- Add minimal null guards in existing UI scripts so the required `astro check` gate passes.

## Validation
- `bunx astro check`
- `bun test tests/`
- `bun run check:syntax` (warn-only; reports pre-existing unrelated colon-syntax warnings)
- `bun run build`
- `bun run check:sitemap`
- `git diff --check`

Supports claudekit-engineer#806.