### PR TITLE
docs: note settings.json hook/MCP cleanup in ck uninstall

### DIFF
--- a/src/content/docs-vi/cli/uninstall.md
+++ b/src/content/docs-vi/cli/uninstall.md
@@ -38,8 +38,11 @@ Lệnh `ck uninstall`:
 3. Phân tích tệp bằng cách theo dõi quyền sở hữu
 4. Hiển thị xem trước các tệp sẽ xóa và bảo toàn
 5. Xóa các tệp thuộc quyền sở hữu của ClaudeKit
-6. Bảo toàn các tùy chỉnh và cấu hình của người dùng
-7. Dọn dẹp các thư mục trống
+6. Xóa các đăng ký hook và MCP mà nó đã thêm vào `settings.json` và dọn dẹp dữ liệu theo dõi trong `.ck.json`
+7. Bảo toàn các tùy chỉnh và cấu hình của người dùng
+8. Dọn dẹp các thư mục trống
+
+Các hook do bạn tự viết hoặc tự chỉnh sửa sẽ được giữ nguyên, và khi gỡ một kit khỏi cài đặt nhiều kit, các đăng ký vẫn còn được kit còn lại sử dụng sẽ được giữ lại.
 
 ## Cú Pháp
 

--- a/src/content/docs/cli/uninstall.md
+++ b/src/content/docs/cli/uninstall.md
@@ -38,8 +38,11 @@ The `ck uninstall` command:
 4. Shows preview of files to delete and preserve
 5. Creates a scoped recovery backup under `~/.claudekit/backups/`
 6. Removes ClaudeKit-owned files
-6. Preserves user customizations and configurations
-7. Cleans up empty directories
+7. Removes the hook and MCP registrations it added to `settings.json` and clears its `.ck.json` tracking
+8. Preserves user customizations and configurations
+9. Cleans up empty directories
+
+Hook entries you authored or edited yourself are left untouched, and when a single kit is removed from a multi-kit install, registrations still used by the remaining kit are kept.
 
 ## Syntax
 


### PR DESCRIPTION
## Summary

`ck uninstall` now reverses the `settings.json` mutations install made: it
removes the hook and MCP registrations it added and clears its `.ck.json`
tracking. This documents that behavior.

- `cli/uninstall.md` (EN) and `cli-vi`/`docs-vi/cli/uninstall.md` (VI): add the
  settings.json cleanup step to "What It Does" and a note that user-authored
  entries and shared remaining-kit registrations are preserved.
- Fixes a duplicate list-number (`6.` twice) in the EN page.

Pairs with claudekit-cli#899 (target `dev`).

## Validation

- [x] `bun run build` passes (link validator + Pagefind index)
