### PR TITLE
docs: migrate gemini cli references to antigravity (agy)

### DIFF
--- a/src/content/docs-vi/cli/migrate.md
+++ b/src/content/docs-vi/cli/migrate.md
@@ -69,6 +69,8 @@ Mỗi cột cho biết mức độ `ck migrate` có thể chuyển loại nội 
 | Cline | Một phần | - | Co | Co | Co | - |
 | OpenHands | Một phần | - | Co | Co | Co | - |
 
+> **Lưu ý về dòng Gemini CLI:** Google đã ngừng cung cấp Gemini CLI độc lập vào 2026-06-18. Kế nhiệm của nó là Antigravity CLI (`agy`), được liệt kê ở dòng riêng phía trên. Dòng Gemini CLI vẫn giữ để `ck migrate` có thể chuyển config sang bố cục Gemini CLI hiện có.
+
 ## Tùy Chọn
 
 ### Tùy Chọn Target

--- a/src/content/docs-vi/cli/new.md
+++ b/src/content/docs-vi/cli/new.md
@@ -53,7 +53,7 @@ ck new [OPTIONS]
 | `--exclude <pattern>` | Loại trừ các tệp khớp với mẫu glob (có thể lặp lại) | Không có |
 | `--prefix` | Chuyển các lệnh sang không gian tên `/ck:` | `false` |
 | `--opencode` | Cài đặt gói OpenCode trên toàn cầu | `false` |
-| `--gemini` | Cài đặt Gemini CLI và thiết lập tích hợp MCP | `false` |
+| `--gemini` | Cài đặt Antigravity (agy) CLI và thiết lập tích hợp MCP | `false` |
 | `--install-skills` | Tự động cài đặt các phụ thuộc của kỹ năng | `false` |
 | `--docs-dir <name>` | Tên tùy chỉnh cho thư mục tài liệu | `docs` |
 | `--plans-dir <name>` | Tên tùy chỉnh cho thư mục kế hoạch | `plans` |

--- a/src/content/docs-vi/engineer/agents/scout.md
+++ b/src/content/docs-vi/engineer/agents/scout.md
@@ -1,6 +1,6 @@
 ---
 title: Agent Scout
-description: Nhanh chóng định vị các tệp liên quan trong các kho mã nguồn lớn bằng cách sử dụng tìm kiếm agent song song với Gemini và OpenCode
+description: Nhanh chóng định vị các tệp liên quan trong các kho mã nguồn lớn bằng cách sử dụng tìm kiếm agent song song với Antigravity (agy) và OpenCode
 section: engineer
 kit: engineer
 category: agents
@@ -11,12 +11,12 @@ lang: vi
 
 # Agent Scout
 
-Agent scout nhanh chóng định vị các tệp liên quan trong các kho mã nguồn lớn bằng cách điều phối nhiều agent AI bên ngoài (Gemini, OpenCode) chạy song song, cung cấp danh sách tệp có thể thực hiện được trong vòng chưa đầy 5 phút.
+Agent scout nhanh chóng định vị các tệp liên quan trong các kho mã nguồn lớn bằng cách điều phối nhiều agent AI bên ngoài (Antigravity agy, OpenCode) chạy song song, cung cấp danh sách tệp có thể thực hiện được trong vòng chưa đầy 5 phút.
 
 ## Scout làm gì?
 
 - Nhanh chóng định vị các tệp liên quan trong các kho mã nguồn ở mọi quy mô.
-- Điều phối song song nhiều agent AI bên ngoài (Gemini, OpenCode).
+- Điều phối song song nhiều agent AI bên ngoài (Antigravity agy, OpenCode).
 - Chia nhỏ mã nguồn thành các phần logic để tìm kiếm hiệu quả.
 - Tổng hợp các phát hiện từ nhiều agent thành các danh sách tệp có tổ chức.
 - Xử lý các trường hợp hết thời gian chờ (timeout) một cách khéo léo mà không cần khởi động lại.
@@ -49,7 +49,7 @@ Sử dụng scout khi:
 ## Cách thức hoạt động
 
 ### Bước 1: Quyết định quy mô (Scale)
-Scout xác định số lượng agent cần kích hoạt dựa trên tham số scale (ví dụ: scale <= 3 dùng Gemini, scale > 3 dùng kết hợp Gemini + OpenCode).
+Scout xác định số lượng agent cần kích hoạt dựa trên tham số scale (ví dụ: scale <= 3 dùng agy, scale > 3 dùng kết hợp agy + OpenCode).
 
 ### Bước 2: Chia nhỏ mã nguồn
 Scout chia mã nguồn thành các phần logic như `/src/auth/`, `/src/middleware/`, `/src/api/`, v.v., để các agent tìm kiếm song song.

--- a/src/content/docs-vi/engineer/configuration/mcp-setup.md
+++ b/src/content/docs-vi/engineer/configuration/mcp-setup.md
@@ -75,7 +75,7 @@ Kết quả: context chính vẫn sạch nhưng bạn vẫn khai thác trọn v�
 
 ### Tối ưu nâng cao
 
-Ngay cả khi cô lập bằng subagent, việc duyệt quá nhiều công cụ MCP vẫn tốn token. Để giảm chi phí, ClaudeKit có thể chuyển phần orchestration nặng nề sang **gemini-cli**, tận dụng một runtime rẻ hơn mà vẫn giữ cuộc trò chuyện chính tập trung.
+Ngay cả khi cô lập bằng subagent, việc duyệt quá nhiều công cụ MCP vẫn tốn token. Để giảm chi phí, ClaudeKit có thể chuyển phần orchestration nặng nề sang **Antigravity (agy) CLI**, tận dụng một runtime rẻ hơn mà vẫn giữ cuộc trò chuyện chính tập trung.
 
 ---
 

