### PR TITLE
docs: add Engineer Kit plugin migration guide

### DIFF
--- a/announcements/2026-07-06-engineer-plugin-migration.md
+++ b/announcements/2026-07-06-engineer-plugin-migration.md
@@ -1,0 +1,29 @@
+# Engineer Kit Plugin Migration Announcement Draft
+
+TL;DR: Engineer Kit now installs as the `ck@claudekit` Claude Code plugin. Existing users can migrate with:
+
+```bash
+ck update
+```
+
+What changed:
+- `/ck:*` skills now live under the Claude Code plugin format instead of copied global skill files.
+- Slash-menu descriptions should show again when you type `/ck:plan`.
+- `ck doctor` can report and help fix mixed legacy/plugin state.
+
+How to verify:
+
+```bash
+claude plugin list
+```
+
+Look for `ck@claudekit`, then restart Claude Code and type `/ck:plan`.
+
+Migration guide:
+https://docs.claudekit.cc/docs/engineer/configuration/plugin-migration
+
+If anything looks mixed or stale, run:
+
+```bash
+ck init -g --kit engineer --install-mode auto
+```

--- a/src/content/docs/changelog/index.md
+++ b/src/content/docs/changelog/index.md
@@ -18,6 +18,7 @@ Track all releases and changes for the ClaudeKit Engineer Kit.
 
 - **Expanded default hook wiring** — 7 additional hooks now wired by default: `session-init`, `dev-rules-reminder`, `cook-after-plan-reminder`, `plan-format-kanban`, `session-state`, `subagent-init`, `usage-quota-cache-refresh`. Total: 15 wired entries across 6 events.
 - **Codex hooks on Windows** — Hook wiring to Codex now works on Windows. The platform gate is removed; `ck init` and `ck migrate` probe for `codex`/`codex.exe`, resolve `%USERPROFILE%` paths, and strip Unix shebangs when targeting Windows.
+- **Engineer Kit plugin migration guide** — Added a user-facing guide for moving global Engineer installs from copied skills to the `ck@claudekit` Claude Code plugin format. Start with `ck update`; verify by typing `/ck:plan` and checking `claude plugin list`.
 - **Direct node invocation** — `node-hook-runner.sh` bash wrapper removed. All hook commands now run via `node` directly. `ck init` auto-repairs legacy bash-runner entries on upgrade.
 - **Zombie hook pruner** — `ck init` automatically removes engineer-tagged hook entries whose referenced file is missing (cleans up stale `node-hook-runner.sh` and `skill-dedup.cjs` references from old installs).
 - **3 opt-in hooks** — `usage-context-awareness`, `team-context-inject`, and `workflow-artifact-gate` are documented as user-side opt-ins with example wiring snippets.

--- a/src/content/docs/cli/doctor.md
+++ b/src/content/docs/cli/doctor.md
@@ -322,6 +322,8 @@ ck init -g --kit engineer --install-mode auto
 
 Use `--install-mode legacy` if you intentionally want copied skills and no owned plugin state.
 
+For the full migration checklist, see [Engineer Kit Plugin Migration](/docs/engineer/configuration/plugin-migration).
+
 Issues that require manual intervention:
 
 | Issue | Manual Fix |

--- a/src/content/docs/cli/update.md
+++ b/src/content/docs/cli/update.md
@@ -44,6 +44,8 @@ The `ck update` command:
 
 For global Engineer installs, the follow-up init preserves your saved install mode preference. `legacy` stays legacy across version updates, while `auto` and `plugin` can self-heal missing, disabled, stale-version, or stale-source `ck@claudekit` plugin state.
 
