### PR TITLE
docs: document plugin lifecycle guarantees

### DIFF
--- a/src/content/docs/cli/doctor.md
+++ b/src/content/docs/cli/doctor.md
@@ -21,7 +21,7 @@ ck doctor --fix
 # Generate shareable diagnostic report
 ck doctor --report
 
-# CI mode (JSON output, exit code on failure)
+# CI mode (JSON output, exit code on actionable findings)
 ck doctor --check-only --json
 ```
 
@@ -54,7 +54,7 @@ ck doctor [OPTIONS]
 |------|-------------|---------|
 | `--fix` | Auto-fix all fixable issues | `false` |
 | `--report` | Generate shareable diagnostic report (prompts for gist upload) | `false` |
-| `--check-only` | CI mode: no prompts, exit 1 on failures | `false` |
+| `--check-only` | CI mode: no prompts, exit 1 on failures or actionable warnings | `false` |
 | `--json` | Output results as JSON | `false` |
 | `--full` | Run extended checks (slower but more thorough) | `false` |
 | `--verbose` | Enable verbose logging | `false` |
@@ -153,7 +153,7 @@ Module Checks:
 
 Summary: 17 passed, 1 warning, 0 failed
 
-All checks passed!
+1 actionable warning found
 ```
 
 ### Auto-Fix Issues
@@ -247,8 +247,10 @@ ck doctor --check-only --json
 
 **Exit codes:**
 
-- `0`: All checks pass
-- `1`: One or more checks failed
+- `0`: No failures or actionable warnings
+- `1`: One or more failures or actionable warnings
+
+These exit codes apply consistently to text, JSON, and report output when combined with `--check-only`.
 
 **JSON output example:**
 
@@ -310,9 +312,11 @@ Issues that can be automatically fixed:
 For global Engineer installs, `ck doctor` reports the persisted install mode preference and the live Claude/Codex state:
 
 - `preference: auto|plugin|legacy`
-- Claude plugin registration and enabled/disabled status
 - Normal copied skill state
+- Claude plugin state, including missing, orphaned, disabled, stale version, or stale source
 - Codex plugin state, including missing, disabled, stale version, or stale source
+
+Unknown Codex inspection state and provider inspection errors are actionable; they never pass silently.
 
 If both copied CK skills and the `ck@claudekit` plugin are active, return to the recommended Normal skills mode with:
 
@@ -320,7 +324,7 @@ If both copied CK skills and the `ck@claudekit` plugin are active, return to the
 ck init -g --kit engineer --install-mode legacy
 ```
 
-Only an explicit persisted `plugin` preference preserves plugin mode. Missing, malformed, `auto`, and `legacy` preferences resolve to Normal skills. Doctor cleanup removes CK-owned plugin registration/cache state without deleting user-created or modified skill files.
+Only an explicit persisted `plugin` preference preserves plugin mode. Missing, malformed, `auto`, and `legacy` preferences resolve to Normal skills. Doctor reports repair guidance; the recommended `ck init` transition removes CK-owned plugin registration/cache state without deleting user-created or modified skill files.
 
 For the full mode and transition checklist, see [Engineer Kit Install Modes](/docs/engineer/configuration/plugin-migration).
 

--- a/src/content/docs/cli/uninstall.md
+++ b/src/content/docs/cli/uninstall.md
@@ -39,10 +39,13 @@ The `ck uninstall` command:
 5. Creates a scoped recovery backup under `~/.claudekit/backups/`
 6. Removes ClaudeKit-owned files
 7. Removes the hook and MCP registrations it added to `settings.json` and clears its `.ck.json` tracking
-8. Preserves user customizations and configurations
-9. Cleans up empty directories
+8. For global Engineer scope, removes and verifies Claude and Codex plugins and their ClaudeKit-owned marketplace registrations
+9. Preserves user customizations and configurations
+10. Cleans up empty directories
 
 Hook entries you authored or edited yourself are left untouched, and when a single kit is removed from a multi-kit install, registrations still used by the remaining kit are kept.
+
+Project-local and Marketing-only uninstall do not change global Engineer provider state. Repeating global Engineer uninstall is safe: already-absent plugin and marketplace state is treated as a verified no-op, while provider inspection or removal errors fail instead of reporting success.
 
 ## Syntax
 

--- a/src/content/docs/cli/update.md
+++ b/src/content/docs/cli/update.md
@@ -44,6 +44,8 @@ The `ck update` command:
 
 For global Engineer installs, the follow-up init preserves plugins only when metadata contains explicit `plugin` consent. Missing, malformed, `auto`, and `legacy` preferences converge to the recommended Normal skills installation in `~/.claude/skills/`.
 
+For an explicitly opted-in plugin install, a same-version update also repairs missing, orphaned, disabled, stale-version, or stale-source Claude state and missing, disabled, or stale Codex state. Health repair never opts a Normal installation into plugin mode.
+
 Use `ck init -g --kit engineer --install-mode plugin` to opt in to plugins, or `--install-mode legacy` to return to Normal skills. The transition removes only ClaudeKit-owned state and preserves user-created or modified files. See [Engineer Kit Install Modes](/docs/engineer/configuration/plugin-migration).
 
 ## Syntax

--- a/src/content/docs/engineer/configuration/plugin-migration.md
+++ b/src/content/docs/engineer/configuration/plugin-migration.md
@@ -22,6 +22,8 @@ ck init -g --kit engineer
 
 Fresh interactive installs show Normal skills first and explain both choices. Non-interactive installs, including `--yes`, select Normal skills unless `--install-mode plugin` is supplied.
 
+Normal and plugin mode expose the same `ck:<skill>` names. Normal mode projects the `ck:` namespace exactly once onto copied skill metadata; plugin payloads remain canonical so each supported runtime can apply its own namespace without duplication.
+
 The compatibility inputs `auto` and `legacy` also select Normal skills:
 
 ```bash
@@ -44,6 +46,8 @@ ck init -g --kit engineer --install-mode plugin
 ```
 
 The CLI persists this explicit choice. Later `ck init` and `ck update` runs preserve plugin mode only while the saved preference is `plugin`. Missing, malformed, `auto`, and `legacy` preferences converge to Normal skills rather than inferring consent.
+
+Plugin activation is transactional. ClaudeKit validates a staged replacement before switching the stable plugin source, and restores the previous stage and provider registrations if preparation fails. CK-owned copied skills are removed only after the required Claude plugin and any supported Codex plugin are prepared successfully.
 
 ## Return To Normal Skills
 


### PR DESCRIPTION
## Summary
- clarify Normal versus explicit plugin installation behavior
- document same-version repair and transactional rollback guarantees
- explain doctor exit semantics and verified dual-provider uninstall

## Source change
- mrgoonie/claudekit-cli#923

## Validation
- `bun run build` (586 pages, 2,150 links)
- `git diff --check`