--- a/src/content/docs-vi/engineer/skills/ai-multimodal.md
+++ b/src/content/docs-vi/engineer/skills/ai-multimodal.md
@@ -88,10 +88,10 @@ python scripts/gemini_batch_process.py --files screenshot.png --task analyze --p
 python scripts/gemini_batch_process.py --files img1.jpg img2.jpg --task analyze
 ```
 
-Nếu bạn đã cài `gemini` CLI, có shortcut nhanh hơn:
+Nếu bạn đã cài `agy` (Antigravity) CLI, có shortcut nhanh hơn:
 
 ```bash
-cat image.png | gemini -y -m gemini-2.5-flash
+cat image.png | agy --dangerously-skip-permissions --model gemini-2.5-flash -p
 ```
 
 Gemini xuất sắc ở object detection, OCR từ screenshots, design extraction, visual Q&A và xử lý nhiều images để so sánh.

--- a/src/content/docs-vi/engineer/skills/research.md
+++ b/src/content/docs-vi/engineer/skills/research.md
@@ -39,7 +39,7 @@ Luôn dùng khi:
 Xác định: Quyết định nào cần nghiên cứu này? Sự thật nào sẽ thay đổi kết quả? Đặt ranh giới (độ sâu, độ mới, nguồn). Ví dụ: "Thư viện auth nào cho Next.js?" → Tiêu chí: được duy trì, lịch sử bảo mật, hỗ trợ TypeScript, <50kb.
 
 ### 2. Tìm Kiếm Có Hệ Thống (Tối Đa 5)
-**Ưu tiên**: `gemini -m gemini-2.5-flash -p "your prompt"` (nếu có)
+**Ưu tiên**: `agy --model gemini-2.5-flash -p "your prompt"` (nếu có)
 **Dự phòng**: Công cụ `WebSearch`
 
 **Fan-out truy vấn** trên:

--- a/src/content/docs-vi/engineer/skills/scout.md
+++ b/src/content/docs-vi/engineer/skills/scout.md
@@ -30,14 +30,14 @@ Hãy nghĩ đây như nhiệm vụ trinh sát trước khi thực hiện tính n
 
 - Khám phá file dựa trên agent song song
 - Khám phá codebase tiết kiệm token
-- Tích hợp sẵn khám phá song song hoặc công cụ bên ngoài (Gemini/OpenCode CLI)
+- Tích hợp sẵn khám phá song song hoặc công cụ bên ngoài (Antigravity agy/OpenCode CLI)
 - Mở rộng linh hoạt dựa trên quy mô codebase
 - Báo cáo ngắn gọn với các câu hỏi chưa giải quyết
 
 ## Đối Số
 
 - **Mặc định**: Scout dùng khám phá song song tích hợp sẵn
-- **ext**: Scout dùng công cụ Gemini/OpenCode CLI bên ngoài song song
+- **ext**: Scout dùng công cụ Antigravity (agy)/OpenCode CLI bên ngoài song song
 
 ## Bắt Đầu Nhanh
 

--- a/src/content/docs-vi/marketing/agents/mcp-manager.md
+++ b/src/content/docs-vi/marketing/agents/mcp-manager.md
@@ -17,7 +17,7 @@ Bạn muốn tự động chụp ảnh màn hình, truy cập dữ liệu Google
 
 **Vấn đề**: Các workflow marketing hiện đại phụ thuộc vào nhiều dịch vụ bên ngoài—nền tảng phân tích, công cụ thiết kế, tự động hóa trình duyệt, API. Tích hợp từng dịch vụ có nghĩa là học SDK của nó, xử lý xác thực và viết code tùy chỉnh.
 
-**Giải pháp**: MCP Manager Agent xử lý tất cả các tích hợp server Model Context Protocol (MCP). Nó khám phá các tool có sẵn, thực thi chúng hiệu quả qua Gemini CLI hoặc script trực tiếp, và trả về kết quả gọn gàng. Bạn truy cập các dịch vụ bên ngoài mạnh mẽ với các lệnh đơn giản.
+**Giải pháp**: MCP Manager Agent xử lý tất cả các tích hợp server Model Context Protocol (MCP). Nó khám phá các tool có sẵn, thực thi chúng hiệu quả qua Antigravity (agy) CLI hoặc script trực tiếp, và trả về kết quả gọn gàng. Bạn truy cập các dịch vụ bên ngoài mạnh mẽ với các lệnh đơn giản.
 
 ## Bắt Đầu Nhanh
 
@@ -28,7 +28,7 @@ Thực thi MCP tools qua manager:
 /mcp "Take screenshot of claudekit.cc homepage"
 ```
 
-Manager xử lý việc khám phá tool, thực thi qua phương pháp tối ưu (Gemini CLI trước, script dự phòng), và trả về kết quả.
+Manager xử lý việc khám phá tool, thực thi qua phương pháp tối ưu (Antigravity agy CLI trước, script dự phòng), và trả về kết quả.
 
 ## Khả Năng
 
@@ -42,7 +42,7 @@ Khám phá và quản lý các dịch vụ tích hợp:
 
 ### Chiến Lược Thực Thi Thông Minh
 Chọn phương pháp thực thi tối ưu:
-- **Chính**: Gemini CLI (nhanh nhất, cửa sổ context 2M)
+- **Chính**: Antigravity (agy) CLI (nhanh nhất, cửa sổ context 2M)
 - **Phụ**: Script TypeScript trực tiếp
 - **Dự phòng**: Báo cáo lỗi với hướng dẫn
 - Tự động chuyển đổi dự phòng giữa các phương pháp