+Existing Engineer users moving from copied skills to the plugin format can use `ck update` as the normal migration entry point. See [Engineer Kit Plugin Migration](/docs/engineer/configuration/plugin-migration).
+
 ## Syntax
 
 ```bash

--- a/src/content/docs/engineer/configuration/plugin-migration.md
+++ b/src/content/docs/engineer/configuration/plugin-migration.md
@@ -1,0 +1,114 @@
+---
+title: "Engineer Kit Plugin Migration"
+description: "Move Engineer Kit installs from legacy copied skills to the Claude Code plugin format"
+section: engineer
+kit: engineer
+category: configuration
+order: 5
+published: true
+---
+
+# Engineer Kit Plugin Migration
+
+ClaudeKit Engineer now ships as a Claude Code plugin. This keeps `/ck:*` skills grouped under the `ck@claudekit` plugin, restores slash-menu descriptions, and gives the CLI one owned install surface to update.
+
+## What You Need To Do
+
+Run:
+
+```bash
+ck update
+```
+
+For normal global Engineer installs, that is enough. The CLI updates itself, then offers or runs the matching `ck init` follow-up needed to migrate or self-heal the installed kit content.
+
+## How To Verify
+
+Open Claude Code and type:
+
+```text
+/ck:plan
+```
+
+The slash menu should show the `ck:plan` skill with its description. You can also check the plugin registration:
+
+```bash
+claude plugin list
+```
+
+Look for `ck@claudekit` in the installed plugin list.
+
+## What Changed
+
+Older global installs copied ClaudeKit-managed skills directly into `~/.claude/skills/`. Current global Engineer installs use a Claude Code plugin registration instead. The CLI still preserves your preferences and custom files; the migration only changes how ClaudeKit-owned kit content is installed and updated.
+
+Local project installs continue to work through the project `.claude/` directory.
+
+## Troubleshooting
+
+### Slash Menu Still Shows No Hint
+
+Run the kit self-heal path:
+
+```bash
+ck init -g --kit engineer --install-mode auto
+```
+
+Then restart Claude Code and try `/ck:plan` again.
+
+### Doctor Reports Mixed State
+
+Mixed state means copied ClaudeKit skills and the `ck@claudekit` plugin are both visible. Run:
+
+```bash
+ck doctor
+ck init -g --kit engineer --install-mode auto
+```
+
+`ck init` prunes stale ClaudeKit-owned files and keeps user-owned custom skills intact.
+
+### Plugin Disabled Or Missing
+
+Run:
+
+```bash
+ck doctor --fix
+```
+
+If the plugin is still missing after the fix pass, rerun:
+
+```bash
+ck init -g --kit engineer --install-mode plugin
+```
+
+### Need A Temporary Rollback
+
+Use legacy mode only when you intentionally need copied skills:
+
+```bash
+ck init -g --kit engineer --install-mode legacy
+```
+
+Return to the plugin path with:
+
+```bash
+ck init -g --kit engineer --install-mode auto
+```
+
+## FAQ
+
+### Can I Still Use `~/.claude/skills/`?
+
+Yes. Your own skills can still live there. ClaudeKit-managed `ck:*` skills are managed by the plugin in the default global install mode so updates can remove stale files cleanly.
+
+### Does This Affect Project-Local Installs?
+
+Project-local installs still place kit content inside that project's `.claude/` directory. The plugin migration mainly affects global Engineer installs.
+
+### Do I Need To Delete Old Files Manually?
+
+No. Use `ck update` or `ck init -g --kit engineer --install-mode auto`. The CLI knows which ClaudeKit-owned legacy paths can be removed.
+
+### What If I Pinned Legacy Mode?
+
+Legacy mode remains available for compatibility. If you previously chose `legacy`, the CLI preserves that preference until you opt into `auto` or `plugin`.

--- a/src/content/docs/engineer/skills/coding-agent-orchestration.md
+++ b/src/content/docs/engineer/skills/coding-agent-orchestration.md
@@ -1,0 +1,49 @@
+---
+title: "ck:coding-agent-orchestration"
+description: "Coordinate Claude Code, Codex, Gemini, OpenCode, Cursor, Amp, Droid, Antigravity, and similar coding agents across one engineering workflow"
+section: engineer
+kit: engineer
+category: skills
+order: 51
+published: true
+---
+
+# Coding Agent Orchestration
+
+Plan multi-agent coding work without duplicating effort, assigning overlapping files, or losing the source of truth.
+
+Use this skill when a task benefits from more than one coding agent or AI developer tool. It helps choose between tools such as Claude Code, Codex, Gemini, OpenCode, Cursor, Amp, Droid, and Antigravity; split work safely; define handoffs; and consolidate plans, reviews, tests, and PRs.
+
+## When to Use
+
+- A feature has independent workstreams that can run in parallel
+- A high-risk change needs adversarial review from another model or tool
+- You need to decide which agent should plan, implement, test, debug, document, or review
+- Multiple agents have produced outputs that need one final integration path
+
+For one narrow fix, prefer a single agent. Orchestration should buy lower risk, better coverage, or real parallelism.
+
+## Workflow Shapes
+
+| Shape | Best For |
+|-------|----------|
+| Single-agent | Small fixes, narrow files, easy verification |
+| Sequential | Plan -> implement -> review -> fix -> verify |
+| Parallel | Independent files or modules with explicit ownership |
+| Review-loop | High-risk changes or existing PRs that need adversarial review |
+
+## Coordination Rules
+
+1. Start from the repo, issue, PR, or spec as the source of truth.
+2. Name one final integrator before work begins.
+3. Assign file ownership before parallel edits start.
+4. Do not let parallel agents edit the same files without a merge owner and strategy.
+5. Require evidence before completion: tests, build, lint, screenshots, CI, or a concrete manual check.
+6. Reconcile disagreements by checking repo truth, tests, docs, and user requirements.
+
+## Related Skills
+
+- [Team](/docs/engineer/skills/team) — run Claude Code Agent Teams for persistent parallel sessions
+- [Cook](/docs/engineer/skills/cook) — implement a feature once the execution path is clear
+- [Review PR](/docs/engineer/skills/code-review) — review code quality and correctness
+- [Worktree](/docs/engineer/skills/worktree) — isolate branches for parallel local work

--- a/src/content/docs/engineer/skills/index.md
+++ b/src/content/docs/engineer/skills/index.md
@@ -88,6 +88,7 @@ As of engineer@2.12.0, all commands have been migrated to skills. The `/ck:` sla
 | [kanban](/docs/engineer/skills/kanban) | Alias for plans-kanban — visual plan board shortcut |
 | [project-management](/docs/engineer/skills/project-management) | Task tracking, plan status, session bridging |
 | [team](/docs/engineer/skills/team) | Agent Teams for parallel multi-session collaboration |
+| [coding-agent-orchestration](/docs/engineer/skills/coding-agent-orchestration) | Coordinate multiple coding agents and AI developer tools |
 | [ask](/docs/engineer/skills/ask) | Answer technical and architectural questions |
 | [bootstrap](/docs/engineer/skills/bootstrap) | Initialize new projects with spec-driven development |
 | [coding-level](/docs/engineer/skills/coding-level) | Set coding experience level for tailored output |

--- a/src/content/docs/getting-started/installation.md
+++ b/src/content/docs/getting-started/installation.md
@@ -118,6 +118,8 @@ Then invoke skills with `/ck:` prefix:
 /ck:test
 ```
 
