### PR TITLE
docs: document Antigravity 2 migrate paths

### DIFF
--- a/src/content/docs-vi/cli/migrate.md
+++ b/src/content/docs-vi/cli/migrate.md
@@ -41,7 +41,7 @@ Lệnh `ck migrate`:
 6. **Gộp** cấu hình hooks vào `settings.json` của provider
 7. **Dọn dẹp** registry cũ và đường dẫn deprecated
 
-> **Antigravity 2.0:** skills và agents đã migrate được ghi vào `.agents/skills/<name>/SKILL.md`, rules ghi vào `.agents/rules/`, commands ghi vào `.agents/workflows/`, và skills global ghi vào `~/.gemini/config/skills/`. Agents của ClaudeKit sẽ hiển thị trong Antigravity như skills.
+> **Antigravity 2.0:** agents project được gộp vào `.agents/agents.md`, skills project ghi vào `.agents/skills/<name>/SKILL.md`, rules ghi vào `.agents/rules/`, commands ghi vào `.agents/workflows/`, và skills global ghi vào `~/.gemini/config/skills/`. Chưa có đường dẫn `agents.md` global đã được xác minh.
 
 ## Provider Được Hỗ Trợ
 

--- a/src/content/docs-vi/cli/migrate.md
+++ b/src/content/docs-vi/cli/migrate.md
@@ -41,6 +41,8 @@ Lệnh `ck migrate`:
 6. **Gộp** cấu hình hooks vào `settings.json` của provider
 7. **Dọn dẹp** registry cũ và đường dẫn deprecated
 
+> **Antigravity 2.0:** skills và agents đã migrate được ghi vào `.agents/skills/<name>/SKILL.md`, rules ghi vào `.agents/rules/`, commands ghi vào `.agents/workflows/`, và skills global ghi vào `~/.gemini/config/skills/`. Agents của ClaudeKit sẽ hiển thị trong Antigravity như skills.
+
 ## Provider Được Hỗ Trợ
 
 Mỗi cột cho biết mức độ `ck migrate` có thể chuyển loại nội dung đó sang provider đích:
@@ -63,7 +65,7 @@ Mỗi cột cho biết mức độ `ck migrate` có thể chuyển loại nội 
 | Goose | Một phần | - | Co | Co | Co | - |
 | Gemini CLI | Một phần | Co | Co | Co | Co | - |
 | Amp | Một phần | - | Co | Co | Co | - |
-| Antigravity | - | Co | Co | Co | Co | - |
+| Antigravity | Co | Co | Co | Co | Co | - |
 | Cline | Một phần | - | Co | Co | Co | - |
 | OpenHands | Một phần | - | Co | Co | Co | - |
 

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -57,7 +57,7 @@ After execution, the command ends with a boxed footer:
 - **Default scope**: project-level
 - **Global scope**: pass `-g` or `--global`
 - **Provider quirks still apply**: for example, Codex commands migrate as skills, so project scope writes `.agents/skills/source-command-*/SKILL.md` and global scope writes `~/.agents/skills/source-command-*/SKILL.md`
-- **Antigravity 2.0 paths**: project skills and migrated agents write to `.agents/skills/<name>/SKILL.md`, project rules write to `.agents/rules/`, project commands write to `.agents/workflows/`, and global skills write to `~/.gemini/config/skills/`
+- **Antigravity 2.0 paths**: project agents merge into `.agents/agents.md`, project skills write to `.agents/skills/<name>/SKILL.md`, project rules write to `.agents/rules/`, project commands write to `.agents/workflows/`, and global skills write to `~/.gemini/config/skills/`
 
 If you are migrating in older Windows terminals, set `CK_FORCE_ASCII=1` to force the ASCII fallback border set.
 
@@ -105,7 +105,7 @@ Each column indicates how well `ck migrate` can transfer that content type to th
 | Cline | Partial | - | Yes | Yes | Yes | - |
 | OpenHands | Partial | - | Yes | Yes | Yes | - |
 
-Antigravity agents migrate as Antigravity 2.0 skills, so they appear under the provider's skills surface rather than a separate custom-agent directory.
+Antigravity agents migrate into `.agents/agents.md`, Antigravity 2.0's project agents/personas file. Global Antigravity skills are supported, but no verified global `agents.md` path is documented.
 
 ## Options
 

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -57,6 +57,7 @@ After execution, the command ends with a boxed footer:
 - **Default scope**: project-level
 - **Global scope**: pass `-g` or `--global`
 - **Provider quirks still apply**: for example, Codex commands migrate as skills, so project scope writes `.agents/skills/source-command-*/SKILL.md` and global scope writes `~/.agents/skills/source-command-*/SKILL.md`
+- **Antigravity 2.0 paths**: project skills and migrated agents write to `.agents/skills/<name>/SKILL.md`, project rules write to `.agents/rules/`, project commands write to `.agents/workflows/`, and global skills write to `~/.gemini/config/skills/`
 
 If you are migrating in older Windows terminals, set `CK_FORCE_ASCII=1` to force the ASCII fallback border set.
 
@@ -100,9 +101,11 @@ Each column indicates how well `ck migrate` can transfer that content type to th
 | Goose | Partial | - | Yes | Yes | Yes | - |
 | Gemini CLI | Partial | Yes | Yes | Yes | Yes | - |
 | Amp | Partial | - | Yes | Yes | Yes | - |
-| Antigravity | - | Yes | Yes | Yes | Yes | - |
+| Antigravity | Yes | Yes | Yes | Yes | Yes | - |
 | Cline | Partial | - | Yes | Yes | Yes | - |
 | OpenHands | Partial | - | Yes | Yes | Yes | - |
+
+Antigravity agents migrate as Antigravity 2.0 skills, so they appear under the provider's skills surface rather than a separate custom-agent directory.
 
 ## Options
 


### PR DESCRIPTION
Follows mrgoonie/claudekit-cli#890.

## Summary
- Document the Antigravity 2.0 migration layout: agents merge into `.agents/agents.md`, skills install to `.agents/skills/<name>/SKILL.md`, rules install to `.agents/rules`, workflows install to `.agents/workflows`, and global skills install to `~/.gemini/config/skills`.
- Update the `ck migrate` support matrix so Antigravity agents are accurately listed as supported through Antigravity's agents file, not as migrated skills.
- Mirror the path guidance and support matrix correction in Vietnamese docs.

## Validation
- `bun run build`
- `bun run test`
- `bun run check:syntax` (warn mode; existing unrelated colon-syntax warnings only)