@@ -83,11 +83,11 @@ Sử dụng MCP Manager Agent khi bạn cần:
 ```
 
 **Manager sẽ**:
-1. Kiểm tra Gemini CLI có sẵn không
+1. Kiểm tra Antigravity (agy) CLI có sẵn không
 2. Thiết lập symlink MCP server nếu cần
-3. Thực thi qua Gemini: `gemini -y -m gemini-2.5-flash -p "Take screenshot of https://claudekit.cc/docs"`
+3. Thực thi qua agy: `agy --dangerously-skip-permissions --model gemini-2.5-flash -p "Take screenshot of https://claudekit.cc/docs"`
 4. Trả về đường dẫn file ảnh màn hình
-5. Nếu Gemini không khả dụng, chuyển sang thực thi script trực tiếp
+5. Nếu agy không khả dụng, chuyển sang thực thi script trực tiếp
 
 ### Dữ Liệu Google Analytics
 
@@ -117,18 +117,18 @@ Data from: google-analytics MCP server
 
 ## Phương Pháp Thực Thi
 
-### Phương Pháp 1: Gemini CLI (Chính)
+### Phương Pháp 1: Antigravity (agy) CLI (Chính)
 
 Nhanh nhất và nhận thức context tốt nhất:
 ```bash
 # Kiểm tra tính khả dụng
-command -v gemini >/dev/null 2>&1
+command -v agy >/dev/null 2>&1
 
-# Thiết lập symlink config MCP
-mkdir -p .gemini && ln -sf .claude/.mcp.json .gemini/settings.json
+# Thiết lập symlink config MCP (agy đọc file global ~/.gemini/config/mcp_config.json)
+mkdir -p ~/.gemini/config && ln -sf "$(pwd)/.claude/.mcp.json" ~/.gemini/config/mcp_config.json
 
 # Thực thi tác vụ
-gemini -y -m gemini-2.5-flash -p "Take screenshot of example.com"
+agy --dangerously-skip-permissions --model gemini-2.5-flash -p "Take screenshot of example.com"
 ```
 
 **Ưu điểm**:
@@ -139,7 +139,7 @@ gemini -y -m gemini-2.5-flash -p "Take screenshot of example.com"
 
 ### Phương Pháp 2: Script Trực Tiếp (Dự Phòng)
 
-Khi Gemini không khả dụng:
+Khi agy không khả dụng:
 ```bash
 npx tsx .claude/skills/mcp-management/scripts/cli.ts call-tool \
   <server-name> <tool-name> '<json-args>'
@@ -195,7 +195,7 @@ Thêm bất kỳ server tuân thủ MCP vào `.claude/.mcp.json`
 ## Hiệu Suất
 
 Thực thi được tối ưu:
-- Gemini CLI: ~2-5 giây cho tác vụ đơn giản
+- Antigravity (agy) CLI: ~2-5 giây cho tác vụ đơn giản
 - Script trực tiếp: ~3-8 giây cho cùng tác vụ
 - Tự động chuyển dự phòng thêm dưới 1 giây overhead
 - Kết quả được cache khi phù hợp
@@ -213,9 +213,9 @@ Thực thi được tối ưu:
 
 ## Mẹo
 
-**Ưu Tiên Gemini CLI**: Nếu cả hai đều có sẵn, Gemini CLI nhanh hơn và linh hoạt hơn. Cài đặt Gemini CLI để có trải nghiệm tốt nhất.
+**Ưu Tiên Antigravity (agy) CLI**: Nếu cả hai đều có sẵn, Antigravity (agy) CLI nhanh hơn và linh hoạt hơn. Cài đặt nó để có trải nghiệm tốt nhất.
 
-**Tác Vụ Ngôn Ngữ Tự Nhiên**: Với Gemini CLI, mô tả tác vụ một cách tự nhiên: "Take screenshot and resize to 1200px wide" hoạt động tốt hơn việc chuỗi tool thủ công.
+**Tác Vụ Ngôn Ngữ Tự Nhiên**: Với Antigravity (agy) CLI, mô tả tác vụ một cách tự nhiên: "Take screenshot and resize to 1200px wide" hoạt động tốt hơn việc chuỗi tool thủ công.
 
 **Kiểm Tra Tính Khả Dụng**: Chạy `/tools` để xem tất cả MCP tool có sẵn trên các server đã cấu hình.
 
@@ -223,13 +223,13 @@ Thực thi được tối ưu:
 
 ## Khắc Phục Sự Cố
 
-**Không tìm thấy Gemini CLI**:
+**Không tìm thấy Antigravity (agy) CLI**:
 ```bash
-# Cài đặt Gemini CLI
-npm install -g @anthropic-ai/gemini-cli
+# Cài đặt Antigravity (agy) CLI (macOS/Linux)
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 # Xác minh cài đặt
-gemini --version
+agy --version
 ```
 
 **MCP server không phản hồi**:

--- a/src/content/docs-vi/marketing/agents/scout-external.md
+++ b/src/content/docs-vi/marketing/agents/scout-external.md
@@ -9,7 +9,7 @@ order: 7
 
 # Scout External Agent
 
-> **Your AI-powered explorer** - Harnesses Gemini and other AI tools for deep codebase analysis
+> **Your AI-powered explorer** - Harnesses the Antigravity (agy) CLI and other AI tools for deep codebase analysis
 
 ## What This Agent Does
 
@@ -17,7 +17,7 @@ Bạn đang làm việc với một monorepo khổng lồ với hàng trăm thư
 
 **The Problem**: Các cơ sở mã lớn, phức tạp cần tìm kiếm song song, thông minh trên nhiều thư mục. Khớp mẫu đơn giản không đủ - bạn cần AI hiểu ngữ nghĩa mã và các mối quan hệ.
 