+> **Engineer Kit plugin install:** Current global Engineer installs use the Claude Code plugin format. Existing users can migrate with `ck update`; details are in the [Engineer Kit Plugin Migration guide](/docs/engineer/configuration/plugin-migration).
+
 Initialize project documentation (optional but recommended):
 
 ```bash

--- a/src/content/docs/getting-started/upgrade-guide.md
+++ b/src/content/docs/getting-started/upgrade-guide.md
@@ -45,6 +45,8 @@ ck update
 npm install -g claudekit-cli@latest
 ```
 
+For existing global Engineer installs, `ck update` also guides the legacy-to-plugin self-heal path. See [Engineer Kit Plugin Migration](/docs/engineer/configuration/plugin-migration) for verification and rollback details.
+
 ## Gradual Migration Path
 
 ### Week 1: Try Core Commands

--- a/src/content/docs/support/faq.md
+++ b/src/content/docs/support/faq.md
@@ -47,6 +47,12 @@ claudekit init
 - Works with your existing projects
 - Preserves your custom commands
 
+### Q: Do I need to do anything for the Engineer Kit plugin migration?
+**A:** Run `ck update`. For normal global Engineer installs, the CLI updates itself and guides the needed kit self-heal. See the [Engineer Kit Plugin Migration guide](/docs/engineer/configuration/plugin-migration).
+
+### Q: Can I still use `~/.claude/skills/`?
+**A:** Yes. User-owned skills can still live there. ClaudeKit-managed `ck:*` skills are managed through the plugin by default so updates can cleanly remove stale files.
+
 ### Q: What are the system requirements?
 **A:**
 - Node.js 16+

--- a/src/content/docs/support/troubleshooting/index.md
+++ b/src/content/docs/support/troubleshooting/index.md
@@ -15,6 +15,7 @@ Quick fixes for common issues. Most problems resolve in under 5 minutes.
 **Problem category?**
 - [Installation fails](#installation) → [Installation Issues](/docs/support/troubleshooting/installation-issues)
 - [Command not found or errors](#commands) → [Command Errors](/docs/support/troubleshooting/command-errors)
+- [`/ck:*` slash menu has no descriptions](#plugin-migration) → [Engineer Kit Plugin Migration](/docs/engineer/configuration/plugin-migration)
 - [Agent not working](#agents) → [Agent Issues](/docs/support/troubleshooting/agent-issues)
 - [API key errors](#api-keys) → [API Key Setup](/docs/support/troubleshooting/api-key-setup)
 - [Slow or hanging](#performance) → [Performance Issues](/docs/support/troubleshooting/performance-issues)
@@ -55,6 +56,18 @@ cat .claude/commands/core/cook.md
 ```
 
 [More command fixes →](/docs/support/troubleshooting/command-errors)
+
+## Plugin Migration
+
+**Issue**: `/ck:*` skills appear without descriptions, or `ck doctor` reports mixed legacy/plugin state.
+
+**Fix**:
+```bash
+ck update
+ck init -g --kit engineer --install-mode auto
+```
+
+[Complete migration guide →](/docs/engineer/configuration/plugin-migration)
 
 ## Agents
 


### PR DESCRIPTION
## Summary
- add an Engineer Kit plugin migration guide covering update, verification, troubleshooting, FAQ, and rollback guidance
- link the guide from install, update, doctor, upgrade, FAQ, troubleshooting, and changelog pages
- add a Discord announcement draft for the migration
- add a public docs page for `ck:coding-agent-orchestration`

## Validation
- `bun test tests/`
- `bun run check:syntax` (warn-only; existing legacy command examples remain outside this change)
- `bun run build`

Closes claudekit/claudekit-engineer#694
Related to claudekit/claudekit-engineer#789