-**The Solution**: Scout External điều phối nhiều trợ lý AI viết mã (Gemini, OpenCode) để tìm kiếm các phần khác nhau của cơ sở mã của bạn đồng thời. Nó ủy quyền các tìm kiếm phức tạp cho các công cụ AI có cửa sổ ngữ cảnh khổng lồ, sau đó tổng hợp kết quả thành các danh sách tệp có hành động.
+**The Solution**: Scout External điều phối nhiều trợ lý AI viết mã (Antigravity agy, OpenCode) để tìm kiếm các phần khác nhau của cơ sở mã của bạn đồng thời. Nó ủy quyền các tìm kiếm phức tạp cho các công cụ AI có cửa sổ ngữ cảnh khổng lồ, sau đó tổng hợp kết quả thành các danh sách tệp có hành động.
 
 ## Quick Start
 
@@ -34,7 +34,7 @@ Nhiều công cụ AI tìm kiếm song song, hiểu ngữ nghĩa mã để tìm 
 
 ### AI-Powered Search Orchestration
 Phối hợp nhiều trợ lý AI:
-- Ủy quyền các khu vực tìm kiếm cho Gemini Flash 2.5 (ngữ cảnh 2M)
+- Ủy quyền các khu vực tìm kiếm cho Antigravity (agy) CLI chạy Gemini Flash 2.5 (ngữ cảnh 2M)
 - Sử dụng OpenCode để phân tích mã chuyên biệt
 - Chạy tìm kiếm song song để tăng tốc độ
 - Kết hợp kết quả từ nhiều công cụ
@@ -117,7 +117,7 @@ Sử dụng Scout External khi:
 ### Small Scale (2-3 agents)
 Cho các tìm kiếm tập trung:
 ```bash
-# Uses only Gemini
+# Uses only the Antigravity (agy) CLI
 Agent 1: Search lib/ for payment utilities
 Agent 2: Search app/api/ for payment routes
 Agent 3: Search db/ for payment schemas
@@ -126,19 +126,19 @@ Agent 3: Search db/ for payment schemas
 ### Large Scale (4-5 agents)
 Cho các tìm kiếm toàn diện:
 ```bash
-# Uses Gemini + OpenCode for diversity
-Agent 1 (Gemini): Frontend payment UI
-Agent 2 (Gemini): Backend payment logic
+# Uses agy + OpenCode for diversity
+Agent 1 (agy): Frontend payment UI
+Agent 2 (agy): Backend payment logic
 Agent 3 (OpenCode): Database and migrations
-Agent 4 (Gemini): Webhook handlers
+Agent 4 (agy): Webhook handlers
 Agent 5 (OpenCode): Configuration and tests
 ```
 
 ## AI Tool Commands
 
-**Gemini Flash 2.5** (primary):
+**Antigravity (agy) CLI** (primary, runs Gemini Flash 2.5):
 ```bash
-gemini -y -p "Search app/ for email-related files. Return file paths only." --model gemini-2.5-flash
+agy --dangerously-skip-permissions -p "Search app/ for email-related files. Return file paths only." --model gemini-2.5-flash
 ```
 
 **OpenCode** (secondary):
@@ -186,7 +186,7 @@ opencode run "Search db/ for schema files. Return file paths only." --model open
 
 **Describe Functionality**: Thay vì "tìm tệp với 'stripe' trong chúng", hãy nói "tìm xử lý thanh toán và tệp webhook". AI hiểu ý định.
 
-**Trust Semantic Search**: AI có thể gợi ý các tệp bạn không mong đợi. Nếu Gemini nghĩ một tệp có liên quan, nó có thể - ngay cả khi cách đặt tên không khớp.
+**Trust Semantic Search**: AI có thể gợi ý các tệp bạn không mong đợi. Nếu agy nghĩ một tệp có liên quan, nó có thể, ngay cả khi cách đặt tên không khớp.
 
 **Check Timeouts**: Nếu một agent hết thời gian, kết quả sẽ ghi chú khoảng trống. Bạn có thể chạy lại hoặc tìm kiếm phần đó theo cách thủ công.
 
@@ -195,12 +195,12 @@ opencode run "Search db/ for schema files. Return file paths only." --model open
 ```
 AI-Powered Search Results (5 agents, 4.2 minutes):
 
-Frontend Payment UI (Agent 1 - Gemini):
+Frontend Payment UI (Agent 1 - agy):
 - app/checkout/page.tsx - Checkout page with Stripe Elements
 - components/PaymentForm.tsx - Payment form component
 - components/PaymentMethod.tsx - Payment method selector
 
-Backend Payment Logic (Agent 2 - Gemini):
+Backend Payment Logic (Agent 2 - agy):
 - lib/stripe/client.ts - Stripe API client
 - lib/sepay/client.ts - SePay API client
 - api/checkout/route.ts - Checkout API endpoint
@@ -211,7 +211,7 @@ Database & Schemas (Agent 3 - OpenCode):
 - db/schema/transactions.ts - Transaction logs
 - db/migrations/001_add_payments.sql - Payment tables migration
 
-Webhooks (Agent 4 - Gemini):
+Webhooks (Agent 4 - agy):
 - api/webhooks/stripe/route.ts - Stripe webhook handler
 - api/webhooks/sepay/route.ts - SePay webhook handler
 - lib/webhooks/verify.ts - Webhook signature verification

--- a/src/content/docs-vi/marketing/skills/research.md
+++ b/src/content/docs-vi/marketing/skills/research.md
@@ -39,7 +39,7 @@ Kết hợp tìm kiếm web, phân tích tài liệu và khám phá kho GitHub.
 5. **Xác nhận chéo**: Xác minh qua 3+ nguồn độc lập
 
 **Ưu tiên tìm kiếm**:
-- Kiểm tra xem lệnh `gemini` bash có sẵn không → dùng cho nghiên cứu (timeout 10 phút)
+- Kiểm tra xem lệnh `agy` (Antigravity) bash có sẵn không → dùng cho nghiên cứu (`--print-timeout 600s`)
 - Dự phòng sang công cụ `WebSearch` nếu cần
 - Chạy tối đa 5 truy vấn nghiên cứu song song
 

--- a/src/content/docs-vi/workflows/gemini.md
+++ b/src/content/docs-vi/workflows/gemini.md
@@ -46,13 +46,15 @@ Hãy nhìn vào ví dụ sau, Claude Desktop failed hoàn toàn so với Gemini 
 
 Claude không định nghĩa được đúng hành động và thiết bị trong hình.
 
-**Bây giờ thử so sánh trực tiếp trong Claude Code và Gemini CLI luôn nhé!**
+**Bây giờ thử so sánh trực tiếp trong Claude Code và Antigravity CLI (agy) luôn nhé!**
+
+> Google đã ngừng cung cấp `gemini` CLI độc lập vào 2026-06-18. Kế nhiệm của nó là Antigravity CLI, binary `agy`. Ảnh chụp bên dưới được chụp bằng Gemini CLI gốc, nhưng phép so sánh tương tự vẫn đúng với `agy`, vì nó chạy cùng các model Gemini.
 
 Mình sẽ thử yêu cầu cả 2 cùng đọc tấm hình blueprint và mô tả lại chi tiết những gì nó nhìn thấy:
 
-![Gemini Analyze Screenshot](/assets/03-claude-code-vs-gemini-cli.jpg)
+![Antigravity CLI analyze screenshot](/assets/03-claude-code-vs-gemini-cli.jpg)
 
-Gemini CLI cho kết quả chi tiết mô tả bản vẽ blueprint, trong khi Claude Code thì khá sơ sài…
+Antigravity CLI (agy) cho kết quả chi tiết mô tả bản vẽ blueprint, trong khi Claude Code thì khá sơ sài…
 
 Bạn thấy sự khác biệt rồi chứ?
 
@@ -60,7 +62,7 @@ Bạn thấy sự khác biệt rồi chứ?
 
 ## Tiếp nè, còn một thứ nữa mà “đôi mắt” của Claude hiện đang KHÔNG THỂ làm được: đó là khả năng PHÂN TÍCH VIDEO
 
-Nhưng Gemini (bản web, không phải bản CLI) lại có thể làm được điều đó, điều này giúp cho việc debug trong Vibe Coding trở nên dễ dàng hơn rất nhiều.
+Nhưng Gemini (bản web, không phải bản agy CLI) lại có thể làm được điều đó, điều này giúp cho việc debug trong Vibe Coding trở nên dễ dàng hơn rất nhiều.
 
 ![Gemini Analyze Video](/assets/04-gemini-analyze-video.jpg)
 

--- a/src/content/docs/cli/migrate.md
+++ b/src/content/docs/cli/migrate.md
@@ -107,6 +107,8 @@ Each column indicates how well `ck migrate` can transfer that content type to th
 
 Antigravity agents migrate into `.agents/agents.md`, Antigravity 2.0's project agents/personas file. Global Antigravity skills are supported, but no verified global `agents.md` path is documented.
 
+> **Note on the Gemini CLI row:** Google retired the standalone Gemini CLI on 2026-06-18. Its successor is the Antigravity CLI (`agy`), listed as a separate row above. The Gemini CLI row stays so `ck migrate` can still transfer configs to existing Gemini CLI layouts.
+
 ## Options
 
 ### Target Options

--- a/src/content/docs/cli/new.md
+++ b/src/content/docs/cli/new.md
@@ -52,7 +52,7 @@ ck new [OPTIONS]
 | `--exclude <pattern>` | Exclude files matching glob pattern (repeatable) | None |
 | `--prefix` | Move commands to `/ck:` namespace | `false` |
 | `--opencode` | Install OpenCode package globally | `false` |
-| `--gemini` | Install Gemini CLI and set up MCP integration | `false` |
+| `--gemini` | Install the Antigravity (agy) CLI and set up MCP integration | `false` |
 | `--install-skills` | Auto-install skill dependencies | `false` |
 | `--docs-dir <name>` | Custom name for docs folder | `docs` |
 | `--plans-dir <name>` | Custom name for plans folder | `plans` |

--- a/src/content/docs/engineer/configuration/mcp-setup.md
+++ b/src/content/docs/engineer/configuration/mcp-setup.md
@@ -74,7 +74,7 @@ The result: your main context stays pristine, yet you can still tap into special
 
 ### Further Optimization
 
-Even with subagent isolation, processing massive MCP catalogs still burns tokens. To mitigate that, ClaudeKit can hand off heavy MCP orchestration to **gemini-cli**, shifting the most expensive reasoning to a cheaper, external runtime while keeping the main conversation focused.
+Even with subagent isolation, processing massive MCP catalogs still burns tokens. To mitigate that, ClaudeKit can hand off heavy MCP orchestration to the **Antigravity (agy) CLI**, shifting the most expensive reasoning to a cheaper, external runtime while keeping the main conversation focused.
 
 ---
 

--- a/src/content/docs/engineer/skills/ai-multimodal.md
+++ b/src/content/docs/engineer/skills/ai-multimodal.md
@@ -87,10 +87,10 @@ python scripts/gemini_batch_process.py --files screenshot.png --task analyze --p
 python scripts/gemini_batch_process.py --files img1.jpg img2.jpg --task analyze
 ```
 
-If you have the `gemini` CLI installed, there's a faster shortcut:
+If you have the `agy` (Antigravity) CLI installed, there's a faster shortcut:
 
 ```bash
-cat image.png | gemini -y -m gemini-2.5-flash
+cat image.png | agy --dangerously-skip-permissions --model gemini-2.5-flash -p
 ```
 
 Gemini excels at object detection, OCR from screenshots, design extraction, visual Q&A, and handling multiple images for comparison.

--- a/src/content/docs/engineer/skills/mcp-management.md
+++ b/src/content/docs/engineer/skills/mcp-management.md
@@ -36,10 +36,10 @@ MCP is an open protocol that lets AI agents connect to external tools and data s
 
 MCP servers are configured in `.claude/.mcp.json` in your project root.
 
-**Gemini CLI integration** (recommended) — create a symlink so both Claude Code and Gemini CLI share one config:
+**Antigravity (agy) CLI integration** (recommended) — share one MCP config so both Claude Code and the Antigravity (agy) CLI read the same servers. agy loads MCP servers from the global `~/.gemini/config/mcp_config.json`, so symlink it to your project config:
 
 ```bash
-mkdir -p .gemini && ln -sf .claude/.mcp.json .gemini/settings.json
+mkdir -p ~/.gemini/config && ln -sf "$(pwd)/.claude/.mcp.json" ~/.gemini/config/mcp_config.json
 ```
 
 ## Core Capabilities

--- a/src/content/docs/engineer/skills/research.md
+++ b/src/content/docs/engineer/skills/research.md
@@ -37,7 +37,7 @@ Especially when:
 Identify: What decision needs this research? What facts will change the outcome? Set boundaries (depth, recency, sources). Example: "Which auth lib for Next.js?" → Criteria: maintained, security track record, TypeScript support, <50kb.
 
 ### 2. Systematic Search (Max 5)
-**Preferred**: `gemini -m gemini-2.5-flash -p "your prompt"` (if available)
+**Preferred**: `agy --model gemini-2.5-flash -p "your prompt"` (if available)
 **Fallback**: `WebSearch` tool
 
 **Query fan-out** across:

--- a/src/content/docs/engineer/skills/scout.md
+++ b/src/content/docs/engineer/skills/scout.md
@@ -29,14 +29,14 @@ Think of it as your reconnaissance mission before feature work—quickly mapping
 
 - Parallel agent-based file discovery
 - Token-efficient codebase exploration
-- Built-in parallel scouting or external tools (Gemini/OpenCode CLI)
+- Built-in parallel scouting or external tools (Antigravity agy/OpenCode CLI)
 - Adaptive scaling based on codebase size
 - Concise reporting with unresolved questions
 
 ## Arguments
 
 - **Default**: Scout using built-in parallel exploration
-- **ext**: Scout using external Gemini/OpenCode CLI tools in parallel
+- **ext**: Scout using external Antigravity (agy)/OpenCode CLI tools in parallel
 
 ## Quick Start
 

--- a/src/content/docs/marketing/agents/mcp-manager.md
+++ b/src/content/docs/marketing/agents/mcp-manager.md
@@ -15,7 +15,7 @@ You want to automate screenshot capture, access Google Analytics data, or intera
 
 **The Problem**: Modern marketing workflows depend on many external services—analytics platforms, design tools, browser automation, APIs. Integrating each service means learning its SDK, handling auth, and writing custom code.
 
-**The Solution**: The MCP Manager Agent handles all Model Context Protocol (MCP) server integrations. It discovers available tools, executes them efficiently via Gemini CLI or direct scripts, and returns results cleanly. You access powerful external services with simple commands.
+**The Solution**: The MCP Manager Agent handles all Model Context Protocol (MCP) server integrations. It discovers available tools, executes them efficiently via the Antigravity (agy) CLI or direct scripts, and returns results cleanly. You access powerful external services with simple commands.
 
 ## Quick Start
 
@@ -26,7 +26,7 @@ Execute MCP tools through the manager:
 /mcp "Take screenshot of claudekit.cc homepage"
 ```
 
-The manager handles tool discovery, execution via optimal method (Gemini CLI first, scripts fallback), and result delivery.
+The manager handles tool discovery, execution via optimal method (Antigravity agy CLI first, scripts fallback), and result delivery.
 
 ## Capabilities
 
@@ -40,7 +40,7 @@ Discovers and manages integrated services:
 
 ### Intelligent Execution Strategy
 Chooses optimal execution method:
-- **Primary**: Gemini CLI (fastest, 2M context window)
+- **Primary**: Antigravity (agy) CLI (fastest, 2M context window)
 - **Secondary**: Direct TypeScript scripts
 - **Fallback**: Error reporting with guidance
 - Automatic failover between methods
@@ -81,11 +81,11 @@ Use the MCP Manager Agent when you need to:
 ```
 
 **The manager will**:
-1. Check if Gemini CLI available
+1. Check if the Antigravity (agy) CLI is available
 2. Setup MCP server symlink if needed
-3. Execute via Gemini: `gemini -y -m gemini-2.5-flash -p "Take screenshot of https://claudekit.cc/docs"`
+3. Execute via agy: `agy --dangerously-skip-permissions --model gemini-2.5-flash -p "Take screenshot of https://claudekit.cc/docs"`
 4. Return screenshot file path
-5. If Gemini unavailable, fall back to direct script execution
+5. If agy unavailable, fall back to direct script execution
 
 ### Google Analytics Data
 
@@ -115,18 +115,18 @@ Data from: google-analytics MCP server
 
 ## Execution Methods
 
-### Method 1: Gemini CLI (Primary)
+### Method 1: Antigravity (agy) CLI (Primary)
 
 Fastest and most context-aware:
 ```bash
 # Check availability
-command -v gemini >/dev/null 2>&1
+command -v agy >/dev/null 2>&1
 
-# Setup MCP config symlink
-mkdir -p .gemini && ln -sf .claude/.mcp.json .gemini/settings.json
+# Setup MCP config symlink (agy reads the global ~/.gemini/config/mcp_config.json)
+mkdir -p ~/.gemini/config && ln -sf "$(pwd)/.claude/.mcp.json" ~/.gemini/config/mcp_config.json
 
 # Execute task
-gemini -y -m gemini-2.5-flash -p "Take screenshot of example.com"
+agy --dangerously-skip-permissions --model gemini-2.5-flash -p "Take screenshot of example.com"
 ```
 
 **Advantages**:
@@ -137,7 +137,7 @@ gemini -y -m gemini-2.5-flash -p "Take screenshot of example.com"
 
 ### Method 2: Direct Scripts (Fallback)
 
-When Gemini unavailable:
+When agy unavailable:
 ```bash
 npx tsx .claude/skills/mcp-management/scripts/cli.ts call-tool \
   <server-name> <tool-name> '<json-args>'
@@ -193,7 +193,7 @@ Add any MCP-compliant server to `.claude/.mcp.json`
 ## Performance
 
 Optimized execution:
-- Gemini CLI: ~2-5 seconds for simple tasks
+- Antigravity (agy) CLI: ~2-5 seconds for simple tasks
 - Direct scripts: ~3-8 seconds for same task
 - Automatic failover adds <1 second overhead
 - Results cached when appropriate
@@ -211,9 +211,9 @@ Optimized execution:
 
 ## Tips
 
-**Prefer Gemini CLI**: If both available, Gemini CLI is faster and more flexible. Install Gemini CLI for best experience.
+**Prefer the Antigravity (agy) CLI**: If both available, the Antigravity (agy) CLI is faster and more flexible. Install it for the best experience.
 
-**Natural Language Tasks**: With Gemini CLI, describe tasks naturally: "Take screenshot and resize to 1200px wide" works better than manual tool chaining.
+**Natural Language Tasks**: With the Antigravity (agy) CLI, describe tasks naturally: "Take screenshot and resize to 1200px wide" works better than manual tool chaining.
 
 **Check Availability**: Run `/tools` to see all available MCP tools across configured servers.
 
@@ -221,13 +221,13 @@ Optimized execution:
 
 ## Troubleshooting
 
-**Gemini CLI not found**:
+**Antigravity (agy) CLI not found**:
 ```bash
-# Install Gemini CLI
-npm install -g @anthropic-ai/gemini-cli
+# Install the Antigravity (agy) CLI (macOS/Linux)
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 
 # Verify installation
-gemini --version
+agy --version
 ```
 
 **MCP server not responding**:

--- a/src/content/docs/marketing/agents/scout-external.md
+++ b/src/content/docs/marketing/agents/scout-external.md
@@ -7,7 +7,7 @@ order: 7
 ---
 # Scout External Agent
 
-> **Your AI-powered explorer** - Harnesses Gemini and other AI tools for deep codebase analysis
+> **Your AI-powered explorer** - Harnesses the Antigravity (agy) CLI and other AI tools for deep codebase analysis
 
 ## What This Agent Does
 
@@ -15,7 +15,7 @@ You're working on a massive monorepo with hundreds of directories. You need to f
 
 **The Problem**: Large, complex codebases need parallel, intelligent search across many directories. Simple pattern matching isn't enough—you need AI that understands code semantics and relationships.
 
-**The Solution**: Scout External orchestrates multiple AI coding assistants (Gemini, OpenCode) to search different parts of your codebase simultaneously. It delegates complex searches to AI tools with massive context windows, then synthesizes results into actionable file lists.
+**The Solution**: Scout External orchestrates multiple AI coding assistants (Antigravity agy, OpenCode) to search different parts of your codebase simultaneously. It delegates complex searches to AI tools with massive context windows, then synthesizes results into actionable file lists.
 
 ## Quick Start
 
@@ -32,7 +32,7 @@ Multiple AI tools search in parallel, understanding code semantics to find relev
 
 ### AI-Powered Search Orchestration
 Coordinates multiple AI assistants:
-- Delegates search regions to Gemini Flash 2.5 (2M context)
+- Delegates search regions to the Antigravity (agy) CLI running Gemini Flash 2.5 (2M context)
 - Uses OpenCode for specialized code analysis
 - Runs searches in parallel for speed
 - Combines results from multiple tools
@@ -115,7 +115,7 @@ Use Scout External when:
 ### Small Scale (2-3 agents)
 For focused searches:
 ```bash
-# Uses only Gemini
+# Uses only the Antigravity (agy) CLI
 Agent 1: Search lib/ for payment utilities
 Agent 2: Search app/api/ for payment routes
 Agent 3: Search db/ for payment schemas
@@ -124,19 +124,19 @@ Agent 3: Search db/ for payment schemas
 ### Large Scale (4-5 agents)
 For comprehensive searches:
 ```bash
-# Uses Gemini + OpenCode for diversity
-Agent 1 (Gemini): Frontend payment UI
-Agent 2 (Gemini): Backend payment logic
+# Uses agy + OpenCode for diversity
+Agent 1 (agy): Frontend payment UI
+Agent 2 (agy): Backend payment logic
 Agent 3 (OpenCode): Database and migrations
-Agent 4 (Gemini): Webhook handlers
+Agent 4 (agy): Webhook handlers
 Agent 5 (OpenCode): Configuration and tests
 ```
 
 ## AI Tool Commands
 
-**Gemini Flash 2.5** (primary):
+**Antigravity (agy) CLI** (primary, runs Gemini Flash 2.5):
 ```bash
-gemini -y -p "Search app/ for email-related files. Return file paths only." --model gemini-2.5-flash
+agy --dangerously-skip-permissions -p "Search app/ for email-related files. Return file paths only." --model gemini-2.5-flash
 ```
 
 **OpenCode** (secondary):
@@ -184,7 +184,7 @@ Optimized for large-scale searches:
 
 **Describe Functionality**: Instead of "find files with 'stripe' in them," say "find payment processing and webhook files." AI understands intent.
 
-**Trust Semantic Search**: AI might suggest files you didn't expect. If Gemini thinks a file is relevant, it probably is—even if naming doesn't match.
+**Trust Semantic Search**: AI might suggest files you didn't expect. If agy thinks a file is relevant, it probably is, even if naming doesn't match.
 
 **Check Timeouts**: If an agent times out, results will note the gap. You can rerun or search that section manually.
 
@@ -193,12 +193,12 @@ Optimized for large-scale searches:
 ```
 AI-Powered Search Results (5 agents, 4.2 minutes):
 
-Frontend Payment UI (Agent 1 - Gemini):
+Frontend Payment UI (Agent 1 - agy):
 - app/checkout/page.tsx - Checkout page with Stripe Elements
 - components/PaymentForm.tsx - Payment form component
 - components/PaymentMethod.tsx - Payment method selector
 
-Backend Payment Logic (Agent 2 - Gemini):
+Backend Payment Logic (Agent 2 - agy):
 - lib/stripe/client.ts - Stripe API client
 - lib/sepay/client.ts - SePay API client
 - api/checkout/route.ts - Checkout API endpoint
@@ -209,7 +209,7 @@ Database & Schemas (Agent 3 - OpenCode):
 - db/schema/transactions.ts - Transaction logs
 - db/migrations/001_add_payments.sql - Payment tables migration
 
-Webhooks (Agent 4 - Gemini):
+Webhooks (Agent 4 - agy):
 - api/webhooks/stripe/route.ts - Stripe webhook handler
 - api/webhooks/sepay/route.ts - SePay webhook handler
 - lib/webhooks/verify.ts - Webhook signature verification

--- a/src/content/docs/marketing/skills/research.md
+++ b/src/content/docs/marketing/skills/research.md
@@ -38,7 +38,7 @@ Combine web search, documentation analysis, and GitHub repository exploration.
 5. **Cross-validation**: Verify across 3+ independent sources
 
 **Search priorities**:
-- Check if `gemini` bash command available → use for research (10min timeout)
+- Check if `agy` (Antigravity) bash command available → use for research (`--print-timeout 600s`)
 - Fall back to `WebSearch` tool if needed
 - Run maximum 5 research queries in parallel
 

--- a/src/content/docs/workflows/gemini.md
+++ b/src/content/docs/workflows/gemini.md
@@ -50,13 +50,15 @@ Look at this example, Claude Desktop completely failed compared to Gemini and Ch
 
 Claude couldn't correctly identify the actions and devices in the image.
 
-**Now let's compare directly between Claude Code and Gemini CLI!**
+**Now let's compare directly between Claude Code and the Antigravity CLI (agy)!**
+
+> Google retired the standalone `gemini` CLI on 2026-06-18. Its successor is the Antigravity CLI, binary `agy`. The screenshot below was captured with the original Gemini CLI, but the same comparison holds for `agy`, which runs the same Gemini models.
 
 I'll ask both to read a blueprint image and describe in detail what they see:
 
-![Gemini Analyze Screenshot](/assets/03-claude-code-vs-gemini-cli.jpg)
+![Antigravity CLI analyze screenshot](/assets/03-claude-code-vs-gemini-cli.jpg)
 
-Gemini CLI provides detailed descriptions of the blueprint, while Claude Code is quite superficial...
+The Antigravity CLI (agy) provides detailed descriptions of the blueprint, while Claude Code is quite superficial...
 
 Do you see the difference?
 
@@ -64,7 +66,7 @@ Do you see the difference?
 
 ## Wait, there's one more thing that Claude's "eyes" currently CANNOT do: VIDEO ANALYSIS capability
 
-But Gemini (web version, not CLI) can do this, which makes debugging in Vibe Coding much easier.
+But Gemini (web version, not the agy CLI) can do this, which makes debugging in Vibe Coding much easier.
 
 ![Gemini Analyze Video](/assets/04-gemini-analyze-video.jpg)
 


### PR DESCRIPTION
## What

Google retired the `gemini` CLI on 2026-06-18 for free, AI Pro, and Ultra tiers. The docs site still taught the gemini CLI in many places. This migrates that content to `agy` (Antigravity CLI), the successor.

## Changes

- 22 files updated across both locales (EN `src/content/docs/`, VI `src/content/docs-vi/`).
- Engineer skills (ai-multimodal CLI vision line, mcp-management, mcp-setup, research, scout), marketing agents (mcp-manager, scout-external) now show `agy` invocations and the global `~/.gemini/config/mcp_config.json` MCP path.
- `cli/new.md`: the `--gemini` flag now documents that it installs the Antigravity (agy) CLI. Flag token kept.
- `cli/migrate.md`: kept the provider row, added a retirement note.
- `workflows/gemini.md`: the Claude Code vs CLI comparison now uses agy. The Gemini API vision tutorial part is unchanged.
- Fixed a wrong-scope `@anthropic-ai/gemini-cli` install typo (replaced with the agy installer).

## Out of scope (unchanged)

Gemini API and model-name content (google-genai SDK, Imagen, Veo, `GEMINI_API_KEY`, model ids like `gemini-2.5-flash`). That API still works.

## Validation

`bun run build` passes: 584 pages, link validator and frontmatter checks clean.

## Related

Pairs with claudekit-engineer#858, claudekit-marketing#64, claudekit-cli#902.